### PR TITLE
[FEAT]: PasswordTextField 구현

### DIFF
--- a/Projects/DesignSystem/Sources/TextField/PasswordTextField/PasswordTextField.swift
+++ b/Projects/DesignSystem/Sources/TextField/PasswordTextField/PasswordTextField.swift
@@ -1,0 +1,58 @@
+//
+//  PasswordTextField.swift
+//  DesignSystem
+//
+//  Created by jung on 5/8/24.
+//  Copyright © 2024 com.alloon. All rights reserved.
+//
+
+import UIKit
+import Core
+
+/// content를 show 혹은 off 할 수 있는 TextField입니다.
+public final class PasswordTextField: LineTextField {
+  private let secureButton: IconButton = {
+    let iconButton = IconButton(size: .medium)
+    iconButton.selectedTintColor = .gray500
+    iconButton.unSelectedTintColor = .gray500
+    
+    iconButton.unSelectedIcon = UIImage(systemName: "eye.slash.fill")!
+    iconButton.selectedIcon = UIImage(systemName: "eye.fill")!
+    iconButton.invalidateIntrinsicContentSize()
+    
+    return iconButton
+  }()
+  
+  var isSecureTextEntry: Bool {
+    get {
+      return textField.isSecureTextEntry
+    }
+    set {
+      print(newValue)
+      textField.isSecureTextEntry = newValue
+      secureButton.isSelected = !newValue
+    }
+  }
+  
+  // MARK: - Setup UI
+  override func setupUI() {
+    super.setupUI()
+    
+    isSecureTextEntry = true
+    secureButton.addTarget(self, action: #selector(didTapButton), for: .touchUpInside)
+    
+    textField.setRightView(
+      secureButton,
+      size: CGSize(width: 32, height: 32),
+      leftPdding: 8,
+      rightPadding: 9
+    )
+  }
+}
+
+// MARK: - private Extension
+private extension PasswordTextField {
+  @objc func didTapButton() {
+    textField.isSecureTextEntry.toggle()
+  }
+}


### PR DESCRIPTION
## 관련 이슈

- #26 
## 작업 설명

passwordTextField 구현
<img src="https://github.com/alloon-project/alloon-ios/assets/81402827/af5d179d-7058-40f9-96fb-62f2aabcec5a" width=200>

오른쪽의 icon을 누르게 되면 다음과 같이, `isSecureTextEntry`가 toggle되어 content hide여부가 결정납니다. 
```swift 
// MARK: - private Extension
private extension PasswordTextField {
  @objc func didTapButton() {
    textField.isSecureTextEntry.toggle()
  }
}
```
