### PR TITLE
[FEAT]: 챌린지 없을 때 Home화면 API

### DIFF
--- a/Projects/App/Sources/AppContainer.swift
+++ b/Projects/App/Sources/AppContainer.swift
@@ -65,6 +65,10 @@ final class AppContainer:
     return SignUpUseCaseImpl(repository: signUpRepository)
   }()
   
+  lazy var homeUseCae: HomeUseCase = {
+    return HomeUseCaseImpl(repository: challengeRepository)
+  }()
+  
   // MARK: - Repository
   lazy var logInRepository: LogInRepository = {
     return LogInRepositoryImpl(dataMapper: LogInDataMapperImpl())
@@ -72,5 +76,9 @@ final class AppContainer:
   
   lazy var signUpRepository: SignUpRepository = {
     return SignUpRepositoryImpl(dataMapper: SignUpDataMapperImpl())
+  }()
+  
+  lazy var challengeRepository: ChallengeRepository = {
+    return ChallengeRepositoryImpl(dataMapper: ChallengeDataMapperImpl())
   }()
 }

--- a/Projects/Core/Extensions/Date+Extension.swift
+++ b/Projects/Core/Extensions/Date+Extension.swift
@@ -27,9 +27,10 @@ public extension Date {
     return component.day ?? 0
   }
   
-  func toString() -> String {
-    let monthText = month < 10 ? "0\(month)" : "\(month)"
-    let dayText = day < 10 ? "0\(day)" : "\(day)"
-    return "\(year).\(monthText).\(dayText)"
+  func toString(_ format: String) -> String {
+    let formatter = DateFormatter()
+    formatter.dateFormat = format
+    
+    return formatter.string(from: self)
   }
 }

--- a/Projects/Data/DTO/Challenge/ChallengeResponseDTO.swift
+++ b/Projects/Data/DTO/Challenge/ChallengeResponseDTO.swift
@@ -1,0 +1,50 @@
+//
+//  ChallengeResponseDTO.swift
+//  DTO
+//
+//  Created by jung on 10/15/24.
+//  Copyright © 2024 com.photi. All rights reserved.
+//
+
+import Foundation
+
+public struct ChallengeResponseDTO: Decodable {
+  public let id: Int
+  public let name: String
+  public let imageUrl: URL
+  public let goal: String
+  public let proveTime: String
+  public let endDate: String
+  public let hashtags: [HashTagResponseDTO]
+}
+
+public struct HashTagResponseDTO: Decodable {
+  public let hashtag: String
+}
+
+public extension ChallengeResponseDTO {
+  static let stubData = """
+  {
+    "code": "200 OK",
+    "message": "성공",
+    "data": [
+      {
+        "id": 1,
+        "name": "신나게 하는 러닝 챌린지",
+        "imageUrl": "https://url.kr/5MhHhD",
+        "goal": "하루에 한 번씩 꼭 러닝을 하는 것이 우리 챌린지의 목표입니다.",
+        "proveTime": "13:00",
+        "endDate": "2024-12-01",
+        "hashtags": [
+          {
+            "hashtag": "러닝"
+          },
+          {
+            "hashtag": "건강"
+          }
+        ]
+      }
+    ]
+  }
+"""
+}

--- a/Projects/Data/DataMapper/ChallengeDataMapper.swift
+++ b/Projects/Data/DataMapper/ChallengeDataMapper.swift
@@ -1,0 +1,36 @@
+//
+//  ChallengeDataMapper.swift
+//  DTO
+//
+//  Created by jung on 10/15/24.
+//  Copyright © 2024 com.photi. All rights reserved.
+//
+
+import Foundation
+import DTO
+import Core
+import Entity
+
+public protocol ChallengeDataMapper {
+  func mapToChallenge(dto: ChallengeResponseDTO) -> Challenge
+}
+
+public struct ChallengeDataMapperImpl: ChallengeDataMapper {
+  public init() {}
+  
+  public func mapToChallenge(dto: ChallengeResponseDTO) -> Challenge {
+    let endDate = dto.endDate.toDate() ?? Date()
+    let proveTime = dto.proveTime.toDate("HH:mm") ?? Date()
+    let hasTags = dto.hashtags.map { $0.hashtag }
+    
+    return .init(
+      id: dto.id,
+      name: dto.name,
+      imageURL: dto.imageUrl,
+      goal: dto.goal,
+      proveTime: proveTime,
+      endDate: endDate,
+      hashTags: hasTags
+    )
+  }
+}

--- a/Projects/Data/Project.swift
+++ b/Projects/Data/Project.swift
@@ -24,7 +24,8 @@ let project = Project.make(
 			sources: ["DataMapper/**"],
 			dependencies: [
 				.Project.Data.DTO,
-				.Project.Domain.Entity
+				.Project.Domain.Entity,
+				.Project.Core
 			]
 		),
 		.make(

--- a/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeAPI.swift
+++ b/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeAPI.swift
@@ -1,0 +1,52 @@
+//
+//  ChallengeAPI.swift
+//  DTO
+//
+//  Created by jung on 10/15/24.
+//  Copyright © 2024 com.photi. All rights reserved.
+//
+
+import Foundation
+import Core
+import DTO
+import PhotiNetwork
+
+public enum ChallengeAPI {
+  case popularChallenges
+}
+
+extension ChallengeAPI: TargetType {
+  public var baseURL: URL {
+    //    return ServiceConfiguration.baseUrl
+    return URL(string: "http://localhost:8080/challenges")!
+  }
+  
+  public var path: String {
+    switch self {
+      case .popularChallenges: return "popular"
+    }
+  }
+  
+  public var method: HTTPMethod {
+    switch self {
+      case .popularChallenges: return .get
+    }
+  }
+  
+  public var task: TaskType {
+    switch self {
+      case .popularChallenges:
+        return .requestPlain
+    }
+  }
+  
+  public var sampleResponse: EndpointSampleResponse {
+    switch self {
+      case .popularChallenges:
+        let data = ChallengeResponseDTO.stubData
+        let jsonData = data.data(using: .utf8)
+        
+        return .networkResponse(200, jsonData ?? Data(), "OK", "성공")
+    }
+  }
+}

--- a/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeRepositoryImpl.swift
+++ b/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeRepositoryImpl.swift
@@ -1,0 +1,45 @@
+//
+//  ChallengeRepositoryImpl.swift
+//  DTO
+//
+//  Created by jung on 10/15/24.
+//  Copyright © 2024 com.photi. All rights reserved.
+//
+
+import RxSwift
+import DataMapper
+import DTO
+import Entity
+import PhotiNetwork
+import Repository
+
+public struct ChallengeRepositoryImpl: ChallengeRepository {
+  private let dataMapper: ChallengeDataMapper
+  
+  public init(dataMapper: ChallengeDataMapper) {
+    self.dataMapper = dataMapper
+  }
+  
+  public func fetchPopularChallenges() -> Single<[Challenge]> {
+    Single.create { single in
+      Task {
+        do {
+          let provider = Provider<ChallengeAPI>(stubBehavior: .immediate, session: Session())
+          let result = try await provider
+            .request(ChallengeAPI.popularChallenges, type: [ChallengeResponseDTO].self).value
+          
+          if result.statusCode == 200, let data = result.data {
+            let challenges = data.map { dataMapper.mapToChallenge(dto: $0) }
+            single(.success(challenges))
+          } else {
+            single(.failure(APIError.serverError))
+          }
+        } catch {
+          single(.failure(error))
+        }
+      }
+      
+      return Disposables.create()
+    }
+  }
+}

--- a/Projects/DesignSystem/Sources/Popup/Alert/UIViewController+Alert.swift
+++ b/Projects/DesignSystem/Sources/Popup/Alert/UIViewController+Alert.swift
@@ -1,0 +1,16 @@
+//
+//  UIViewController+Alert.swift
+//  DesignSystem
+//
+//  Created by jung on 10/16/24.
+//  Copyright © 2024 com.photi. All rights reserved.
+//
+
+import UIKit
+
+public extension UIViewController {
+  func presentWarningPopup() {
+    let alertVC = AlertViewController(alertType: .confirm, title: "오류", subTitle: "서버가 불안정합니다. 잠시 후에 다시 시도해주세요.")
+    alertVC.present(to: self, animted: false)
+  }
+}

--- a/Projects/DesignSystem/Sources/TextField/DateTextField/DateTextField.swift
+++ b/Projects/DesignSystem/Sources/TextField/DateTextField/DateTextField.swift
@@ -59,8 +59,8 @@ public final class DateTextField: UIView {
   public var endDate: Date? {
     didSet {
       guard let endDate else { return }
-      
-      self.setAttributedText(endDate.toString())
+      let dateString = endDate.toString("yyyy.MM.dd")
+      self.setAttributedText(dateString)
     }
   }
   
@@ -166,7 +166,7 @@ private extension DateTextField {
   
   func setLeftView(_ textField: PhotiTextField, date: Date) {
     let startDateLabel = UILabel()
-    let text = date.toString()
+    let text = date.toString("yyyy.MM.dd")
     
     startDateLabel.attributedText = text.attributedString(
       font: .body2,

--- a/Projects/Domain/Entity/Challenge.swift
+++ b/Projects/Domain/Entity/Challenge.swift
@@ -1,0 +1,37 @@
+//
+//  Challenge.swift
+//  UseCase
+//
+//  Created by jung on 10/14/24.
+//  Copyright © 2024 com.photi. All rights reserved.
+//
+
+import Foundation
+
+public struct Challenge: Identifiable {
+  public let id: Int
+  public let name: String
+  public let imageURL: URL
+  public let goal: String
+  public let proveTime: Date
+  public let endDate: Date
+  public let hashTags: [String]
+  
+  public init(
+    id: Int,
+    name: String,
+    imageURL: URL,
+    goal: String,
+    proveTime: Date,
+    endDate: Date,
+    hashTags: [String]
+  ) {
+    self.id = id
+    self.name = name
+    self.imageURL = imageURL
+    self.goal = goal
+    self.proveTime = proveTime
+    self.endDate = endDate
+    self.hashTags = hashTags
+  }
+}

--- a/Projects/Domain/Repository/Interfaces/ChallengeRepository.swift
+++ b/Projects/Domain/Repository/Interfaces/ChallengeRepository.swift
@@ -1,0 +1,17 @@
+//
+//  ChallengeRepository.swift
+//  Entity
+//
+//  Created by jung on 10/15/24.
+//  Copyright © 2024 com.photi. All rights reserved.
+//
+
+import RxSwift
+import DataMapper
+import Entity
+
+public protocol ChallengeRepository {
+  init(dataMapper: ChallengeDataMapper)
+    
+  func fetchPopularChallenges() -> Single<[Challenge]>
+}

--- a/Projects/Domain/UseCase/Implementations/HomeUseCaseImpl.swift
+++ b/Projects/Domain/UseCase/Implementations/HomeUseCaseImpl.swift
@@ -1,0 +1,24 @@
+//
+//  HomeUseCaseImpl.swift
+//  UseCaseImpl
+//
+//  Created by jung on 10/15/24.
+//  Copyright © 2024 com.photi. All rights reserved.
+//
+
+import RxSwift
+import Entity
+import UseCase
+import Repository
+
+public struct HomeUseCaseImpl: HomeUseCase {
+  private let repository: ChallengeRepository
+  
+  public init(repository: ChallengeRepository) {
+    self.repository = repository
+  }
+  
+  public func fetchPopularChallenge() -> Single<[Challenge]> {
+    return repository.fetchPopularChallenges()
+  }
+}

--- a/Projects/Domain/UseCase/Interfaces/HomeUseCase.swift
+++ b/Projects/Domain/UseCase/Interfaces/HomeUseCase.swift
@@ -1,0 +1,17 @@
+//
+//  HomeUseCase.swift
+//  UseCase
+//
+//  Created by jung on 10/14/24.
+//  Copyright © 2024 com.photi. All rights reserved.
+//
+
+import RxSwift
+import Entity
+import Repository
+
+public protocol HomeUseCase {
+  init(repository: ChallengeRepository)
+
+  func fetchPopularChallenge() -> Single<[Challenge]>
+}

--- a/Projects/Presentation/Home/Implementations/HomeContainer.swift
+++ b/Projects/Presentation/Home/Implementations/HomeContainer.swift
@@ -9,9 +9,11 @@
 import Core
 import Home
 import LogIn
+import UseCase
 
 public protocol HomeDependency: Dependency {
   var loginContainable: LogInContainable { get }
+  var homeUseCae: HomeUseCase { get }
 }
 
 public final class HomeContainer:
@@ -19,8 +21,10 @@ public final class HomeContainer:
   HomeContainable,
   NoneMemberHomeDependency,
   NoneChallengeHomeDependency {
+  var homeUseCase: HomeUseCase { dependency.homeUseCae }
+  
   public func coordinator(listener: HomeListener) -> Coordinating {
-    let viewModel = HomeViewModel()
+    let viewModel = HomeViewModel(useCase: dependency.homeUseCae)
     
     let noneMemberHome = NoneMemberHomeContainer(dependency: self)
     let noneChallengeHome = NoneChallengeHomeContainer(dependency: self)

--- a/Projects/Presentation/Home/Implementations/HomeViewModel.swift
+++ b/Projects/Presentation/Home/Implementations/HomeViewModel.swift
@@ -9,6 +9,7 @@
 import Foundation
 import RxCocoa
 import RxSwift
+import UseCase
 
 protocol HomeCoordinatable: AnyObject { }
 
@@ -21,6 +22,7 @@ protocol HomeViewModelType: AnyObject, HomeViewModelable {
 }
 
 final class HomeViewModel: HomeViewModelType {
+  private let useCase: HomeUseCase
   let disposeBag = DisposeBag()
   
   weak var coordinator: HomeCoordinatable?
@@ -32,7 +34,9 @@ final class HomeViewModel: HomeViewModelType {
   struct Output { }
   
   // MARK: - Initializers
-  init() { }
+  init(useCase: HomeUseCase) {
+    self.useCase = useCase
+  }
   
   func transform(input: Input) -> Output {
     return Output()

--- a/Projects/Presentation/Home/Implementations/NoneChallengeHome/NoneChallengeHomeContainer.swift
+++ b/Projects/Presentation/Home/Implementations/NoneChallengeHome/NoneChallengeHomeContainer.swift
@@ -7,8 +7,11 @@
 //
 
 import Core
+import UseCase
 
-protocol NoneChallengeHomeDependency: Dependency { }
+protocol NoneChallengeHomeDependency: Dependency {
+  var homeUseCase: HomeUseCase { get }
+}
 
 protocol NoneChallengeHomeContainable: Containable {
   func coordinator(listener: NoneChallengeHomeListener) -> Coordinating
@@ -18,7 +21,7 @@ final class NoneChallengeHomeContainer:
   Container<NoneChallengeHomeDependency>,
   NoneChallengeHomeContainable {
   func coordinator(listener: NoneChallengeHomeListener) -> Coordinating {
-    let viewModel = NoneChallengeHomeViewModel()
+    let viewModel = NoneChallengeHomeViewModel(useCase: dependency.homeUseCase)
     let coordinator = NoneChallengeHomeCoordinator(viewModel: viewModel)
     coordinator.listener = listener
     

--- a/Projects/Presentation/Home/Implementations/NoneChallengeHome/NoneChallengeHomeViewController.swift
+++ b/Projects/Presentation/Home/Implementations/NoneChallengeHome/NoneChallengeHomeViewController.swift
@@ -23,16 +23,18 @@ final class NoneChallengeHomeViewController: UIViewController {
   private let viewModel: NoneChallengeHomeViewModel
   private let disposeBag = DisposeBag()
   private var currentPage = 0
-  private var items: [ChallengeViewModel] = [] {
+  private var dataSource: [ChallengePresentationModel] = [] {
     didSet {
       challengeImageCollectionView.reloadData()
     }
   }
   
+  private let viewWillAppear = PublishRelay<Void>()
+  
   // MARK: - UI Components
   private let logoImageView: UIImageView = {
     let imageView = UIImageView()
-    imageView.image = .logoLetters
+    imageView.image = .logoLettersBlue
     imageView.contentMode = .left
     
     return imageView
@@ -95,10 +97,18 @@ final class NoneChallengeHomeViewController: UIViewController {
     challengeImageCollectionView.dataSource = self
   }
   
+  override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+    
+    viewWillAppear.accept(())
+  }
+  
   override func viewDidAppear(_ animated: Bool) {
     super.viewDidAppear(animated)
-
+    
+    guard !dataSource.isEmpty else { return }
     scrollToPage(currentPage)
+    challengeInformationView.configure(with: dataSource[currentPage])
   }
 }
 
@@ -155,19 +165,45 @@ private extension NoneChallengeHomeViewController {
 
 // MARK: - Bind Methods
 private extension NoneChallengeHomeViewController {
-  func bind() { }
+  func bind() {
+    let input = NoneChallengeHomeViewModel.Input(
+      viewWillAppear: viewWillAppear.asSignal()
+    )
+    
+    let output = viewModel.transform(input: input)
+    bind(for: output)
+  }
+  
+  func bind(for output: NoneChallengeHomeViewModel.Output) {
+    output.challenges
+      .drive(with: self) { owner, challenges in
+        owner.dataSource = challenges
+      }
+      .disposed(by: disposeBag)
+    
+    output.requestFailed
+      .emit(with: self) { owner, _ in
+        owner.presentWarningPopup()
+      }
+      .disposed(by: disposeBag)
+  }
 }
 
 // MARK: - UICollectionViewDataSource
 extension NoneChallengeHomeViewController: UICollectionViewDataSource {
   func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-    return items.count
+    return dataSource.count + 1
   }
   
   func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
     let cell = collectionView.dequeueCell(ChallengeImageCell.self, for: indexPath)
     
-    cell.configure(with: items[indexPath.row])
+    if indexPath.row == dataSource.count {
+      cell.configureCreateCell()
+    } else {
+      cell.configure(with: dataSource[indexPath.row])
+    }
+    
     cell.isCurrentPage = indexPath.row == currentPage
     
     return cell
@@ -204,7 +240,7 @@ private extension NoneChallengeHomeViewController {
   
   func offSetDidChange(_ offset: CGPoint) {
     let page = currentPage(for: offset)
-    defer { currentPage = page }
+    guard page <= dataSource.count && page >= 0 else { return }
     guard
       let beforeCell = cellForPage(currentPage),
       let currentCell = cellForPage(page)
@@ -213,12 +249,14 @@ private extension NoneChallengeHomeViewController {
     beforeCell.isCurrentPage = false
     currentCell.isCurrentPage = true
     
-    if page == items.count - 1 {
+    if page == dataSource.count {
       presentCreateChallengeInformationView()
     } else {
       presentChallengeInformationView()
-      challengeInformationView.configure(with: items[page])
+      challengeInformationView.configure(with: dataSource[page])
     }
+    
+    currentPage = page
   }
   
   func currentPage(for offset: CGPoint) -> Int {
@@ -238,13 +276,14 @@ private extension NoneChallengeHomeViewController {
   }
   
   func scrollToPage(_ page: Int, animated: Bool = false) {
-    guard items.count > page else { return }
+    guard dataSource.count > page else { return }
     let indexPath = IndexPath(row: page, section: 0)
     
     DispatchQueue.main.async {
       self.challengeImageCollectionView.scrollToItem(at: indexPath, at: .top, animated: animated)
     }
   }
+
   func presentChallengeInformationView() {
     challengeInformationView.isHidden = false
     createChallengeInformationView.isHidden = true

--- a/Projects/Presentation/Home/Implementations/NoneChallengeHome/NoneChallengeHomeViewModel.swift
+++ b/Projects/Presentation/Home/Implementations/NoneChallengeHome/NoneChallengeHomeViewModel.swift
@@ -27,11 +27,19 @@ final class NoneChallengeHomeViewModel: NoneChallengeHomeViewModelType, NoneChal
   
   weak var coordinator: NoneChallengeHomeCoordinatable?
   
+  private let challengesRelay = BehaviorRelay<[ChallengePresentationModel]>(value: [])
+  private let requestFailedRelay = PublishRelay<Void>()
+
   // MARK: - Input
-  struct Input { }
+  struct Input {
+    let viewWillAppear: Signal<Void>
+  }
   
   // MARK: - Output
-  struct Output { }
+  struct Output {
+    let challenges: Driver<[ChallengePresentationModel]>
+    let requestFailed: Signal<Void>
+  }
   
   // MARK: - Initializers
   init(useCase: HomeUseCase) {
@@ -39,6 +47,50 @@ final class NoneChallengeHomeViewModel: NoneChallengeHomeViewModelType, NoneChal
   }
   
   func transform(input: Input) -> Output {
-    return Output()
+    input.viewWillAppear
+      .emit(with: self) { owner, _ in
+        owner.fetchPopularChallenge()
+      }
+      .disposed(by: disposeBag)
+    
+    return Output(
+      challenges: challengesRelay.asDriver(),
+      requestFailed: requestFailedRelay.asSignal()
+    )
+  }
+}
+
+// MARK: - Private Methods
+private extension NoneChallengeHomeViewModel {
+  func fetchPopularChallenge() {
+    useCase.fetchPopularChallenge()
+      .subscribe(
+        with: self,
+        onSuccess: { owner, challenges in
+          let models = challenges.map { owner.mapToChallengePresentationModel($0) }
+          
+          owner.challengesRelay.accept(models)
+        },
+        onFailure: { owner, err in
+          print(err)
+          owner.requestFailedRelay.accept(())
+        }
+      )
+      .disposed(by: disposeBag)
+  }
+  
+  func mapToChallengePresentationModel(_ challenge: Challenge) -> ChallengePresentationModel {
+    let proveTime = challenge.proveTime.toString("HH:mm")
+    let endDate = challenge.endDate.toString("yyyy.MM.dd")
+    
+    return .init(
+      name: challenge.name,
+      image: nil,
+      goal: challenge.goal,
+      proveTime: proveTime,
+      endDate: endDate,
+      numberOfPersons: 0,
+      hashTags: challenge.hashTags
+    )
   }
 }

--- a/Projects/Presentation/Home/Implementations/NoneChallengeHome/NoneChallengeHomeViewModel.swift
+++ b/Projects/Presentation/Home/Implementations/NoneChallengeHome/NoneChallengeHomeViewModel.swift
@@ -8,6 +8,8 @@
 
 import RxCocoa
 import RxSwift
+import Entity
+import UseCase
 
 protocol NoneChallengeHomeCoordinatable: AnyObject { }
 
@@ -20,6 +22,7 @@ protocol NoneChallengeHomeViewModelType: AnyObject {
 }
 
 final class NoneChallengeHomeViewModel: NoneChallengeHomeViewModelType, NoneChallengeHomeViewModelable {
+  private let useCase: HomeUseCase
   let disposeBag = DisposeBag()
   
   weak var coordinator: NoneChallengeHomeCoordinatable?
@@ -31,7 +34,9 @@ final class NoneChallengeHomeViewModel: NoneChallengeHomeViewModelType, NoneChal
   struct Output { }
   
   // MARK: - Initializers
-  init() { }
+  init(useCase: HomeUseCase) {
+    self.useCase = useCase
+  }
   
   func transform(input: Input) -> Output {
     return Output()

--- a/Projects/Presentation/Home/Implementations/NoneChallengeHome/Views/ChallengInformationView/ChallengeInformationView.swift
+++ b/Projects/Presentation/Home/Implementations/NoneChallengeHome/Views/ChallengInformationView/ChallengeInformationView.swift
@@ -69,20 +69,27 @@ final class ChallengeInformationView: UIView {
     fatalError("init(coder:) has not been implemented")
   }
   
-  func configure(with viewModel: ChallengeViewModel) {
-    goalContentView.configure(firstContent: viewModel.goal)
+  override func layoutSubviews() {
+    super.layoutSubviews()
+    
+    centerContentHorizontalyByInsetIfNeeded()
+  }
+  
+  // MARK: - Configure Methods
+  func configure(with model: ChallengePresentationModel) {
+    goalContentView.configure(firstContent: model.goal)
     challengeTimeContentView.configure(
-      firstContent: viewModel.verificatoinTime,
-      secondContent: viewModel.expirationTime
+      firstContent: model.proveTime,
+      secondContent: model.endDate
     )
     
-    challengeNameLabel.attributedText = viewModel.name.attributedString(font: .body1Bold, color: .gray900)
-    participateCountLabel.attributedText = "\(viewModel.numberOfPersons)명 도전 중".attributedString(
+    challengeNameLabel.attributedText = model.name.attributedString(font: .body1Bold, color: .gray900)
+    participateCountLabel.attributedText = "\(model.numberOfPersons)명 도전 중".attributedString(
       font: .caption1,
       color: .gray700
     )
     
-    self.hashTags = ["해시태그 1", "해시태그 2", "해시태그 3"]
+    self.hashTags = model.hashTags
   }
 }
 

--- a/Projects/Presentation/Home/Implementations/NoneChallengeHome/Views/ChallengeImageCell.swift
+++ b/Projects/Presentation/Home/Implementations/NoneChallengeHome/Views/ChallengeImageCell.swift
@@ -36,15 +36,14 @@ final class ChallengeImageCell: UICollectionViewCell {
   }
   
   // MARK: - Configure Methods
-  func configure(with viewModel: ChallengeViewModel) {
+  func configure(with viewModel: ChallengePresentationModel) {
     var defaultImage = UIImage.defaultChallengeImage
-    
-    if case .create = viewModel.mode {
-      defaultImage = .createChallenge
-    }
-    
     let image: UIImage = (viewModel.image == nil) ? defaultImage : viewModel.image!
     imageView.image = image
+  }
+  
+  func configureCreateCell() {
+    imageView.image = .createChallenge
   }
 }
 

--- a/Projects/Presentation/Home/Implementations/NoneChallengeHome/Views/ChallengePresentationModel.swift
+++ b/Projects/Presentation/Home/Implementations/NoneChallengeHome/Views/ChallengePresentationModel.swift
@@ -8,18 +8,12 @@
 
 import UIKit
 
-struct ChallengeViewModel {
-  enum Mode {
-    case `default`
-    case create
-  }
-  
+struct ChallengePresentationModel {
   let name: String
-  let mode: Mode
   let image: UIImage?
   let goal: String
-  let verificatoinTime: String
-  let expirationTime: String
-  
+  let proveTime: String
+  let endDate: String
   let numberOfPersons: Int
-} 
+  let hashTags: [String]
+}

--- a/Projects/Presentation/LogIn/Implementations/SignUp/EnterEmail/EnterEmailViewController.swift
+++ b/Projects/Presentation/LogIn/Implementations/SignUp/EnterEmail/EnterEmailViewController.swift
@@ -157,7 +157,7 @@ private extension EnterEmailViewController {
     
     output.requestFailed
       .emit(with: self) { owner, _ in
-        owner.displayAlertPopUp()
+        owner.presentWarningPopup()
       }
       .disposed(by: disposeBag)
     
@@ -179,10 +179,5 @@ private extension EnterEmailViewController {
       lineTextField.commentViews = []
       lineTextField.mode = .success
     }
-  }
-  
-  func displayAlertPopUp() {
-    let alertVC = AlertViewController(alertType: .confirm, title: "오류", subTitle: "잠시 후에 다시 시도해주세요.")
-    alertVC.present(to: self, animted: false)
   }
 }

--- a/Projects/Presentation/LogIn/Implementations/SignUp/EnterEmail/VerifyEmail/VerifyEmailViewController.swift
+++ b/Projects/Presentation/LogIn/Implementations/SignUp/EnterEmail/VerifyEmail/VerifyEmailViewController.swift
@@ -159,7 +159,7 @@ private extension VerifyEmailViewController {
     
     output.requestFailed
       .emit(with: self) { owner, _ in
-        owner.displayRequestFailedPopUp()
+        owner.presentWarningPopup()
       }
       .disposed(by: disposeBag)
     
@@ -190,11 +190,6 @@ extension VerifyEmailViewController {
 
 // MARK: - Private Methods
 private extension VerifyEmailViewController {
-  func displayRequestFailedPopUp() {
-    let alertVC = AlertViewController(alertType: .confirm, title: "오류", subTitle: "잠시 후에 다시 시도해주세요.")
-    alertVC.present(to: self, animted: false)
-  }
-  
   func displayEmailNotFoundPopUp() {
     let alertVC = AlertViewController(alertType: .confirm, title: "오류", subTitle: "해당 이메일이 존재하지 않습니다.")
     alertVC.present(to: self, animted: false)

--- a/Projects/Presentation/LogIn/Implementations/SignUp/EnterId/EnterIdViewController.swift
+++ b/Projects/Presentation/LogIn/Implementations/SignUp/EnterId/EnterIdViewController.swift
@@ -195,15 +195,8 @@ private extension EnterIdViewController {
     
     output.requestFailed
       .emit(with: self) { owner, _ in
-        owner.displayRequestFailedPopUp()
+        owner.presentWarningPopup()
       }
       .disposed(by: disposeBag)
-  }
-}
-
-private extension EnterIdViewController {
-  func displayRequestFailedPopUp() {
-    let alertVC = AlertViewController(alertType: .confirm, title: "오류", subTitle: "잠시 후에 다시 시도해주세요.")
-    alertVC.present(to: self, animted: false)
   }
 }

--- a/Projects/Presentation/LogIn/Implementations/SignUp/EnterPassword/EnterPasswordViewController.swift
+++ b/Projects/Presentation/LogIn/Implementations/SignUp/EnterPassword/EnterPasswordViewController.swift
@@ -222,7 +222,7 @@ private extension EnterPasswordViewController {
     
     output.requestFailed
       .emit(with: self) { owner, _ in
-        owner.displayRequestFailedPopUp()
+        owner.presentWarningPopup()
       }
       .disposed(by: disposeBag)
   }
@@ -246,11 +246,6 @@ private extension EnterPasswordViewController {
       .map { _ in PhotiProgressStep.four }
       .bind(to: progressBar.rx.step)
       .disposed(by: disposeBag)
-  }
-  
-  func displayRequestFailedPopUp() {
-    let alertVC = AlertViewController(alertType: .confirm, title: "오류", subTitle: "잠시 후에 다시 시도해주세요.")
-    alertVC.present(to: self, animted: false)
   }
 }
 


### PR DESCRIPTION
## 관련 이슈

- #143

## 작업 설명

Home화면 챌린지 없는 경우 인기 있는 챌린지 API 연결했습니다.

## PR 특이 사항
- 몇명 도전중은 아직 API가 나오지 않아서, 나오는 대로 붙이겠습니다. 추가로! 이미지 URL의 경우 이미지 캐싱 작업 이후, 일괄 처리하겠습니다!