### PR TITLE
[FEAT]: 챌린지(회원) 소개 UI 구현 완료

### DIFF
--- a/Projects/Core/Utils/BaseCoordinator/NavigationControllerable.swift
+++ b/Projects/Core/Utils/BaseCoordinator/NavigationControllerable.swift
@@ -12,22 +12,8 @@ public extension ViewControllerable where Self: NavigationControllerable {
   var uiviewController: UIViewController { return self.navigationController }
 }
 
-extension NavigationControllerable: ViewControllerable { }
-
-public class NavigationControllerable {
+public class NavigationControllerable: ViewControllerable {
   public let navigationController: UINavigationController
-  
-  /// 가장위에 있는 ViewControllable을 리턴합니다.
-  public var topViewControllable: ViewControllerable {
-    var top: ViewControllerable = self
-    
-    while
-      let presented = getPresentedViewController(base: top.uiviewController) as? ViewControllerable {
-      top = presented
-    }
-    
-    return top
-  }
   
   // MARK: - Initializers
   public init(navigationController: UINavigationController) {
@@ -40,38 +26,5 @@ public class NavigationControllerable {
   
   public init() {
     self.navigationController = UINavigationController()
-  }
-}
-
-// MARK: - Public Methods
-public extension NavigationControllerable {
-  func pushViewController(_ viewControllable: ViewControllerable, animated: Bool) {
-    navigationController.pushViewController(viewControllable.uiviewController, animated: animated)
-  }
-  
-  func popViewController(animated: Bool) {
-    navigationController.popViewController(animated: animated)
-  }
-  
-  func popToRoot(animated: Bool) {
-    navigationController.popToRootViewController(animated: animated)
-  }
-  
-  func setViewControllers(_ viewControllerables: [ViewControllerable]) {
-    let uiviewControllers = viewControllerables.map(\.uiviewController)
-    navigationController.setViewControllers(uiviewControllers, animated: true)
-  }
-}
-
-// MARK: - Private Methods
-private extension NavigationControllerable {
-  func getPresentedViewController(base: UIViewController) -> UIViewController? {
-    if let navigation = base as? UINavigationController {
-      return navigation.visibleViewController
-    } else if let tapBar = base as? UITabBarController {
-      return tapBar.selectedViewController
-    } else {
-      return base.presentedViewController
-    }
   }
 }

--- a/Projects/Core/Utils/BaseCoordinator/ViewControllerable.swift
+++ b/Projects/Core/Utils/BaseCoordinator/ViewControllerable.swift
@@ -69,6 +69,13 @@ public extension ViewControllerable {
     }
   }
   
+  func popViewController(animated: Bool, completion: @escaping () -> Void) {
+    CATransaction.begin()
+    CATransaction.setCompletionBlock(completion)
+    popViewController(animated: animated)
+    CATransaction.commit()
+  }
+  
   func popToRoot(animated: Bool) {
     if let nav = self.uiviewController as? UINavigationController {
       nav.popToRootViewController(animated: animated)

--- a/Projects/Presentation/Challenge/Implementations/Member/ChallengeCoordinator.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/ChallengeCoordinator.swift
@@ -12,6 +12,7 @@ import Challenge
 protocol ChallengePresentable {
   func attachViewControllerables(_ viewControllerables: ViewControllerable...)
   func didChangeContentOffsetAtMainContainer(_ offset: Double)
+  func presentDidChangeGoalToastView()
 }
 
 final class ChallengeCoordinator: ViewableCoordinator<ChallengePresentable> {
@@ -90,12 +91,14 @@ extension ChallengeCoordinator {
     viewControllerable.pushViewController(coordinator.viewControllerable, animated: true)
   }
   
-  func detachEditChallengeGoal() {
+  func detachEditChallengeGoal(completion: (() -> Void)? = nil) {
     guard let coordinator = editChallengeGoalCoordinator else { return }
     
     removeChild(coordinator)
     self.editChallengeGoalCoordinator = nil
-    viewControllerable.popViewController(animated: true)
+    viewControllerable.popViewController(animated: true) {
+      completion?()
+    }
   }
 }
 
@@ -128,6 +131,8 @@ extension ChallengeCoordinator: EditChallengeGoalListener {
   
   func didChangeChallengeGoal(_ goal: String) {
     // TODO: API 연결 이후 수정 예정
-    detachEditChallengeGoal()
+    detachEditChallengeGoal { [weak self] in
+      self?.presenter.presentDidChangeGoalToastView()
+    }
   }
 }

--- a/Projects/Presentation/Challenge/Implementations/Member/ChallengeViewController.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/ChallengeViewController.swift
@@ -136,6 +136,21 @@ extension ChallengeViewController: ChallengePresentable {
       $0.top.equalToSuperview().offset(mainContainerOffset)
     }
   }
+  
+  func presentDidChangeGoalToastView() {
+    let toastView = ToastView(
+      tipPosition: .none,
+      text: "수정 완료! 새로운 목표까지 화이팅이에요!",
+      icon: .bulbWhite
+    )
+    
+    toastView.setConstraints {
+      $0.bottom.equalToSuperview().inset(64)
+      $0.centerX.equalToSuperview()
+    }
+    
+    toastView.present(to: self)
+  }
 }
 
 // MARK: - Private Methods

--- a/Projects/Presentation/Challenge/Implementations/Member/Description/DescriptionViewController.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/Description/DescriptionViewController.swift
@@ -19,6 +19,22 @@ final class DescriptionViewController: UIViewController, ViewControllerable {
   private let disposeBag = DisposeBag()
   
   // MARK: - UI Components
+  private let mainContainerView = UIView()
+  private let ruleDescriptionView = RuleDescriptionView()
+  private let goalDescriptionView = DescriptionView(type: .goal)
+  private let durationDescriptionView = DescriptionView(type: .duration)
+  private let seperatorViewBetweenRuleAndGoal: UIView = {
+    let view = UIView()
+    view.backgroundColor = .gray100
+    
+    return view
+  }()
+  private let seperatorViewBetweenGoalAndDuration: UIView = {
+    let view = UIView()
+    view.backgroundColor = .gray100
+    
+    return view
+  }()
   
   // MARK: - Initializers
   init(viewModel: DescriptionViewModel) {
@@ -46,9 +62,50 @@ private extension DescriptionViewController {
     setConstraints()
   }
   
-  func setViewHierarchy() { }
+  func setViewHierarchy() {
+    view.addSubviews(mainContainerView)
+    mainContainerView.addSubviews(
+      ruleDescriptionView,
+      goalDescriptionView,
+      durationDescriptionView,
+      seperatorViewBetweenRuleAndGoal,
+      seperatorViewBetweenGoalAndDuration
+    )
+  }
   
-  func setConstraints() { }
+  func setConstraints() {
+    mainContainerView.snp.makeConstraints {
+      $0.top.equalToSuperview().offset(32)
+      $0.leading.trailing.equalToSuperview().inset(24)
+      $0.bottom.equalToSuperview()
+    }
+    
+    ruleDescriptionView.snp.makeConstraints {
+      $0.top.leading.trailing.equalToSuperview()
+    }
+    
+    seperatorViewBetweenRuleAndGoal.snp.makeConstraints {
+      $0.height.equalTo(1)
+      $0.leading.trailing.equalToSuperview()
+      $0.top.equalTo(ruleDescriptionView.snp.bottom).offset(24)
+    }
+    
+    goalDescriptionView.snp.makeConstraints {
+      $0.leading.trailing.equalToSuperview()
+      $0.top.equalTo(seperatorViewBetweenRuleAndGoal.snp.bottom).offset(32)
+    }
+    
+    seperatorViewBetweenGoalAndDuration.snp.makeConstraints {
+      $0.height.equalTo(1)
+      $0.leading.trailing.equalToSuperview()
+      $0.top.equalTo(goalDescriptionView.snp.bottom).offset(24)
+    }
+    
+    durationDescriptionView.snp.makeConstraints {
+      $0.leading.trailing.equalToSuperview()
+      $0.top.equalTo(seperatorViewBetweenGoalAndDuration.snp.bottom).offset(32)
+    }
+  }
 }
 
 // MARK: - Bind Methods

--- a/Projects/Presentation/Challenge/Implementations/Member/Description/Views/DescriptionView.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/Description/Views/DescriptionView.swift
@@ -1,0 +1,70 @@
+//
+//  DescriptionView.swift
+//  HomeImpl
+//
+//  Created by jung on 1/21/25.
+//  Copyright © 2025 com.photi. All rights reserved.
+//
+
+import UIKit
+import Core
+import DesignSystem
+
+final class DescriptionView: UIView {
+  enum DescriptionType {
+    case goal, duration
+  }
+  
+  // MARK: - UI Components
+  private let titleLabel = UILabel()
+  private let subTitleLabel = UILabel()
+  
+  // MARK: - Initializers
+  init(type: DescriptionType) {
+    super.init(frame: .zero)
+    
+    setupUI(type: type)
+  }
+  
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  // MARK: - Configure Methods
+  func configure(subTitle: String) {
+    subTitleLabel.attributedText = subTitle.attributedString(
+      font: .body2,
+      color: .gray600
+    )
+  }
+}
+
+// MARK: - UI Methods
+private extension DescriptionView {
+  func setupUI(type: DescriptionType) {
+    let title = type == .goal ? "목표" : "기간"
+    
+    titleLabel.attributedText = title.attributedString(
+      font: .body1Bold,
+      color: .gray900
+    )
+    setViewHierarchy()
+    setConstraints()
+  }
+  
+  func setViewHierarchy() {
+    addSubviews(titleLabel, subTitleLabel)
+  }
+  
+  func setConstraints() {
+    titleLabel.snp.makeConstraints {
+      $0.leading.top.equalToSuperview()
+    }
+    
+    subTitleLabel.snp.makeConstraints {
+      $0.leading.trailing.bottom.equalToSuperview()
+      $0.top.equalTo(titleLabel.snp.bottom).offset(20)
+    }
+  }
+}

--- a/Projects/Presentation/Challenge/Implementations/Member/Description/Views/RuleDescriptionView.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/Description/Views/RuleDescriptionView.swift
@@ -1,0 +1,152 @@
+//
+//  RuleDescriptionCell.swift
+//  HomeImpl
+//
+//  Created by jung on 1/21/25.
+//  Copyright © 2025 com.photi. All rights reserved.
+//
+
+import UIKit
+import Core
+import DesignSystem
+
+final class RuleDescriptionView: UIView {
+  private var rules = [String]() {
+    didSet {
+      self.rulesLabels = configureRuleLabels(rules)
+    }
+  }
+  
+  // MARK: - UI Components
+  private let titleLabel: UILabel = {
+    let label = UILabel()
+    label.attributedText = "인증 룰".attributedString(
+      font: .body1Bold,
+      color: .gray900
+    )
+    return label
+  }()
+  private let ruleStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .vertical
+    stackView.alignment = .fill
+    stackView.distribution = .fillEqually
+    stackView.spacing = 16
+    
+    return stackView
+  }()
+  private let challengeVerificationTimeView: UIView = {
+    let view = UIView()
+    view.backgroundColor = .blue0
+    view.layer.cornerRadius = 8
+    
+    return view
+  }()
+  private let challengeVerificationImageView = UIImageView(image: .timeBlue)
+  private let challengeVerificationTitleLabel: UILabel = {
+    let label = UILabel()
+    label.attributedText = "인증 시간".attributedString(
+      font: .body2Bold,
+      color: .blue500
+    )
+    return label
+  }()
+
+  private let challengeVerificationTimeLabel = UILabel()
+  
+  private var rulesLabels: [UILabel] = [] {
+    didSet {
+      oldValue.forEach { $0.removeFromSuperview() }
+      ruleStackView.addArrangedSubviews(rulesLabels)
+    }
+  }
+  
+  // MARK: - Initializers
+  init() {
+    super.init(frame: .zero)
+    
+    setupUI()
+  }
+  
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  // MARK: - Configure Methods
+  func configure(rules: [String], vertificationTime: String) {
+    self.rules = rules
+    challengeVerificationTimeLabel.attributedText = vertificationTime.attributedString(
+      font: .body2,
+      color: .blue400
+    )
+  }
+}
+
+// MARK: - UI Methods
+private extension RuleDescriptionView {
+  func setupUI() {
+    setViewHierarchy()
+    setConstraints()
+  }
+  
+  func setViewHierarchy() {
+    addSubviews(
+      titleLabel,
+      ruleStackView,
+      challengeVerificationTimeView
+    )
+    challengeVerificationTimeView.addSubviews(
+      challengeVerificationImageView,
+      challengeVerificationTitleLabel,
+      challengeVerificationTimeLabel
+    )
+  }
+  
+  func setConstraints() {
+    titleLabel.snp.makeConstraints {
+      $0.leading.top.equalToSuperview()
+    }
+    
+    ruleStackView.snp.makeConstraints {
+      $0.leading.trailing.equalToSuperview()
+      $0.top.equalTo(titleLabel.snp.bottom).offset(20)
+    }
+    
+    challengeVerificationTimeView.snp.makeConstraints {
+      $0.top.equalTo(ruleStackView.snp.bottom).offset(20)
+      $0.leading.trailing.bottom.equalToSuperview()
+      $0.height.equalTo(42)
+    }
+    
+    challengeVerificationImageView.snp.makeConstraints {
+      $0.leading.equalToSuperview().offset(14)
+      $0.width.height.equalTo(24)
+      $0.centerY.equalToSuperview()
+    }
+    
+    challengeVerificationTitleLabel.snp.makeConstraints {
+      $0.leading.equalTo(challengeVerificationImageView.snp.trailing).offset(4)
+      $0.centerY.equalToSuperview()
+    }
+    
+    challengeVerificationTimeLabel.snp.makeConstraints {
+      $0.leading.equalTo(challengeVerificationTitleLabel.snp.trailing).offset(10)
+      $0.centerY.equalToSuperview()
+    }
+  }
+}
+
+// MARK: - Private Methods
+private extension RuleDescriptionView {
+  func configureRuleLabels(_ rules: [String]) -> [UILabel] {
+    rules.map {
+      let label = UILabel()
+      label.attributedText = $0.attributedString(
+        font: .body2,
+        color: .gray600
+      )
+      return label
+    }
+  }
+}


### PR DESCRIPTION
## 관련 이슈

- #173

## 작업 설명
챌린지(회원) 소개 UI 구현 완료했습니다.
추가로 이전 작업에서 챌린지 개인 목표 수정 후 ToastView 띄우는 작업이 누락되어 같이 추가했습니다. 
## 스크린샷

![Simulator Screenshot - iPhone 16 Pro - 2025-01-21 at 23 34 28](https://github.com/user-attachments/assets/9d4b8357-de98-45d1-9d53-125c60a90062)
