### PR TITLE
[FEAT] : SearchNavagation 구현

### DIFF
--- a/Projects/DesignSystem/Sources/Navigations/Top/SearchNavigation.swift
+++ b/Projects/DesignSystem/Sources/Navigations/Top/SearchNavigation.swift
@@ -7,15 +7,19 @@
 //
 
 import UIKit
+import RxCocoa
+import RxGesture
+import RxSwift
 import SnapKit
+import Core
 
 public class SearchNavigation: UIView {
-  public var leftBackButtonImage = {
+  fileprivate let leftBackButtonImage = {
     var imageView = UIImageView()
     imageView.image = UIImage(resource: .leftBackButtonDark).resize(CGSize(width: 24, height: 24))
     return imageView
   }()
-  public var searchBar: AlloonSearchBar
+  fileprivate let searchBar: AlloonSearchBar
   
   public init(placeholder: String = "",
               text: String = "") {
@@ -33,6 +37,7 @@ private extension SearchNavigation {
   // MARK: - Setup UI
   func setupUI() {
     self.addSubviews(leftBackButtonImage, searchBar)
+    
     leftBackButtonImage.snp.makeConstraints {
       $0.width.height.equalTo(32)
       $0.centerY.equalToSuperview()
@@ -46,5 +51,16 @@ private extension SearchNavigation {
       $0.top.equalToSuperview().offset(5)
       $0.bottom.equalToSuperview().offset(-5)
     }
+  }
+}
+
+public extension Reactive where Base: SearchNavigation {
+  var leftBackButtonDidTap: ControlEvent<Void> {
+    let source = base.leftBackButtonImage.rx.tapGesture().when(.recognized).map { _ in }
+    return .init(events: source)
+  }
+  
+  var searchButtonDidTap: ControlEvent<Void> {
+    return base.searchBar.rx.searchButtonClicked
   }
 }


### PR DESCRIPTION
## 관련 이슈

- #36

## 작업 설명

AlloonSearchBar를 활용하여 SearchNavigation을 구현했습니다.

### 사용법
사용 방법은 다음과 같습니다.
``` Swift
   // in viewController
    let searchNavigation = SearchNavigation(placeholder: "플레이스 홀더")
```
플레이스 홀더, 기본검색값을 모두 줄 수 있습니다 (두개 모두 default = "")

<img width="374" alt="스크린샷 2024-05-12 오후 6 30 57" src="https://github.com/alloon-project/alloon-ios/assets/75213755/97c60774-244c-4ced-9007-376860057d34">

#### 동작삽입
back button 및 검색 버튼 동작은 rx extension으로 삽입 해줍니다.

``` Swift
    searchNavigation.leftBackButtonImage.rx.tapGesture()
      .when(.recognized)
      .subscribe { [weak self] _ in
        self?.someFunction()
      }.disposed(by: disposeBag)
```

``` Swift
    searchNavigation.searchBar.rx.searchButtonClicked
      .asObservable()
      .subscribe { [weak self] _ in
        print("검색!")
      }.disposed(by: disposeBag)
```
## 스크린샷
| 검색어 입력시 |
|:---:|
|<img src = "https://github.com/alloon-project/alloon-ios/assets/75213755/0f585edb-efb5-4129-8b66-0bc04adab728" width="200"/>|