### PR TITLE
[FEAT]: SearchNavigation 구현

### DIFF
--- a/Projects/DesignSystem/Sources/Navigations/Top/SearchNavigation.swift
+++ b/Projects/DesignSystem/Sources/Navigations/Top/SearchNavigation.swift
@@ -13,6 +13,7 @@ import RxSwift
 import SnapKit
 import Core
 
+/// 앱 상단에 들어가는 검색가능한 NavigationView 입니다.
 public class SearchNavigation: UIView {
   fileprivate let leftBackButtonImage = {
     var imageView = UIImageView()
@@ -21,6 +22,7 @@ public class SearchNavigation: UIView {
   }()
   fileprivate let searchBar: AlloonSearchBar
   
+  // MARK: - Initializers
   public init(placeholder: String = "",
               text: String = "") {
     self.searchBar = AlloonSearchBar(placeholder: placeholder, text: text)
@@ -54,6 +56,7 @@ private extension SearchNavigation {
   }
 }
 
+// MARK: - Reactive Extension
 public extension Reactive where Base: SearchNavigation {
   var leftBackButtonDidTap: ControlEvent<Void> {
     let source = base.leftBackButtonImage.rx.tapGesture().when(.recognized).map { _ in }


### PR DESCRIPTION
## 관련 이슈

- #36

## 작업 설명

AlloonSearchBar를 활용하여 SearchNavigation을 구현했습니다.

### 사용법
사용 방법은 다음과 같습니다.
``` Swift
   // in viewController
    let searchNavigation = SearchNavigation(placeholder: "플레이스 홀더")
```
플레이스 홀더, 기본검색값을 모두 줄 수 있습니다 (두개 모두 default = "")

<img width="374" alt="스크린샷 2024-05-12 오후 6 30 57" src="https://github.com/alloon-project/alloon-ios/assets/75213755/97c60774-244c-4ced-9007-376860057d34">

#### 동작삽입
back button 및 검색 버튼 동작은 Reactive Extension으로 구현 했습니다.

``` Swift
    searchNavigation.rx.leftBackButtonDidTap
      .subscribe { [weak self] _ in
         self?.backFunction()
       }.disposed(by: disposeBag)
```

``` Swift
    searchNavigation.rx.searchButtonDidTap
      .subscribe { [weak self] _ in
       self?.someSearchFunction()
      }.disposed(by: disposeBag)
```
## 스크린샷
| 검색어 입력시 |
|:---:|
|<img src = "https://github.com/alloon-project/alloon-ios/assets/75213755/0f585edb-efb5-4129-8b66-0bc04adab728" width="200"/>|