### PR TITLE
[FEAT]: 비밀번호 찾기 UI 구현

### DIFF
--- a/Projects/Presentation/LogIn/Implementations/FindPassword/FindPasswordViewController.swift
+++ b/Projects/Presentation/LogIn/Implementations/FindPassword/FindPasswordViewController.swift
@@ -7,5 +7,102 @@
 //
 
 import UIKit
+import DesignSystem
 
-final class FindPasswordViewController: UIViewController { }
+final class FindPasswordViewController: UIViewController {
+  private lazy var input = FindPasswordViewModel.Input(
+    userId: idTextField.rx.text,
+    email: emailTextField.rx.text,
+    didTapNextButton: nextButton.rx.tap
+  )
+  
+  // MARK: - UI Components
+  private let navigationBar = PrimaryNavigationView(textType: .center, iconType: .one, titleText: "비밀번호 찾기")
+  private let enterIdLabel: UILabel = {
+    let label = UILabel()
+    label.textAlignment = .left
+    label.attributedText = "아이디를 입력해주세요".attributedString(font: .heading4, color: .gray900)
+    return label
+  }()
+  private let idTextField: LineTextField = {
+    let textField = LineTextField(placeholder: "아이디", type: .default)
+    textField.setKeyboardType(.default)
+    return textField
+  }()
+  
+  private let announceLabel: UILabel = {
+    let label = UILabel()
+    label.textAlignment = .left
+    label.attributedText = "가입 시 사용했던 이메일을 입력해주세요".attributedString(font: .heading4, color: .gray900)
+    return label
+  }()
+  private let emailTextField: LineTextField = {
+    let textField = LineTextField(placeholder: "이메일", type: .default)
+    textField.setKeyboardType(.emailAddress)
+    return textField
+  }()
+  private let nextButton = FilledRoundButton(type: .primary, size: .xLarge, text: "다음")
+  
+  // MARK: - View Life Cycle
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    
+    setupUI()
+  }
+  // MARK: - UIResponder
+  override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+    super.touchesEnded(touches, with: event)
+    
+    view.endEditing(true)
+  }
+}
+
+// MARK: - UI Methods
+private extension FindPasswordViewController {
+  func setupUI() {
+    self.navigationController?.setNavigationBarHidden(true, animated: false)
+    self.view.backgroundColor = .white
+    
+    setViewHierarchy()
+    setConstraints()
+  }
+  
+  func setViewHierarchy() {
+    view.addSubviews(navigationBar, enterIdLabel, idTextField, announceLabel, emailTextField, nextButton)
+  }
+  
+  func setConstraints() {
+    navigationBar.snp.makeConstraints {
+      $0.leading.trailing.equalToSuperview()
+      $0.top.equalTo(view.safeAreaLayoutGuide)
+      $0.height.equalTo(56)
+    }
+    
+    enterIdLabel.snp.makeConstraints {
+      $0.leading.equalToSuperview().offset(20)
+      $0.trailing.equalToSuperview().offset(-20)
+      $0.top.equalTo(navigationBar.snp.bottom).offset(40)
+    }
+    
+    idTextField.snp.makeConstraints {
+      $0.centerX.equalToSuperview()
+      $0.top.equalTo(enterIdLabel .snp.bottom).offset(20)
+    }
+    
+    announceLabel.snp.makeConstraints {
+      $0.leading.equalToSuperview().offset(20)
+      $0.trailing.equalToSuperview().offset(-20)
+      $0.top.equalTo(idTextField.snp.bottom).offset(40)
+    }
+    
+    emailTextField.snp.makeConstraints {
+      $0.centerX.equalToSuperview()
+      $0.top.equalTo(announceLabel.snp.bottom).offset(20)
+    }
+    
+    nextButton.snp.makeConstraints {
+      $0.centerX.equalToSuperview()
+      $0.bottom.equalToSuperview().offset(-56)
+    }
+  }
+}

--- a/Projects/Presentation/LogIn/Implementations/FindPassword/FindPasswordViewModel.swift
+++ b/Projects/Presentation/LogIn/Implementations/FindPassword/FindPasswordViewModel.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2024 com.alloon. All rights reserved.
 //
 
+import RxCocoa
 import RxSwift
 
 protocol FindPasswordCoordinatable { }
@@ -21,7 +22,11 @@ final class FindPasswordViewModel: FindPasswordViewModelType {
   let disposeBag = DisposeBag()
   
   // MARK: - Input
-  struct Input { }
+  struct Input {
+    let userId: ControlProperty<String>
+    let email: ControlProperty<String>
+    let didTapNextButton: ControlEvent<Void>
+  }
   
   // MARK: - Output
   struct Output { }

--- a/Projects/Presentation/LogIn/Implementations/LogInViewModel.swift
+++ b/Projects/Presentation/LogIn/Implementations/LogInViewModel.swift
@@ -56,6 +56,17 @@ class LogInViewModel: LogInViewModelType {
       }
       .disposed(by: disposeBag)
     
+    input.didTapFindIdButton
+      .bind(with: self) { owner, _ in
+        owner.coordinator?.attachFindId()
+      }
+      .disposed(by: disposeBag)
+    
+    input.didTapFindPasswordButton
+      .bind(with: self) { owner, _ in
+        owner.coordinator?.attachFindPassword()
+      }
+      .disposed(by: disposeBag)
     return Output()
   }
 }


### PR DESCRIPTION
## 관련 이슈

- #64 

## 작업 설명

비밀번호 찾기 화면 UI 작업 입니다.

## 스크린샷

|동작|UI|아이디|이메일|
|:---:|:---:|:---:|:---:|
|<img src = "https://github.com/alloon-project/alloon-ios/assets/75213755/eb4a51d3-1405-4a65-a58b-f71f0c963102" width = 180>|<img src = "https://github.com/alloon-project/alloon-ios/assets/75213755/14ba7366-5d7c-4afe-81e2-24b5a595b8d4" width = 180>|<img src = "https://github.com/alloon-project/alloon-ios/assets/75213755/861bb475-6ea6-41a8-a968-ec7d1bea56fd" width = 180>|<img src = "https://github.com/alloon-project/alloon-ios/assets/75213755/04d2f158-f682-4a35-8e8a-2ab582be12dc" width = 180>|

- 화면 확인을 위해 Login ViewModel의 tansfrom에 동작을 추가했습니다.

```Swift 
  func transform(input: Input) -> Output {
    input.didTapSignUpButton
      .bind(with: self) { owner, _ in
        owner.coordinator?.attachSignUp()
      }
      .disposed(by: disposeBag)
    
    input.didTapFindIdButton
      .bind(with: self) { owner, _ in
        owner.coordinator?.attachFindId()
      }
      .disposed(by: disposeBag)
    
    input.didTapFindPasswordButton
      .bind(with: self) { owner, _ in
        owner.coordinator?.attachFindPassword()
      }
      .disposed(by: disposeBag)
    return Output()
  }
```
