### PR TITLE
[FEAT]: FeedComment API 연동 

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -16,14 +16,8 @@ echo $stagingFiles
 echo "🔍  대상 파일 목록:"
 echo $targets
 
-if [ -z "$stagingFiles" ]; then
-  printf "🏷️  Staging Area swift 파일이 없습니다"
-  printf "\n ✔ git add를 먼저 진행해주세요:)"
-  exit 1
-fi
-
-if [ "$RESULT" == '' ]; then 
-  printf "✨  SwiftLint를 돌릴 파일이 없습니다!! 고생하셨습니다:)\n"
+if [ -z "$targets" ]; then 
+  printf "🏷️  SwiftLint를 검사할 파일이 없습니다. 수고하셨습니다"
   exit 0
 fi
 
@@ -31,29 +25,24 @@ fi
 RESULT=$($LINT lint --quiet --config ${PWD}/.swiftlint.yml -- $targets)
 if [ "$RESULT" == '' ]; then
 	printf "✨  SwiftLint 적용을 완료했습니다!! 고생하셨습니다:)\n"
-else
-	echo ""
-	printf "✔ SwiftLint Failed 아래 내용을 확인해주세요:\n"
-  while read -r line; do
-    FILEPATH=$(echo $line | cut -d : -f 1)
-    L=$(echo $line | cut -d : -f 2)
-    C=$(echo $line | cut -d : -f 3)
-    TYPE=$(echo $line | cut -d : -f 4 | cut -c 2-)
-    MESSAGE=$(echo $line | cut -d : -f 5 | cut -c 2-)
-    DESCRIPTION=$(echo $line | cut -d : -f 6 | cut -c 2-)
-    if [ $TYPE == 'warning' ]; then
-      printf "\n 🚧  $TYPE\n"
-      warning 타입은 오류메시지만 표시하고 커밋을 허용하고 싶다면 line 40~42 주석 해제.
-      printf "    $FILEPATH:$L:$C\n"
-      printf "    📌  $MESSAGE: - $DESCRIPTION\n"
-      exit 0
-    elif [ $TYPE == 'error' ]; then
-      printf "\n 🚨  $TYPE\n"
-    fi
-    printf "    ✔ $FILEPATH:$L:$C\n"
-    printf "    📌 $MESSAGE: - $DESCRIPTION\n"
-  done <<< "$RESULT"
-
-  printf "\n 🚑  커밋실패!! Swiftlint rule에 맞게 코드를 변경해주세요:)\n"
-  exit 1
+  exit 0
 fi
+echo ""
+printf "✔ SwiftLint Failed 아래 내용을 확인해주세요:\n"
+while read -r line; do
+  FILEPATH=$(echo $line | cut -d : -f 1)
+  L=$(echo $line | cut -d : -f 2)
+  C=$(echo $line | cut -d : -f 3)
+  TYPE=$(echo $line | cut -d : -f 4 | cut -c 2-)
+  MESSAGE=$(echo $line | cut -d : -f 5 | cut -c 2-)
+  DESCRIPTION=$(echo $line | cut -d : -f 6 | cut -c 2-)
+  if [ $TYPE == 'warning' ]; then
+    printf "\n 🚧  $TYPE\n"
+    printf "    $FILEPATH:$L:$C\n"
+    printf "    📌  $MESSAGE: - $DESCRIPTION\n"
+  elif [ $TYPE == 'error' ]; then
+    printf "\n 🚨  $TYPE\n"
+  fi
+done <<< "$RESULT"
+printf "\n 🚑  커밋실패!! Swiftlint rule에 맞게 코드를 변경해주세요:)\n"
+exit 1

--- a/Projects/App/Sources/AppContainer.swift
+++ b/Projects/App/Sources/AppContainer.swift
@@ -106,21 +106,17 @@ final class AppContainer:
   lazy var challengeUseCase: ChallengeUseCase = {
     return ChallengeUseCaseImpl(repository: challengeRepository, authRepository: authRepository)
   }()
-   
+  
   lazy var feedUseCase: FeedUseCase = {
     return FeedUseCaseImpl(repository: challengeRepository)
   }()
-
+  
   lazy var reportUseCase: ReportUseCase = {
     return ReportUseCaseImpl(repository: reportRepository)
   }()
   
   lazy var inquiryUseCase: InquiryUseCase = {
     return InquiryUseCaseImpl(repository: inquiryRepository)
-  }()
-  
-  lazy var resignUsecase: ResignUseCase = {
-    return ResignUseCaseImpl(repository: resignRepository)
   }()
   
   // MARK: - Repository
@@ -166,9 +162,5 @@ final class AppContainer:
   
   lazy var inquiryRepository: InquiryRepository = {
     return InquiryRepositoryImpl(dataMapper: InquiryDataMapperImpl())
-  }()
-  
-  lazy var resignRepository: ResignRepository = {
-    return ResignRepositoryImpl(dataMapper: ResignDataMapperImpl())
   }()
 }

--- a/Projects/App/Sources/AppContainer.swift
+++ b/Projects/App/Sources/AppContainer.swift
@@ -106,6 +106,10 @@ final class AppContainer:
   lazy var challengeUseCase: ChallengeUseCase = {
     return ChallengeUseCaseImpl(repository: challengeRepository, authRepository: authRepository)
   }()
+   
+  lazy var feedUseCase: FeedUseCase = {
+    return FeedUseCaseImpl(repository: challengeRepository)
+  }()
 
   lazy var reportUseCase: ReportUseCase = {
     return ReportUseCaseImpl(repository: reportRepository)

--- a/Projects/Core/Utils/ServiceConfiguration.swift
+++ b/Projects/Core/Utils/ServiceConfiguration.swift
@@ -8,11 +8,28 @@
 
 import Foundation
 
-public struct ServiceConfiguration {
-  public static var baseUrl: String {
+public final class ServiceConfiguration {
+  public static let shared = ServiceConfiguration()
+  
+  private init() { }
+  
+  public var baseUrl: String {
     guard let baseUrl = Bundle.main.object(forInfoDictionaryKey: "BaseURL") as? String else {
       fatalError("Service API URL could not find in plist. Please check plist or user-defined!")
     }
     return baseUrl
+  }
+  
+  /// 사용자의 `userName`을 리턴합니다.
+  public var userName: String {
+    guard let name = UserDefaults.standard.string(forKey: "userName") else {
+      return ""
+    }
+    
+    return name
+  }
+  
+  public func setUseName(_ name: String) {
+    UserDefaults.standard.set(name, forKey: "userName")
   }
 }

--- a/Projects/Data/DTO/Challenge/FeedComment/FeedCommentsResponseDTO.swift
+++ b/Projects/Data/DTO/Challenge/FeedComment/FeedCommentsResponseDTO.swift
@@ -1,0 +1,90 @@
+//
+//  FeedCommentsResponseDTO.swift
+//  DTO
+//
+//  Created by jung on 2/27/25.
+//  Copyright © 2025 com.photi. All rights reserved.
+//
+
+public struct FeedCommentsResponseDTO: Decodable {
+  public let content: [CommentResponseDTO]
+  public let last: Bool
+}
+
+public struct CommentResponseDTO: Decodable {
+  public let id: Int
+  public let username: String
+  public let comment: String
+}
+
+public extension FeedCommentsResponseDTO {
+  static let stubData1 = """
+{
+  "code": "200 OK",
+  "message": "성공",
+  "data": {
+    "content": [
+      {
+        "id": 1,
+        "username": "photi",
+        "comment": "멋져요"
+      },
+      {
+        "id": 2,
+        "username": "석영",
+        "comment": "멋져요"
+      },
+      {
+        "id": 3,
+        "username": "우섭",
+        "comment": "멋져요"
+      },
+      {
+        "id": 4,
+        "username": "photi",
+        "comment": "멋져요"
+      },
+      {
+        "id": 5,
+        "username": "photi",
+        "comment": "멋져요"
+      },
+      {
+        "id": 6,
+        "username": "photi",
+        "comment": "멋져요!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+      }
+    ],
+    "page": 0,
+    "size": 0,
+    "first": true,
+    "last": false
+  }
+}
+"""
+  
+  static let stubData2 = """
+{
+  "code": "200 OK",
+  "message": "성공",
+  "data": {
+    "content": [
+      {
+        "id": 7,
+        "username": "photi",
+        "comment": "멋져요"
+      },
+      {
+        "id": 8,
+        "username": "석영",
+        "comment": "멋져요"
+      }
+    ],
+    "page": 0,
+    "size": 0,
+    "first": true,
+    "last": true
+  }
+}
+"""
+}

--- a/Projects/Data/DTO/Challenge/FeedDetail/FeedDetailResponseDTO.swift
+++ b/Projects/Data/DTO/Challenge/FeedDetail/FeedDetailResponseDTO.swift
@@ -1,0 +1,33 @@
+//
+//  FeedDetailResponseDTO.swift
+//  DTO
+//
+//  Created by jung on 2/26/25.
+//  Copyright © 2025 com.photi. All rights reserved.
+//
+
+import Foundation
+
+public struct FeedDetailResponseDTO: Decodable {
+  public let username: String
+  public let userImageUrl: URL
+  public let feedImageUrl: URL
+  public let createdDateTime: String
+  public let likeCnt: Int
+}
+
+public extension FeedDetailResponseDTO {
+  static let stubData = """
+{
+  "code": "200 OK",
+  "message": "성공",
+  "data": {
+    "username": "photi",
+    "userImageUrl": "https://fastly.picsum.photos/id/370/200/200.jpg?hmac=HT9dVkM8BnOVYNnQU3Kiehyb9hJUPrehSqcOHXrq_y0",
+    "feedImageUrl": "https://fastly.picsum.photos/id/370/200/200.jpg?hmac=HT9dVkM8BnOVYNnQU3Kiehyb9hJUPrehSqcOHXrq_y0",
+    "createdDateTime": "2025-02-25T17:11:12.098Z",
+    "likeCnt": 10
+  }
+}
+"""
+}

--- a/Projects/Data/DataMapper/ChallengeDataMapper.swift
+++ b/Projects/Data/DataMapper/ChallengeDataMapper.swift
@@ -16,6 +16,7 @@ public protocol ChallengeDataMapper {
   func mapToChallengeDetail(dto: ChallengeDetailResponseDTO, id: Int) -> ChallengeDetail
   func mapToChallengeSummary(dto: EndedChallengeResponseDTO) -> [ChallengeSummary]
   func mapToFeed(dto: FeedResponseDTO) -> Feed
+  func mapToFeed(dto: FeedDetailResponseDTO, id: Int) -> Feed
 }
 
 public struct ChallengeDataMapperImpl: ChallengeDataMapper {
@@ -87,6 +88,18 @@ public struct ChallengeDataMapperImpl: ChallengeDataMapper {
       imageURL: dto.imageUrl,
       isLike: dto.isLike,
       updateTime: updateTime
+    )
+  }
+  
+  public func mapToFeed(dto: FeedDetailResponseDTO, id: Int) -> Feed {
+    let updateTime = dto.createdDateTime.toDateFromISO8601() ?? Date()
+    return .init(
+      id: id,
+      author: dto.username,
+      imageURL: dto.feedImageUrl,
+      authorImageURL: dto.userImageUrl,
+      updateTime: updateTime,
+      likeCount: dto.likeCnt
     )
   }
 }

--- a/Projects/Data/DataMapper/ChallengeDataMapper.swift
+++ b/Projects/Data/DataMapper/ChallengeDataMapper.swift
@@ -17,6 +17,7 @@ public protocol ChallengeDataMapper {
   func mapToChallengeSummary(dto: EndedChallengeResponseDTO) -> [ChallengeSummary]
   func mapToFeed(dto: FeedResponseDTO) -> Feed
   func mapToFeed(dto: FeedDetailResponseDTO, id: Int) -> Feed
+  func mapToFeedComment(dto: CommentResponseDTO) -> FeedComment
 }
 
 public struct ChallengeDataMapperImpl: ChallengeDataMapper {
@@ -100,6 +101,14 @@ public struct ChallengeDataMapperImpl: ChallengeDataMapper {
       authorImageURL: dto.userImageUrl,
       updateTime: updateTime,
       likeCount: dto.likeCnt
+    )
+  }
+  
+  public func mapToFeedComment(dto: CommentResponseDTO) -> FeedComment {
+    return .init(
+      id: dto.id,
+      author: dto.username,
+      comment: dto.comment
     )
   }
 }

--- a/Projects/Data/PhotiNetwork/EndPoint.swift
+++ b/Projects/Data/PhotiNetwork/EndPoint.swift
@@ -69,6 +69,10 @@ extension EndPoint {
         
       case let .uploadMultipartFormData(multipart):
         return request.encoded(multipart)
+        
+      case let .uploadCompositeMultipart(multipart, urlParameters):
+        request = request.encoded(multipart)
+        return try request.encoded(urlParameters, parameterEncoding: URLEncoding.queryString)
     }
   }
 }

--- a/Projects/Data/PhotiNetwork/TaskType.swift
+++ b/Projects/Data/PhotiNetwork/TaskType.swift
@@ -33,4 +33,7 @@ public enum TaskType {
   
   /// "multipart/form-data"를 upload합니다.
   case uploadMultipartFormData(multipart: MultipartFormData)
+  
+  /// `urlParameters`와 함께, "multipart/form-data"를 upload합니다.
+  case uploadCompositeMultipart(multipart: MultipartFormData, urlParameters: [String: Any])
 }

--- a/Projects/Data/Repository/Implementations/AuthRepositoryImpl/AuthAPI.swift
+++ b/Projects/Data/Repository/Implementations/AuthRepositoryImpl/AuthAPI.swift
@@ -51,7 +51,11 @@ extension AuthAPI: TargetType {
 fileprivate extension AuthAPI {
   static let sampleData = """
     {
+    "code": "200 OK",
+    "message": "성공",
+    "data": {
       "successMessage": "string"
+      }
     }
   """
 }

--- a/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeAPI.swift
+++ b/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeAPI.swift
@@ -22,6 +22,7 @@ public enum ChallengeAPI {
   case updateLikeState(challengeId: Int, feedId: Int, isLike: Bool)
   case isProve(challengeId: Int)
   case feedDetail(challengeId: Int, feedId: Int)
+  case feedComments(feedId: Int, page: Int, size: Int)
 }
 
 extension ChallengeAPI: TargetType {
@@ -42,6 +43,7 @@ extension ChallengeAPI: TargetType {
       case let .updateLikeState(challengeId, feedId, _): return "challenges/\(challengeId)/feeds/\(feedId)/like"
       case let .isProve(challengeId): return "/users/challenges/\(challengeId)/prove"
       case let .feedDetail(challengeId, feedId): return "/challenges/\(challengeId)/feeds/\(feedId)"
+      case let .feedComments(feedId, _, _): return "/challenges/feeds/\(feedId)/comments"
     }
   }
   
@@ -57,6 +59,7 @@ extension ChallengeAPI: TargetType {
       case let .updateLikeState(_, _, isLike): return isLike ? .post : .delete
       case .isProve: return .get
       case .feedDetail: return .get
+      case .feedComments: return .get
     }
   }
   
@@ -109,6 +112,10 @@ extension ChallengeAPI: TargetType {
         
       case let .isProve(challengeId):
         let parameters = ["challengeId": challengeId]
+        return .requestParameters(parameters: parameters, encoding: URLEncoding.queryString)
+        
+      case let .feedComments(feedId, page, size):
+        let parameters = ["feedId": "\(feedId)", "page": "\(page)", "size": "\(size)"]
         return .requestParameters(parameters: parameters, encoding: URLEncoding.queryString)
     }
   }
@@ -163,6 +170,13 @@ extension ChallengeAPI: TargetType {
       case .feedDetail:
         let data = FeedDetailResponseDTO.stubData
         let jsonData = data.data(using: .utf8)
+        
+        return .networkResponse(200, jsonData ?? Data(), "OK", "성공")
+        
+      case let .feedComments(_, page, _):
+        let page = min(page, 1)
+        let commentsData = [FeedCommentsResponseDTO.stubData1, FeedCommentsResponseDTO.stubData2]
+        let jsonData = commentsData[page].data(using: .utf8)
         
         return .networkResponse(200, jsonData ?? Data(), "OK", "성공")
     }

--- a/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeAPI.swift
+++ b/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeAPI.swift
@@ -157,7 +157,7 @@ extension ChallengeAPI: TargetType {
         
         return .networkResponse(200, jsonData ?? Data(), "OK", "성공")
         
-      // swiftlint:disable line_length
+      // swiftlint:disable line_length 
       case .joinChallenge, .joinPrivateChallenge, .uploadChallengeProof, .updateLikeState, .uploadFeedComment, .deleteFeedComment:
       // swiftlint:enable line_length
         let data = """

--- a/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeAPI.swift
+++ b/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeAPI.swift
@@ -23,6 +23,8 @@ public enum ChallengeAPI {
   case isProve(challengeId: Int)
   case feedDetail(challengeId: Int, feedId: Int)
   case feedComments(feedId: Int, page: Int, size: Int)
+  case uploadFeedComment(challengeId: Int, feedId: Int, comment: String)
+  case deleteFeedComment(challengeId: Int, feedId: Int, commentId: Int)
 }
 
 extension ChallengeAPI: TargetType {
@@ -44,6 +46,10 @@ extension ChallengeAPI: TargetType {
       case let .isProve(challengeId): return "/users/challenges/\(challengeId)/prove"
       case let .feedDetail(challengeId, feedId): return "/challenges/\(challengeId)/feeds/\(feedId)"
       case let .feedComments(feedId, _, _): return "/challenges/feeds/\(feedId)/comments"
+      case let .uploadFeedComment(challengeId, feedId, _): 
+        return "/challenges/\(challengeId)feeds/\(feedId)/comments"
+      case let .deleteFeedComment(challengeId, feedId, commentId): 
+        return "/challenges/\(challengeId)/feeds/\(feedId)/comments/\(commentId)"
     }
   }
   
@@ -60,6 +66,8 @@ extension ChallengeAPI: TargetType {
       case .isProve: return .get
       case .feedDetail: return .get
       case .feedComments: return .get
+      case .uploadFeedComment: return .post
+      case .deleteFeedComment: return .delete
     }
   }
   
@@ -117,6 +125,15 @@ extension ChallengeAPI: TargetType {
       case let .feedComments(feedId, page, size):
         let parameters = ["feedId": "\(feedId)", "page": "\(page)", "size": "\(size)"]
         return .requestParameters(parameters: parameters, encoding: URLEncoding.queryString)
+        
+      case let .uploadFeedComment(challengeId, feedId, comment):
+        let urlParameters = ["challengeId": challengeId, "feedId": feedId]
+        let bodyParameters = ["comment": comment]
+        return .requestCompositeParameters(bodyParameters: bodyParameters, urlParameters: urlParameters)
+        
+      case let .deleteFeedComment(challengeId, feedId, commentId):
+        let parameters = ["challengeId": challengeId, "feedId": feedId, "commentId": commentId]
+        return .requestParameters(parameters: parameters, encoding: URLEncoding.queryString)
     }
   }
   
@@ -140,7 +157,9 @@ extension ChallengeAPI: TargetType {
         
         return .networkResponse(200, jsonData ?? Data(), "OK", "성공")
         
-      case .joinChallenge, .joinPrivateChallenge, .uploadChallengeProof, .updateLikeState:
+      // swiftlint:disable line_length
+      case .joinChallenge, .joinPrivateChallenge, .uploadChallengeProof, .updateLikeState, .uploadFeedComment, .deleteFeedComment:
+      // swiftlint:enable line_length
         let data = """
           {
             "code": "200 OK",

--- a/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeRepositoryImpl.swift
+++ b/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeRepositoryImpl.swift
@@ -133,6 +133,17 @@ public struct ChallengeRepositoryImpl: ChallengeRepository {
     
     return result.isProve
   }
+  
+  public func fetchFeed(challengeId: Int, feedId: Int) async throws -> Feed {
+    let api = ChallengeAPI.feedDetail(challengeId: challengeId, feedId: feedId)
+    let result = try await requestAuthorizableAPI(
+      api: api,
+      responseType: FeedDetailResponseDTO.self,
+      behavior: .immediate
+    ).value
+    
+    return dataMapper.mapToFeed(dto: result, id: challengeId)
+  }
 }
 
 // MARK: - Private Methods

--- a/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeRepositoryImpl.swift
+++ b/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeRepositoryImpl.swift
@@ -161,6 +161,45 @@ public struct ChallengeRepositoryImpl: ChallengeRepository {
     
     return (feeds, result.last)
   }
+  
+  public func uploadFeedComment(challengeId: Int, feedId: Int, comment: String) async throws -> Int {
+    let api = ChallengeAPI.uploadFeedComment(challengeId: challengeId, feedId: feedId, comment: comment)
+    let provider = Provider<ChallengeAPI>(
+      stubBehavior: .immediate,
+      session: .init(interceptor: AuthenticationInterceptor())
+    )
+    
+    guard let result = try? await provider.request(api).value else {
+      throw APIError.serverError
+    }
+    
+    if result.statusCode == 401 || result.statusCode == 403 {
+      throw APIError.authenticationFailed
+    } else if result.statusCode == 404 {
+      throw APIError.challengeFailed(reason: .challengeNotFound)
+    }
+      
+    // TODO: 서버 API수정시 Feed CommentID 리턴으로 수정 예정
+    return 100
+  }
+  
+  public func deleteFeedComment(challengeId: Int, feedId: Int, commentId: Int) async throws {
+    let api = ChallengeAPI.deleteFeedComment(challengeId: challengeId, feedId: feedId, commentId: commentId)
+    let provider = Provider<ChallengeAPI>(
+      stubBehavior: .immediate,
+      session: .init(interceptor: AuthenticationInterceptor())
+    )
+    
+    guard let result = try? await provider.request(api).value else {
+      throw APIError.serverError
+    }
+    
+    if result.statusCode == 401 || result.statusCode == 403 {
+      throw APIError.authenticationFailed
+    } else if result.statusCode == 404 {
+      throw APIError.challengeFailed(reason: .challengeNotFound)
+    }
+  }
 }
 
 // MARK: - Private Methods

--- a/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeRepositoryImpl.swift
+++ b/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeRepositoryImpl.swift
@@ -144,6 +144,23 @@ public struct ChallengeRepositoryImpl: ChallengeRepository {
     
     return dataMapper.mapToFeed(dto: result, id: challengeId)
   }
+  
+  public func fetchFeedComments(
+    feedId: Int,
+    page: Int,
+    size: Int
+  ) async throws -> (feeds: [FeedComment], isLast: Bool) {
+    let api = ChallengeAPI.feedComments(feedId: feedId, page: page, size: size)
+    let result = try await requestAuthorizableAPI(
+      api: api,
+      responseType: FeedCommentsResponseDTO.self,
+      behavior: .immediate
+    ).value
+    
+    let feeds = result.content.map { dataMapper.mapToFeedComment(dto: $0) }
+    
+    return (feeds, result.last)
+  }
 }
 
 // MARK: - Private Methods

--- a/Projects/DesignSystem/Sources/Button/IconButton/IconButton.swift
+++ b/Projects/DesignSystem/Sources/Button/IconButton/IconButton.swift
@@ -62,6 +62,7 @@ public final class IconButton: UIButton {
     self.size = size
     super.init(frame: .zero)
     setupUI()
+    addTarget(self, action: #selector(didTap), for: .touchUpInside)
   }
   
   public convenience init(size: ButtonSize) {
@@ -87,12 +88,6 @@ public final class IconButton: UIButton {
   public override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
     let circlePath = UIBezierPath(ovalIn: self.bounds)
     return circlePath.contains(point)
-  }
-  
-  // MARK: - touchesEnded
-  public override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
-    super.touchesEnded(touches, with: event)
-    isSelected.toggle()
   }
   
   // MARK: - Setup UI
@@ -149,5 +144,9 @@ private extension IconButton {
       case .xSmall:
         return CGSize(width: 12, height: 12)
     }
+  }
+  
+  @objc func didTap() {
+    isSelected.toggle()
   }
 }

--- a/Projects/DesignSystem/Sources/Popup/Alert/UIViewController+Alert.swift
+++ b/Projects/DesignSystem/Sources/Popup/Alert/UIViewController+Alert.swift
@@ -16,4 +16,17 @@ public extension UIViewController {
     
     return alertVC 
   }
+  
+  @discardableResult
+  func presentLoginTriggerAlert() -> AlertViewController {
+    let alertVC = AlertViewController(
+      alertType: .canCancel,
+      title: "재로그인이 필요해요",
+      subTitle: "보안을 위해 자동 로그아웃 됐어요.\n다시 로그인해주세요."
+    )
+    alertVC.confirmButtonTitle = "로그인하기"
+    alertVC.cancelButtonTitle = "나중에 할래요"
+    
+    return alertVC
+  }
 }

--- a/Projects/DesignSystem/Sources/Popup/Alert/UIViewController+Alert.swift
+++ b/Projects/DesignSystem/Sources/Popup/Alert/UIViewController+Alert.swift
@@ -10,8 +10,12 @@ import UIKit
 
 public extension UIViewController {
   @discardableResult
-  func presentNetworkUnstableAlert() -> AlertViewController {
-    let alertVC = AlertViewController(alertType: .confirm, title: "오류", subTitle: "서버가 불안정합니다. 잠시 후에 다시 시도해주세요.")
+  func presentNetworkUnstableAlert(reason: String? = nil) -> AlertViewController {
+    let alertVC = AlertViewController(
+      alertType: .confirm,
+      title: "네트워크가 불안정해요",
+      subTitle: reason ?? "네트워크가 불안정합니다\n. 잠시 후에 다시 시도해주세요."
+    )
     alertVC.present(to: self, animted: false)
     
     return alertVC 

--- a/Projects/Domain/Entity/Feed.swift
+++ b/Projects/Domain/Entity/Feed.swift
@@ -12,8 +12,12 @@ public struct Feed {
   public let id: Int
   public let author: String
   public let imageURL: URL
+  public let authorImageURL: URL?
   public let isLike: Bool
   public let updateTime: Date
+  public let likeCount: Int
+  
+  
   
   public init(
     id: Int,
@@ -27,5 +31,26 @@ public struct Feed {
     self.imageURL = imageURL
     self.isLike = isLike
     self.updateTime = updateTime
+    
+    self.authorImageURL = nil
+    self.likeCount = 0
+  }
+  
+  public init(
+    id: Int,
+    author: String,
+    imageURL: URL,
+    authorImageURL: URL,
+    updateTime: Date,
+    likeCount: Int
+  ) {
+    self.id = id
+    self.author = author
+    self.imageURL = imageURL
+    self.authorImageURL = authorImageURL
+    self.updateTime = updateTime
+    self.likeCount = likeCount
+    
+    self.isLike = false
   }
 }

--- a/Projects/Domain/Entity/FeedComment.swift
+++ b/Projects/Domain/Entity/FeedComment.swift
@@ -1,0 +1,19 @@
+//
+//  FeedComment.swift
+//  Entity
+//
+//  Created by jung on 2/27/25.
+//  Copyright © 2025 com.photi. All rights reserved.
+//
+
+public struct FeedComment {
+  public let id: Int
+  public let author: String
+  public let comment: String
+  
+  public init(id: Int, author: String, comment: String) {
+    self.id = id
+    self.author = author
+    self.comment = comment
+  }
+}

--- a/Projects/Domain/Repository/Interfaces/ChallengeRepository.swift
+++ b/Projects/Domain/Repository/Interfaces/ChallengeRepository.swift
@@ -37,4 +37,9 @@ public protocol ChallengeRepository {
     orderType: ChallengeFeedsOrderType
   ) async throws -> FeedReturnType
   func fetchFeed(challengeId: Int, feedId: Int) async throws -> Feed
+  func fetchFeedComments(
+    feedId: Int,
+    page: Int,
+    size: Int
+  ) async throws -> (feeds: [FeedComment], isLast: Bool)
 }

--- a/Projects/Domain/Repository/Interfaces/ChallengeRepository.swift
+++ b/Projects/Domain/Repository/Interfaces/ChallengeRepository.swift
@@ -36,4 +36,5 @@ public protocol ChallengeRepository {
     size: Int,
     orderType: ChallengeFeedsOrderType
   ) async throws -> FeedReturnType
+  func fetchFeed(challengeId: Int, feedId: Int) async throws -> Feed
 }

--- a/Projects/Domain/Repository/Interfaces/ChallengeRepository.swift
+++ b/Projects/Domain/Repository/Interfaces/ChallengeRepository.swift
@@ -42,4 +42,6 @@ public protocol ChallengeRepository {
     page: Int,
     size: Int
   ) async throws -> (feeds: [FeedComment], isLast: Bool)
+  func uploadFeedComment(challengeId: Int, feedId: Int, comment: String) async throws -> Int
+  func deleteFeedComment(challengeId: Int, feedId: Int, commentId: Int) async throws
 }

--- a/Projects/Domain/UseCase/Implementations/FeedUseCaseImpl.swift
+++ b/Projects/Domain/UseCase/Implementations/FeedUseCaseImpl.swift
@@ -1,0 +1,31 @@
+//
+//  FeedUseCaseImpl.swift
+//  UseCaseImpl
+//
+//  Created by jung on 2/26/25.
+//  Copyright © 2025 com.photi. All rights reserved.
+//
+
+import Entity
+import Repository
+import UseCase
+
+public struct FeedUseCaseImpl: FeedUseCase {
+  private let repository: ChallengeRepository
+  
+  public init(repository: ChallengeRepository) {
+    self.repository = repository
+  }
+  
+  public func fetchFeed(challengeId: Int, feedId: Int) async throws -> Feed {
+    return try await repository.fetchFeed(challengeId: challengeId, feedId: feedId)
+  }
+  
+  public func isLike(challengeId: Int, feedId: Int) async -> Bool {
+    guard let feed = try? await repository.fetchFeed(challengeId: challengeId, feedId: feedId) else {
+      return false
+    }
+    
+    return feed.isLike
+  }
+}

--- a/Projects/Domain/UseCase/Implementations/FeedUseCaseImpl.swift
+++ b/Projects/Domain/UseCase/Implementations/FeedUseCaseImpl.swift
@@ -28,4 +28,8 @@ public struct FeedUseCaseImpl: FeedUseCase {
     
     return feed.isLike
   }
+  
+  public func updateLikeState(challengeId: Int, feedId: Int, isLike: Bool) async {
+    try? await repository.updateLikeState(challengeId: challengeId, feedId: feedId, isLike: isLike)
+  }
 }

--- a/Projects/Domain/UseCase/Implementations/FeedUseCaseImpl.swift
+++ b/Projects/Domain/UseCase/Implementations/FeedUseCaseImpl.swift
@@ -32,4 +32,14 @@ public struct FeedUseCaseImpl: FeedUseCase {
   public func updateLikeState(challengeId: Int, feedId: Int, isLike: Bool) async {
     try? await repository.updateLikeState(challengeId: challengeId, feedId: feedId, isLike: isLike)
   }
+  
+  public func fetchFeedComments(feedId: Int, page: Int, size: Int) async throws -> FeedCommentsPage {
+    let (feeds, isLast) = try await repository.fetchFeedComments(
+      feedId: feedId,
+      page: page,
+      size: size
+    )
+    
+    return isLast ? .lastPage(feeds) : .default(feeds)
+  }
 }

--- a/Projects/Domain/UseCase/Implementations/FeedUseCaseImpl.swift
+++ b/Projects/Domain/UseCase/Implementations/FeedUseCaseImpl.swift
@@ -42,4 +42,12 @@ public struct FeedUseCaseImpl: FeedUseCase {
     
     return isLast ? .lastPage(feeds) : .default(feeds)
   }
+  
+  public func uploadFeedComment(challengeId: Int, feedId: Int, comment: String) async throws -> Int {
+    return try await repository.uploadFeedComment(challengeId: challengeId, feedId: feedId, comment: comment)
+  }
+  
+  public func deleteFeedComment(challengeId: Int, feedId: Int, commentId: Int) async throws {
+    try await repository.deleteFeedComment(challengeId: challengeId, feedId: feedId, commentId: commentId)
+  }
 }

--- a/Projects/Domain/UseCase/Interfaces/FeedUseCase.swift
+++ b/Projects/Domain/UseCase/Interfaces/FeedUseCase.swift
@@ -17,4 +17,6 @@ public protocol FeedUseCase {
   func fetchFeed(challengeId: Int, feedId: Int) async throws -> Feed
   func updateLikeState(challengeId: Int, feedId: Int, isLike: Bool) async
   func fetchFeedComments(feedId: Int, page: Int, size: Int) async throws -> FeedCommentsPage
+  func uploadFeedComment(challengeId: Int, feedId: Int, comment: String) async throws -> Int
+  func deleteFeedComment(challengeId: Int, feedId: Int, commentId: Int) async throws
 }

--- a/Projects/Domain/UseCase/Interfaces/FeedUseCase.swift
+++ b/Projects/Domain/UseCase/Interfaces/FeedUseCase.swift
@@ -1,0 +1,14 @@
+//
+//  FeedUseCase.swift
+//  UseCase
+//
+//  Created by jung on 2/26/25.
+//  Copyright © 2025 com.photi. All rights reserved.
+//
+
+import Entity
+
+public protocol FeedUseCase {
+  func fetchFeed(challengeId: Int, feedId: Int) async throws -> Feed
+  func isLike(challengeId: Int, feedId: Int) async -> Bool
+}

--- a/Projects/Domain/UseCase/Interfaces/FeedUseCase.swift
+++ b/Projects/Domain/UseCase/Interfaces/FeedUseCase.swift
@@ -10,5 +10,5 @@ import Entity
 
 public protocol FeedUseCase {
   func fetchFeed(challengeId: Int, feedId: Int) async throws -> Feed
-  func isLike(challengeId: Int, feedId: Int) async -> Bool
+  func updateLikeState(challengeId: Int, feedId: Int, isLike: Bool) async 
 }

--- a/Projects/Domain/UseCase/Interfaces/FeedUseCase.swift
+++ b/Projects/Domain/UseCase/Interfaces/FeedUseCase.swift
@@ -8,7 +8,13 @@
 
 import Entity
 
+public enum FeedCommentsPage {
+  case `default`([FeedComment])
+  case lastPage([FeedComment])
+}
+
 public protocol FeedUseCase {
   func fetchFeed(challengeId: Int, feedId: Int) async throws -> Feed
-  func updateLikeState(challengeId: Int, feedId: Int, isLike: Bool) async 
+  func updateLikeState(challengeId: Int, feedId: Int, isLike: Bool) async
+  func fetchFeedComments(feedId: Int, page: Int, size: Int) async throws -> FeedCommentsPage
 }

--- a/Projects/Presentation/Challenge/Implementations/Member/ChallengeContainer.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/ChallengeContainer.swift
@@ -12,6 +12,7 @@ import UseCase
 
 public protocol ChallengeDependency: Dependency {
   var challengeUseCase: ChallengeUseCase { get }
+  var feedUseCase: FeedUseCase { get }
 }
 
 public final class ChallengeContainer:
@@ -43,4 +44,5 @@ public final class ChallengeContainer:
   }
   
   var challengeUseCase: ChallengeUseCase { dependency.challengeUseCase }
+  var feedUseCase: FeedUseCase { dependency.feedUseCase }
 }

--- a/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedComment/FeedCommentContainer.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedComment/FeedCommentContainer.swift
@@ -7,16 +7,31 @@
 //
 
 import Core
+import UseCase
 
-protocol FeedCommentDependency: Dependency { }
+protocol FeedCommentDependency: Dependency {
+  var feedUseCase: FeedUseCase { get }
+}
 
 protocol FeedCommentContainable: Containable {
-  func coordinator(listener: FeedCommentListener, feedID: String) -> ViewableCoordinating
+  func coordinator(
+    listener: FeedCommentListener,
+    challengeId: Int,
+    feedId: Int
+  ) -> ViewableCoordinating
 }
 
 final class FeedCommentContainer: Container<FeedCommentDependency>, FeedCommentContainable {
-  func coordinator(listener: FeedCommentListener, feedID: String) -> ViewableCoordinating {
-    let viewModel = FeedCommentViewModel(feedID: feedID)
+  func coordinator(
+    listener: FeedCommentListener,
+    challengeId: Int,
+    feedId: Int
+  ) -> ViewableCoordinating {
+    let viewModel = FeedCommentViewModel(
+      useCase: dependency.feedUseCase,
+      challengeId: challengeId,
+      feedID: feedId
+    )
     let viewControllerable = FeedCommentViewController(viewModel: viewModel)
     
     let coordinator = FeedCommentCoordinator(

--- a/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedComment/FeedCommentCoordinator.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedComment/FeedCommentCoordinator.swift
@@ -10,6 +10,7 @@ import Core
 
 protocol FeedCommentListener: AnyObject {
   func requestDismissAtFeedComment()
+  func requestLogInAtFeedComment()
 }
 
 protocol FeedCommentPresentable { }
@@ -33,5 +34,9 @@ final class FeedCommentCoordinator: ViewableCoordinator<FeedCommentPresentable> 
 extension FeedCommentCoordinator: FeedCommentCoordinatable {
   func requestDismiss() {
     listener?.requestDismissAtFeedComment()
+  }
+  
+  func requestLogIn() {
+    listener?.requestLogInAtFeedComment()
   }
 }

--- a/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedComment/FeedCommentViewController.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedComment/FeedCommentViewController.swift
@@ -94,8 +94,9 @@ final class FeedCommentViewController: UIViewController, ViewControllerable {
   override func viewIsAppearing(_ animated: Bool) {
     super.viewIsAppearing(animated)
     mainContainerView.layoutIfNeeded()
-    
     bottomGradientLayer.frame = bottomView.bounds
+    
+    presentWithAnimation()
   }
   
   override func viewDidAppear(_ animated: Bool) {
@@ -103,9 +104,15 @@ final class FeedCommentViewController: UIViewController, ViewControllerable {
     scrollToBottom()
   }
   
-  override func viewDidDisappear(_ animated: Bool) {
-    super.viewDidDisappear(animated)
+  override func viewWillDisappear(_ animated: Bool) {
+    super.viewWillDisappear(animated)
     removeKeyboardNotification(keyboardShowNotification, keyboardHideNotification)
+    
+    guard let coordinator = transitionCoordinator else { return }
+    keepAliveBlurView()
+    coordinator.animateAlongsideTransition(in: self.view, animation: nil) { _ in
+      self.blurView.removeFromSuperview()
+    }
   }
   
   // MARK: - UIResponder
@@ -408,5 +415,22 @@ private extension FeedCommentViewController {
     } completion: { _ in
       completion?()
     }
+  }
+  
+  func presentWithAnimation() {
+    let origin = mainContainerView.frame.origin
+    mainContainerView.frame.origin = .init(x: origin.x, y: view.frame.maxY)
+    
+    UIView.animate(withDuration: 0.3) {
+      self.mainContainerView.frame.origin = origin
+      self.mainContainerView.layoutIfNeeded()
+    }
+  }
+  
+  func keepAliveBlurView() {
+    guard let window = UIWindow.key else { return }
+    
+    blurView.frame = window.frame
+    window.addSubview(blurView)
   }
 }

--- a/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedComment/FeedCommentViewController.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedComment/FeedCommentViewController.swift
@@ -179,7 +179,8 @@ private extension FeedCommentViewController {
     
     let input = FeedCommentViewModel.Input(
       didTapBackground: didTapBackground,
-      requestData: requestDataRelay.asSignal()
+      requestData: requestDataRelay.asSignal(),
+      didTapLikeButton: topView.rx.didTapLikeButton.asSignal()
     )
     let output = viewModel.transform(input: input)
     bind(for: output)

--- a/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedComment/FeedCommentViewController.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedComment/FeedCommentViewController.swift
@@ -214,28 +214,8 @@ private extension FeedCommentViewController {
   }
   
   func bind(for output: FeedCommentViewModel.Output) {
-    output.feedImageURL
-      .compactMap { $0 }
-      .drive(with: self) { owner, url in
-        owner.imageView.kf.setImage(with: url)
-      }
-      .disposed(by: disposeBag)
-    
-    output.author
-      .drive(topView.rx.author)
-      .disposed(by: disposeBag)
-    
-    output.updateTime
-      .drive(topView.rx.updateTime)
-      .disposed(by: disposeBag)
-    
-    output.likeCount
-      .drive(topView.rx.likeCount)
-      .disposed(by: disposeBag)
-    
-    output.isLike
-      .drive(topView.rx.isLike)
-      .disposed(by: disposeBag)
+    bindFeedInfo(for: output)
+    bindRequestFailed(for: output)
     
     output.comments
       .skip(1)
@@ -275,6 +255,31 @@ private extension FeedCommentViewController {
       .disposed(by: disposeBag)
   }
   
+  func bindFeedInfo(for output: FeedCommentViewModel.Output) {
+    output.feedImageURL
+      .compactMap { $0 }
+      .drive(with: self) { owner, url in
+        owner.imageView.kf.setImage(with: url)
+      }
+      .disposed(by: disposeBag)
+    
+    output.author
+      .drive(topView.rx.author)
+      .disposed(by: disposeBag)
+    
+    output.updateTime
+      .drive(topView.rx.updateTime)
+      .disposed(by: disposeBag)
+    
+    output.likeCount
+      .drive(topView.rx.likeCount)
+      .disposed(by: disposeBag)
+    
+    output.isLike
+      .drive(topView.rx.isLike)
+      .disposed(by: disposeBag)
+  }
+  
   func bindRequestFailed(for output: FeedCommentViewModel.Output) {
     output.uploadCommentFailed
       .emit(with: self) { owner, id in
@@ -290,8 +295,8 @@ private extension FeedCommentViewController {
       .disposed(by: disposeBag)
     
     output.networkUnstable
-      .emit(with: self) { owner, _ in
-        owner.presentNetworkUnstableAlert()
+      .emit(with: self) { owner, reason in
+        owner.presentNetworkUnstableAlert(reason: reason)
       }
       .disposed(by: disposeBag)
   }

--- a/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedComment/FeedCommentViewController.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedComment/FeedCommentViewController.swift
@@ -16,8 +16,8 @@ import Core
 import DesignSystem
 
 final class FeedCommentViewController: UIViewController, ViewControllerable {
-  typealias DataSourceType = UITableViewDiffableDataSource<Int, FeedCommentPresentationModel>
-  typealias Snapshot = NSDiffableDataSourceSnapshot<Int, FeedCommentPresentationModel>
+  typealias DataSourceType = UITableViewDiffableDataSource<String, FeedCommentPresentationModel>
+  typealias Snapshot = NSDiffableDataSourceSnapshot<String, FeedCommentPresentationModel>
   
   // MARK: - Properties
   var keyboardShowNotification: NSObjectProtocol?
@@ -29,6 +29,9 @@ final class FeedCommentViewController: UIViewController, ViewControllerable {
   
   private let requestComments = PublishRelay<Void>()
   private let requestDataRelay = PublishRelay<Void>()
+  private let requestDeleteCommentRelay = PublishRelay<Int>()
+  private let uploadCommentRelay = PublishRelay<String>()
+  private let didTapLoginButton = PublishRelay<Void>()
   
   // MARK: - UI Components
   private let blurView: UIView = {
@@ -186,7 +189,10 @@ private extension FeedCommentViewController {
       didTapBackground: didTapBackground,
       requestComments: requestComments.asSignal(),
       requestData: requestDataRelay.asSignal(),
-      didTapLikeButton: topView.rx.didTapLikeButton.asSignal()
+      didTapLikeButton: topView.rx.didTapLikeButton.asSignal(),
+      requestDeleteComment: requestDeleteCommentRelay.asSignal(),
+      requestUploadComment: uploadCommentRelay.asSignal(),
+      requestLogin: didTapLoginButton.asSignal()
     )
     let output = viewModel.transform(input: input)
     bind(for: output)
@@ -246,12 +252,53 @@ private extension FeedCommentViewController {
     output.stopLoadingAnimation
       .emit(with: self) { owner, _ in
         owner.tableView.refreshControl?.endRefreshing()
+        owner.scrollToBottom()
+      }
+      .disposed(by: disposeBag)
+    
+    output.comment
+      .emit(with: self) { owner, model in
+        owner.append(model: model)
+      }
+      .disposed(by: disposeBag)
+    
+    output.deleteComment
+      .emit(with: self) { owner, id in
+        owner.delete(commentId: id)
+      }
+      .disposed(by: disposeBag)
+    
+    output.uploadCommentSuccess
+      .emit(with: self) { owner, result in
+        owner.update(commentId: result.1, for: result.0)
       }
       .disposed(by: disposeBag)
   }
   
-  func bind(for cell: FeedCommentCell, model: FeedCommentPresentationModel) {
+  func bindRequestFailed(for output: FeedCommentViewModel.Output) {
+    output.uploadCommentFailed
+      .emit(with: self) { owner, id in
+        owner.delete(modelId: id)
+      }
+      .disposed(by: disposeBag)
+    
+    output.loginTrigger
+      .emit(with: self) { owner, _ in
+        let alert = owner.presentLoginTriggerAlert()
+        owner.bind(alert: alert)
+      }
+      .disposed(by: disposeBag)
+    
+    output.networkUnstable
+      .emit(with: self) { owner, _ in
+        owner.presentNetworkUnstableAlert()
+      }
+      .disposed(by: disposeBag)
+  }
+  
+  func bind(for cell: FeedCommentCell) {
     cell.rx.longPressGesture()
+      .filter { _ in cell.id != -1 }
       .map { $0.state }
       .bind(with: self) { owner, state in
         switch state {
@@ -260,9 +307,17 @@ private extension FeedCommentViewController {
           case .failed, .cancelled:
             cell.isPressed = false
           case .ended:
-            owner.delete(model: model)
+            owner.requestDeleteCommentRelay.accept(cell.id)
           default: break
         }
+      }
+      .disposed(by: disposeBag)
+  }
+  
+  func bind(alert: AlertViewController) {
+    alert.rx.didTapConfirmButton
+      .bind(with: self) { owner, _ in
+        owner.didTapLoginButton.accept(())
       }
       .disposed(by: disposeBag)
   }
@@ -306,33 +361,9 @@ private extension FeedCommentViewController {
     return .init(tableView: tableView) { [weak self] tableView, indexPath, model in
       let cell = tableView.dequeueCell(FeedCommentCell.self, for: indexPath)
       cell.configure(model: model)
-      
-      self?.bind(for: cell, model: model)
+      if model.isOwner { self?.bind(for: cell) }
       
       return cell
-    }
-  }
-  
-  func initialize(models: [FeedCommentPresentationModel]) {
-    let snapshot = append(models: models, snapshot: Snapshot())
-    dataSource?.apply(snapshot) { [weak self] in
-      self?.scrollToBottom()
-    }
-  }
-  
-  func append(models: [FeedCommentPresentationModel]) {
-    guard let dataSource else { return }
-    let snapshot = append(models: models, snapshot: dataSource.snapshot())
-    dataSource.apply(snapshot) { [weak self] in
-      self?.setupBoundaryCellAlpha()
-    }
-  }
-  
-  func append(model: FeedCommentPresentationModel) {
-    guard let dataSource else { return }
-    let snapshot = append(model: model, snapshot: dataSource.snapshot())
-    dataSource.apply(snapshot) { [weak self] in
-      self?.setupBoundaryCellAlpha()
     }
   }
   
@@ -352,14 +383,39 @@ private extension FeedCommentViewController {
     dataSource.apply(snapshot)
   }
   
+  func initialize(models: [FeedCommentPresentationModel]) {
+    let snapshot = append(models: models, snapshot: Snapshot())
+    dataSource?.apply(snapshot) { [weak self] in
+      self?.scrollToBottom()
+    }
+  }
+  
+  func append(models: [FeedCommentPresentationModel]) {
+    guard let dataSource else { return }
+    let snapshot = append(models: models, snapshot: dataSource.snapshot())
+    dataSource.apply(snapshot) { [weak self] in
+      self?.scrollToBottom()
+    }
+  }
+  
+  func append(model: FeedCommentPresentationModel) {
+    guard let dataSource else { return }
+    commentTextField.text = ""
+    let snapshot = append(model: model, snapshot: dataSource.snapshot())
+    dataSource.apply(snapshot) { [weak self] in
+      self?.scrollToBottom { [weak self] in
+        self?.presentDeleteToastView()
+      }
+    }
+  }
+  
   func append(model: FeedCommentPresentationModel, snapshot: Snapshot) -> Snapshot {
     var snapshot = snapshot
     snapshot.appendSections([model.id])
     snapshot.appendItems([model], toSection: model.id)
-    
     return snapshot
   }
-  
+
   func append(models: [FeedCommentPresentationModel], snapshot: Snapshot) -> Snapshot {
     var snapshot = snapshot
     let sections = models.map { $0.id }
@@ -370,6 +426,46 @@ private extension FeedCommentViewController {
     }
     
     return snapshot
+  }
+  
+  func update(commentId: Int, for modelId: String) {
+    guard let dataSource else { return }
+    
+    var snapshot = dataSource.snapshot()
+    
+    guard let index = snapshot.itemIdentifiers.firstIndex(where: { $0.id == modelId }) else { return }
+    
+    let existingModel = snapshot.itemIdentifiers[index]
+    var updatedModel = existingModel
+    updatedModel.commentId = commentId
+    
+    snapshot.deleteItems([existingModel])
+    snapshot.appendItems([updatedModel], toSection: modelId)
+    dataSource.apply(snapshot, animatingDifferences: false)
+  }
+  
+  func delete(commentId: Int) {
+    guard let dataSource else { return }
+    var snapshot = dataSource.snapshot()
+    guard let index = snapshot.itemIdentifiers.firstIndex(where: { $0.commentId == commentId }) else { return }
+    let model = snapshot.itemIdentifiers[index]
+    
+    snapshot.deleteSections([model.id])
+    dataSource.apply(snapshot) { [weak self] in
+      guard snapshot.itemIdentifiers.count <= 3 else { return }
+      self?.scrollToBottom()
+    }
+  }
+  
+  func delete(modelId: String) {
+    guard let dataSource else { return }
+    var snapshot = dataSource.snapshot()
+    guard let model = snapshot.itemIdentifiers.first(where: { $0.id == modelId }) else { return }
+    snapshot.deleteSections([model.id])
+    dataSource.apply(snapshot) { [weak self] in
+      guard snapshot.itemIdentifiers.count <= 3 else { return }
+      self?.scrollToBottom()
+    }
   }
 }
 
@@ -382,6 +478,18 @@ private extension FeedCommentViewController {
   
   @objc func refreshStart() {
     requestComments.accept(())
+  }
+  
+  func scrollToBottom(_ completion: (() -> Void)? = nil) {
+    tableView.layoutIfNeeded()
+    UIView.animate(withDuration: 0.3) {
+      let scrollDistance = self.tableView.contentSize.height - self.tableView.frame.height + 8
+      self.tableView.setContentOffset(CGPoint(x: 0, y: scrollDistance), animated: false)
+      self.view.layoutIfNeeded()
+    } completion: { _ in
+      self.setupBoundaryCellAlpha()
+      completion?()
+    }
   }
   
   func setupBoundaryCellAlpha() {
@@ -439,31 +547,7 @@ private extension FeedCommentViewController {
   func didTapReturnButton() {
     view.endEditing(true)
     guard !commentTextField.text.isEmpty else { return }
-    // TODO: 서버 연동 후, 수정 예정
-    let model = CommentPresentationModel(
-      id: UUID().uuidString,
-      userName: "석영",
-      content: commentTextField.text,
-      isOwner: true,
-      updatedAt: Date()
-    )
-    append(model: model)
-    commentTextField.text = ""
-    
-    scrollToBottom { [weak self] in
-      self?.presentDeleteToastView()
-    }
-  }
-  
-  func scrollToBottom(_ completion: (() -> Void)? = nil) {
-    tableView.layoutIfNeeded()
-    UIView.animate(withDuration: 0.3) {
-      let scrollDistance = self.tableView.contentSize.height - self.tableView.frame.height + 8
-      self.tableView.setContentOffset(CGPoint(x: 0, y: scrollDistance), animated: false)
-      self.view.layoutIfNeeded()
-    } completion: { _ in
-      completion?()
-    }
+    uploadCommentRelay.accept(commentTextField.text)
   }
   
   func presentWithAnimation() {

--- a/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedComment/FeedCommentViewController.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedComment/FeedCommentViewController.swift
@@ -89,7 +89,6 @@ final class FeedCommentViewController: UIViewController, ViewControllerable {
     bind()
     
     requestDataRelay.accept(())
-    requestComments.accept(())
   }
   override func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)

--- a/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedComment/FeedCommentViewModel.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedComment/FeedCommentViewModel.swift
@@ -29,14 +29,27 @@ final class FeedCommentViewModel: FeedCommentViewModelType {
   private let useCase: FeedUseCase
   private let challengeId: Int
   private let feedId: Int
+  
+  private let authorRelay = BehaviorRelay<AuthorPresentationModel>(value: .default)
+  private let updateTimeRelay = BehaviorRelay<String>(value: "")
+  private let likeCountRelay = BehaviorRelay<Int>(value: 0)
+  private let isLikeRelay = BehaviorRelay<Bool>(value: false)
+  private let feedImageURLRelay = BehaviorRelay<URL?>(value: nil)
 
   // MARK: - Input
   struct Input {
-    var didTapBackground: Signal<Void>
+    let didTapBackground: Signal<Void>
+    let requestData: Signal<Void>
   }
   
   // MARK: - Output
-  struct Output { }
+  struct Output {
+    let feedImageURL: Driver<URL?>
+    let updateTime: Driver<String>
+    let author: Driver<AuthorPresentationModel>
+    let likeCount: Driver<Int>
+    let isLike: Driver<Bool>
+  }
   
   // MARK: - Initializers
   init(
@@ -56,6 +69,38 @@ final class FeedCommentViewModel: FeedCommentViewModelType {
       }
       .disposed(by: disposeBag)
     
-    return Output()
+    input.requestData
+      .emit(with: self) { owner, _ in
+        Task { await owner.fetchFeed() }
+      }
+      .disposed(by: disposeBag)
+    
+    return Output(
+      feedImageURL: feedImageURLRelay.asDriver(),
+      updateTime: updateTimeRelay.asDriver(),
+      author: authorRelay.asDriver(),
+      likeCount: likeCountRelay.asDriver(),
+      isLike: isLikeRelay.asDriver()
+    )
+  }
+}
+
+// MARK: - Fetch Method
+private extension FeedCommentViewModel {
+  func fetchFeed() async {
+    do {
+      let result = try await useCase.fetchFeed(challengeId: challengeId, feedId: feedId)
+      let updateTime = modelMapper.mapToUpdateTimeString(result.updateTime)
+      let author = modelMapper.mapToAuthorPresentaionModel(author: result.author, url: result.authorImageURL)
+      
+      feedImageURLRelay.accept(result.imageURL)
+      authorRelay.accept(author)
+      updateTimeRelay.accept(updateTime)
+      likeCountRelay.accept(result.likeCount)
+      isLikeRelay.accept(result.isLike)
+    } catch {
+      // TODO: 에러 구현 예정
+      print(error)
+    }
   }
 }

--- a/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedComment/FeedCommentViewModel.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedComment/FeedCommentViewModel.swift
@@ -9,6 +9,7 @@
 import Foundation
 import RxCocoa
 import RxSwift
+import UseCase
 
 protocol FeedCommentCoordinatable: AnyObject {
   func requestDismiss()
@@ -23,7 +24,11 @@ protocol FeedCommentViewModelType: AnyObject {
 
 final class FeedCommentViewModel: FeedCommentViewModelType {
   weak var coordinator: FeedCommentCoordinatable?
+  private let modelMapper = FeedPresentatoinModelMapper()
   private let disposeBag = DisposeBag()
+  private let useCase: FeedUseCase
+  private let challengeId: Int
+  private let feedId: Int
 
   // MARK: - Input
   struct Input {
@@ -34,7 +39,15 @@ final class FeedCommentViewModel: FeedCommentViewModelType {
   struct Output { }
   
   // MARK: - Initializers
-  init(feedID: String) { }
+  init(
+    useCase: FeedUseCase,
+    challengeId: Int,
+    feedID: Int
+  ) {
+    self.useCase = useCase
+    self.challengeId = challengeId
+    self.feedId = feedID
+  }
   
   func transform(input: Input) -> Output {
     input.didTapBackground

--- a/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedComment/FeedCommentViewModel.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedComment/FeedCommentViewModel.swift
@@ -30,11 +30,16 @@ final class FeedCommentViewModel: FeedCommentViewModelType {
   private let challengeId: Int
   private let feedId: Int
   
+  private var isFetching: Bool = false
+  private var isLastPage: Bool = false
+  private var currentPage: Int = 0
+  
   private let authorRelay = BehaviorRelay<AuthorPresentationModel>(value: .default)
   private let updateTimeRelay = BehaviorRelay<String>(value: "")
   private let likeCountRelay = BehaviorRelay<Int>(value: 0)
   private let isLikeRelay = BehaviorRelay<Bool>(value: false)
   private let feedImageURLRelay = BehaviorRelay<URL?>(value: nil)
+  private let commentsRelay: BehaviorRelay<FeedCommentType> = .init(value: .default([]))
 
   // MARK: - Input
   struct Input {

--- a/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedComment/Views/FeedCommentCell.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedComment/Views/FeedCommentCell.swift
@@ -52,7 +52,7 @@ final class FeedCommentCell: UITableViewCell {
 // MARK: - Internal Methods
 extension FeedCommentCell {
   func configure(model: FeedCommentPresentationModel) {
-    self.id = model.id
+    self.id = model.commentId
     configureUserName(model.author)
     configureComment(model.content)
   }

--- a/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedComment/Views/FeedCommentCell.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedComment/Views/FeedCommentCell.swift
@@ -12,6 +12,7 @@ import Core
 import DesignSystem
 
 final class FeedCommentCell: UITableViewCell {
+  private(set) var id: Int = 0
   var isPressed: Bool = false {
     didSet {
       let alphaComponent: CGFloat = isPressed ? 0.5 : 0.1
@@ -50,9 +51,10 @@ final class FeedCommentCell: UITableViewCell {
 
 // MARK: - Internal Methods
 extension FeedCommentCell {
-  func configure(userName: String, comment: String) {
-    setUserName(userName)
-    setComment(comment)
+  func configure(model: FeedCommentPresentationModel) {
+    self.id = model.id
+    configureUserName(model.author)
+    configureComment(model.content)
   }
 }
 
@@ -92,14 +94,14 @@ private extension FeedCommentCell {
 
 // MARK: - Private Methods
 private extension FeedCommentCell {
-  func setUserName(_ userName: String) {
+  func configureUserName(_ userName: String) {
     userNameLabel.attributedText = userName.attributedString(
       font: .body2Bold,
       color: .gray400
     )
   }
   
-  func setComment(_ comment: String) {
+  func configureComment(_ comment: String) {
     commentLabel.attributedText = comment.attributedString(
       font: .body2,
       color: .gray200

--- a/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedComment/Views/FeedCommentTopView.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedComment/Views/FeedCommentTopView.swift
@@ -8,6 +8,8 @@
 
 import UIKit
 import Kingfisher
+import RxCocoa
+import RxSwift
 import SnapKit
 import Core
 import DesignSystem
@@ -37,7 +39,7 @@ final class FeedCommentTopView: UIView {
   private let avatarImageView = AvatarImageView(size: .xSmall)
   private let userNameLabel = UILabel()
   private let updateTimeLabel = UILabel()
-  private let likeButton = IconButton(size: .small)
+  fileprivate let likeButton = IconButton(size: .small)
   private let likeCountLabel = UILabel()
   
   // MARK: - Initializers
@@ -134,5 +136,13 @@ extension FeedCommentTopView {
       font: .caption1Bold,
       color: .white
     )
+  }
+}
+
+extension Reactive where Base: FeedCommentTopView {
+  var didTapLikeButton: ControlEvent<Bool> {
+    let source = base.likeButton.rx.tap.map { _ in base.likeButton.isSelected }
+    
+    return .init(events: source)
   }
 }

--- a/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedComment/Views/FeedCommentTopView.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedComment/Views/FeedCommentTopView.swift
@@ -7,13 +7,33 @@
 //
 
 import UIKit
+import Kingfisher
 import SnapKit
 import Core
 import DesignSystem
 
 final class FeedCommentTopView: UIView {
+  var author: AuthorPresentationModel? {
+    didSet {
+      guard let author else { return }
+      configureAuthor(author)
+    }
+  }
+  
+  var updateTime: String = "" {
+    didSet { configureUpdateTime(updateTime) }
+  }
+  
+  var likeCount: Int = 0 {
+    didSet { configureLikeCount(likeCount) }
+  }
+  
+  var isLike: Bool = false {
+    didSet { likeButton.isSelected = isLike }
+  }
+  
   // MARK: - UI Components
-  private let topGradientLayer = FeedCommentGradientLayer(mode: .topToBottom, maxAlpha: 0.5)
+  private let topGradientLayer = FeedCommentGradientLayer(mode: .topToBottom, maxAlpha: 0.7)
   private let avatarImageView = AvatarImageView(size: .xSmall)
   private let userNameLabel = UILabel()
   private let updateTimeLabel = UILabel()
@@ -85,25 +105,34 @@ private extension FeedCommentTopView {
 
 // MARK: - Methods
 extension FeedCommentTopView {
-  func setUserName(_ userName: String) {
-    userNameLabel.attributedText = userName.attributedString(
+  func configureAuthor(_ author: AuthorPresentationModel) {
+    userNameLabel.attributedText = author.name.attributedString(
       font: .body2Bold,
       color: .white
     )
+    
+    Task {
+      guard
+        let imageURL = author.imageURL,
+        let result = try? await KingfisherManager.shared.retrieveImage(with: imageURL)
+      else { return }
+      
+      avatarImageView.image = result.image
+    }
   }
   
-  func updateTime(_ updateTime: String) {
+  func configureUpdateTime(_ updateTime: String) {
     updateTimeLabel.attributedText = updateTime.attributedString(
       font: .caption1,
       color: .gray200
     )
   }
   
-  func setLikeCount(_ likeCount: Int) {
+  func configureLikeCount(_ likeCount: Int) {
     let likeCountText = likeCount == 0 ? "" : "\(likeCount)"
     likeCountLabel.attributedText = likeCountText.attributedString(
       font: .caption1Bold,
-      color: .gray200
+      color: .white
     )
   }
 }

--- a/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedContainer.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedContainer.swift
@@ -11,6 +11,7 @@ import UseCase
 
 protocol FeedDependency: Dependency {
   var challengeUseCase: ChallengeUseCase { get }
+  var feedUseCase: FeedUseCase { get }
 }
 
 protocol FeedContainable: Containable {
@@ -21,6 +22,8 @@ final class FeedContainer:
   Container<FeedDependency>,
   FeedContainable,
   FeedCommentDependency {
+  var feedUseCase: FeedUseCase { dependency.feedUseCase }
+
   func coordinator(challengeId: Int, listener: FeedListener) -> ViewableCoordinating {
     let viewModel = FeedViewModel(challengeId: challengeId, useCase: dependency.challengeUseCase)
     let viewControllerable = FeedViewController(viewModel: viewModel)

--- a/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedCoordinator.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedCoordinator.swift
@@ -39,9 +39,13 @@ final class FeedCoordinator: ViewableCoordinator<FeedPresentable> {
 
 // MARK: - FeedCoordinatable
 extension FeedCoordinator: FeedCoordinatable {
-  func attachFeedDetail(for feedID: String) {
+  func attachFeedDetail(challengeId: Int, feedId: Int) {
     guard feedCommentCoordinator == nil else { return }
-    let coordinator = feedCommentContainer.coordinator(listener: self, feedID: feedID)
+    let coordinator = feedCommentContainer.coordinator(
+      listener: self,
+      challengeId: challengeId,
+      feedId: feedId
+    )
     self.feedCommentCoordinator = coordinator
     addChild(coordinator)
     

--- a/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedCoordinator.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedCoordinator.swift
@@ -51,7 +51,7 @@ extension FeedCoordinator: FeedCoordinatable {
     
     viewControllerable.present(
       coordinator.viewControllerable,
-      animated: true,
+      animated: false,
       modalPresentationStyle: .overFullScreen
     )
   }
@@ -61,7 +61,7 @@ extension FeedCoordinator: FeedCoordinatable {
     guard let coordinator = feedCommentCoordinator else { return }
     
     removeChild(coordinator)
-    coordinator.viewControllerable.dismiss(animated: false)
+    coordinator.viewControllerable.dismiss(animated: true)
     self.feedCommentCoordinator = nil
   }
   

--- a/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedCoordinator.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedCoordinator.swift
@@ -83,4 +83,8 @@ extension FeedCoordinator: FeedCommentListener {
   func requestDismissAtFeedComment() {
     detachFeedDetail()
   }
+  
+  func requestLogInAtFeedComment() {
+    listener?.requestLoginAtChallengeFeed()
+  }
 }

--- a/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedViewController.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedViewController.swift
@@ -44,7 +44,7 @@ final class FeedViewController: UIViewController, ViewControllerable, CameraRequ
 
   private let requestData = PublishRelay<Void>()
   private let reloadData = PublishRelay<Void>()
-  private let didTapFeedCell = PublishRelay<String>()
+  private let didTapFeedCell = PublishRelay<Int>()
   private let contentOffset = PublishRelay<Double>()
   private let uploadImageRelay = PublishRelay<UIImageWrapper>()
   private let requestFeeds = PublishRelay<Void>()
@@ -403,8 +403,8 @@ extension FeedViewController {
 // MARK: - UICollectionViewDelegate
 extension FeedViewController: UICollectionViewDelegate {
   func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-    // TODO: API 연결 후 수정
-    didTapFeedCell.accept("0")
+    guard let item = dataSource?.itemIdentifier(for: indexPath) else { return }
+    didTapFeedCell.accept(item.id)
   }
   
   func scrollViewDidScroll(_ scrollView: UIScrollView) {

--- a/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedViewController.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedViewController.swift
@@ -257,7 +257,8 @@ private extension FeedViewController {
     
     output.loginTrigger
       .emit(with: self) { owner, _ in
-        owner.presentLoginTriggerAlert()
+        let alert = owner.presentLoginTriggerAlert()
+        owner.bind(alert: alert)
       }
       .disposed(by: disposeBag)
     
@@ -299,6 +300,14 @@ private extension FeedViewController {
       .debounce(.milliseconds(500), scheduler: MainScheduler.instance)
       .bind(with: self) { owner, result in
         owner.didTapLikeButtonRelay.accept(result)
+      }
+      .disposed(by: disposeBag)
+  }
+  
+  func bind(alert: AlertViewController) {
+    alert.rx.didTapConfirmButton
+      .bind(with: self) { owner, _ in
+        owner.didTapLoginButton.accept(())
       }
       .disposed(by: disposeBag)
   }
@@ -516,22 +525,6 @@ private extension FeedViewController {
     alert.rx.didTapConfirmButton
       .bind(with: self) { owner, _ in
         owner.didTapConfirmButtonAtAlert.accept(())
-      }
-      .disposed(by: disposeBag)
-  }
-  
-  func presentLoginTriggerAlert() {
-    let alert = AlertViewController(
-      alertType: .canCancel,
-      title: "재로그인이 필요해요",
-      subTitle: "보안을 위해 자동 로그아웃 됐어요.\n다시 로그인해주세요."
-    )
-    alert.confirmButtonTitle = "로그인하기"
-    alert.cancelButtonTitle = "나중에 할래요"
-    
-    alert.rx.didTapConfirmButton
-      .bind(with: self) { owner, _ in
-        owner.didTapLoginButton.accept(())
       }
       .disposed(by: disposeBag)
   }

--- a/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedViewModel.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedViewModel.swift
@@ -14,7 +14,7 @@ import Entity
 import UseCase
 
 protocol FeedCoordinatable: AnyObject {
-  func attachFeedDetail(for feedID: String)
+  func attachFeedDetail(challengeId: Int, feedId: Int)
   func didChangeContentOffset(_ offset: Double)
   func requestLogin()
   func didTapConfirmButtonAtAlert()
@@ -65,7 +65,7 @@ final class FeedViewModel: FeedViewModelType {
     let didTapLoginButton: Signal<Void>
     let requestData: Signal<Void>
     let reloadData: Signal<Void>
-    let didTapFeed: Signal<String>
+    let didTapFeed: Signal<Int>
     let contentOffset: Signal<Double>
     let uploadImage: Signal<UIImageWrapper>
     let requestFeeds: Signal<Void>
@@ -112,8 +112,8 @@ final class FeedViewModel: FeedViewModelType {
       .disposed(by: disposeBag)
    
     input.didTapFeed
-      .emit(with: self) { owner, _ in
-        owner.coordinator?.attachFeedDetail(for: "0")
+      .emit(with: self) { owner, feedId in
+        owner.coordinator?.attachFeedDetail(challengeId: owner.challengeId, feedId: feedId)
       }
       .disposed(by: disposeBag)
     

--- a/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedViewModel.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedViewModel.swift
@@ -32,6 +32,7 @@ final class FeedViewModel: FeedViewModelType {
   private let disposeBag = DisposeBag()
   private let challengeId: Int
   private let useCase: ChallengeUseCase
+  private let modelMapper = FeedPresentatoinModelMapper()
   
   private var alignMode: FeedsAlignMode = .recent
   private var currentPage = 0
@@ -229,13 +230,13 @@ private extension FeedViewModel {
       
       switch result {
         case let .defaults(feeds):
-          let models = feeds.flatMap { mapToPresentationModels($0) }
+          let models = feeds.flatMap { modelMapper.mapToFeedPresentationModels($0) }
           let feedsType: FeedsType = currentPage == 0 ? .initialPage(models) : .default(models)
           sleep(2)
           feedsRelay.accept(feedsType)
 
         case let .lastPage(feeds):
-          let models = feeds.flatMap { mapToPresentationModels($0) }
+          let models = feeds.flatMap { modelMapper.mapToFeedPresentationModels($0) }
           isLastFeedPage = true
           sleep(2)
           feedsRelay.accept(.default(models))
@@ -326,64 +327,5 @@ private extension FeedViewModel {
         owner.proofRelay.accept(.didNotProve(time))
       }
       .disposed(by: disposeBag)
-  }
-  
-  func mapToPresentationModels(_ feeds: [Feed]) -> [FeedPresentationModel] {
-    return feeds.map { feed in
-      let convertDate = feed.updateTime.convertTimezone(from: .kst)
-      return .init(
-        id: feed.id,
-        imageURL: feed.imageURL,
-        userName: feed.author,
-        updateTime: mapToUpdateTimeString(convertDate),
-        updateGroup: mapToUpdateGroup(convertDate),
-        isLike: feed.isLike
-      )
-    }
-  }
-  
-  func mapToUpdateTimeString(_ date: Date) -> String {
-    let current = Date()
-
-    guard current.year == date.year else {
-      return "\(abs(current.year - date.year))년 전"
-    }
-    
-    guard current.month == date.month else {
-      return "\(abs(current.month - date.month))년 전"
-    }
-    
-    guard current.day == date.day else {
-      return "\(abs(current.day - date.day))일 전"
-    }
-    
-    guard current.hour == date.hour else {
-      return "\(abs(current.hour - date.hour))시간 전"
-    }
-    
-    guard current.minute != date.minute else {
-      return "방금"
-    }
-    
-    let temp = abs(current.minute - date.minute)
-    switch temp {
-      case 0...10: return "\(temp)분 전"
-      default: return "\(temp / 10)분 전"
-    }
-  }
-  
-  func mapToUpdateGroup(_ date: Date) -> String {
-    let current = Date()
-
-    guard current.year == date.year else {
-      return "\(abs(current.year - date.year))년 전"
-    }
-    
-    guard current.month == date.month else {
-      return "\(abs(current.month - date.month))년 전"
-    }
-    
-    let temp = abs(current.day - date.day)
-    return temp == 0 ? "오늘" : "\(temp)일 전"
   }
 }

--- a/Projects/Presentation/Challenge/Implementations/Member/Feed/PresentationModel/AuthorPresentationModel.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/Feed/PresentationModel/AuthorPresentationModel.swift
@@ -1,0 +1,18 @@
+//
+//  AuthorPresentationModel.swift
+//  ChallengeImpl
+//
+//  Created by jung on 2/26/25.
+//  Copyright © 2025 com.photi. All rights reserved.
+//
+
+import Foundation
+
+struct AuthorPresentationModel {
+  let name: String
+  let imageURL: URL?
+}
+
+extension AuthorPresentationModel {
+  static let `default` = AuthorPresentationModel(name: "", imageURL: nil)
+}

--- a/Projects/Presentation/Challenge/Implementations/Member/Feed/PresentationModel/CommentPresentationModel.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/Feed/PresentationModel/CommentPresentationModel.swift
@@ -9,8 +9,8 @@
 import Foundation
 
 struct CommentPresentationModel: Hashable {
-  let id: String
-  let userName: String
+  let id: Int
+  let author: String
   let content: String
   let isOwner: Bool
   let updatedAt: Date

--- a/Projects/Presentation/Challenge/Implementations/Member/Feed/PresentationModel/FeedCommentPresentationModel.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/Feed/PresentationModel/FeedCommentPresentationModel.swift
@@ -7,10 +7,15 @@
 //
 
 struct FeedCommentPresentationModel: Hashable {
-  let id: Int
+  let id: String
+  var commentId: Int
   let author: String
   let content: String
   let isOwner: Bool
+  
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(id)
+  }
 }
 
 enum FeedCommentType {

--- a/Projects/Presentation/Challenge/Implementations/Member/Feed/PresentationModel/FeedCommentPresentationModel.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/Feed/PresentationModel/FeedCommentPresentationModel.swift
@@ -6,16 +6,14 @@
 //  Copyright © 2024 com.photi. All rights reserved.
 //
 
-import Foundation
-
-struct CommentPresentationModel: Hashable {
+struct FeedCommentPresentationModel: Hashable {
   let id: Int
   let author: String
   let content: String
   let isOwner: Bool
-  let updatedAt: Date
-  
-  func hash(into hasher: inout Hasher) {
-    hasher.combine(id)
-  }
+}
+
+enum FeedCommentType {
+  case initialPage([FeedCommentPresentationModel])
+  case `default`([FeedCommentPresentationModel])
 }

--- a/Projects/Presentation/Challenge/Implementations/Member/Feed/PresentationModel/FeedPresentatoinModelMapper.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/Feed/PresentationModel/FeedPresentatoinModelMapper.swift
@@ -1,0 +1,79 @@
+//
+//  FeedPresentatoinModelMapper.swift
+//  ChallengeImpl
+//
+//  Created by jung on 2/26/25.
+//  Copyright © 2025 com.photi. All rights reserved.
+//
+
+import Foundation
+import Core
+import Entity
+
+struct FeedPresentatoinModelMapper {
+  func mapToFeedPresentationModels(_ feeds: [Feed]) -> [FeedPresentationModel] {
+    return feeds.map { feed in
+      return .init(
+        id: feed.id,
+        imageURL: feed.imageURL,
+        userName: feed.author,
+        updateTime: mapToUpdateTimeString(feed.updateTime),
+        updateGroup: mapToUpdateGroup(feed.updateTime),
+        isLike: feed.isLike
+      )
+    }
+  }
+  
+  func mapToAuthorPresentaionModel(author: String, url: URL?) -> AuthorPresentationModel {
+    return .init(name: author, imageURL: url)
+  }
+}
+
+extension FeedPresentatoinModelMapper {
+  func mapToUpdateTimeString(_ date: Date) -> String {
+    let date = date.convertTimezone(from: .kst)
+    let current = Date()
+  
+    guard current.year == date.year else {
+      return "\(abs(current.year - date.year))년 전"
+    }
+  
+    guard current.month == date.month else {
+      return "\(abs(current.month - date.month))년 전"
+    }
+  
+    guard current.day == date.day else {
+      return "\(abs(current.day - date.day))일 전"
+    }
+  
+    guard current.hour == date.hour else {
+      return "\(abs(current.hour - date.hour))시간 전"
+    }
+  
+    guard current.minute != date.minute else {
+      return "방금"
+    }
+  
+    let temp = abs(current.minute - date.minute)
+    switch temp {
+      case 0...10: return "\(temp)분 전"
+      default: return "\(temp / 10)분 전"
+    }
+  }
+  
+  func mapToUpdateGroup(_ date: Date) -> String {
+    let date = date.convertTimezone(from: .kst)
+    let current = Date()
+  
+    guard current.year == date.year else {
+      return "\(abs(current.year - date.year))년 전"
+    }
+  
+    guard current.month == date.month else {
+      return "\(abs(current.month - date.month))년 전"
+    }
+  
+    let temp = abs(current.day - date.day)
+    return temp == 0 ? "오늘" : "\(temp)일 전"
+  }
+}

--- a/Projects/Presentation/Challenge/Implementations/Member/Feed/PresentationModel/FeedPresentatoinModelMapper.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/Feed/PresentationModel/FeedPresentatoinModelMapper.swift
@@ -11,6 +11,8 @@ import Core
 import Entity
 
 struct FeedPresentatoinModelMapper {
+  private let dummyCommentId = -1
+  
   func mapToFeedPresentationModels(_ feeds: [Feed]) -> [FeedPresentationModel] {
     return feeds.map { feed in
       return .init(
@@ -31,12 +33,23 @@ struct FeedPresentatoinModelMapper {
   func mapToFeedCommentPresentationModels(_ comments: [FeedComment]) -> [FeedCommentPresentationModel] {
     return comments.map {
       .init(
-        id: $0.id,
+        id: UUID().uuidString,
+        commentId: $0.id,
         author: $0.author,
         content: $0.comment,
-        isOwner: true 
+        isOwner: isOwner($0.author)
       )
     }
+  }
+  
+  func feedCommentPresentationModel(_ comment: String) -> FeedCommentPresentationModel {
+    return .init(
+      id: UUID().uuidString,
+      commentId: dummyCommentId,
+      author: ServiceConfiguration.shared.userName,
+      content: comment,
+      isOwner: true
+    )
   }
 }
 
@@ -86,5 +99,12 @@ extension FeedPresentatoinModelMapper {
   
     let temp = abs(current.day - date.day)
     return temp == 0 ? "오늘" : "\(temp)일 전"
+  }
+}
+
+// MARK: - Private Methods
+private extension FeedPresentatoinModelMapper {
+  func isOwner(_ name: String) -> Bool {
+    return name == ServiceConfiguration.shared.userName
   }
 }

--- a/Projects/Presentation/Challenge/Implementations/Member/Feed/PresentationModel/FeedPresentatoinModelMapper.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/Feed/PresentationModel/FeedPresentatoinModelMapper.swift
@@ -27,6 +27,17 @@ struct FeedPresentatoinModelMapper {
   func mapToAuthorPresentaionModel(author: String, url: URL?) -> AuthorPresentationModel {
     return .init(name: author, imageURL: url)
   }
+  
+  func mapToFeedCommentPresentationModels(_ comments: [FeedComment]) -> [FeedCommentPresentationModel] {
+    return comments.map {
+      .init(
+        id: $0.id,
+        author: $0.author,
+        content: $0.comment,
+        isOwner: true 
+      )
+    }
+  }
 }
 
 extension FeedPresentatoinModelMapper {

--- a/Projects/Presentation/Challenge/Implementations/Member/Feed/Views/FeedLikeButton.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/Feed/Views/FeedLikeButton.swift
@@ -21,16 +21,12 @@ final class FeedLikeButton: UIButton {
   init() {
     super.init(frame: .zero)
     setupUI()
+    addTarget(self, action: #selector(didTap), for: .touchUpInside)
   }
   
   @available(*, unavailable)
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
-  }
-  
-  override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
-    super.touchesEnded(touches, with: event)
-    isSelected.toggle()
   }
 }
 
@@ -58,5 +54,9 @@ private extension FeedLikeButton {
     }
     
     button.configuration = configuration
+  }
+  
+  @objc func didTap() {
+    isSelected.toggle()
   }
 }

--- a/Projects/Presentation/MyPage/Implementations/ProfileEdit/Resign/ResignPassword/ResignAuthViewController.swift
+++ b/Projects/Presentation/MyPage/Implementations/ProfileEdit/Resign/ResignPassword/ResignAuthViewController.swift
@@ -126,7 +126,7 @@ private extension ResignAuthViewController {
     
     output.requestFailed
       .emit(with: self) { owner, _ in
-        owner.presentWarningPopup()
+        owner.presentNetworkUnstableAlert()
       }
       .disposed(by: disposeBag)
     


### PR DESCRIPTION
## 관련 이슈

- #211 

## 작업 설명

- Comment Delete 구현 
- Comment Pagination 구현 
- Error 관련 UI 바인딩 완료 

## PR 특이 사항

- API에서 `uploadFeedComment`이후, commentID를 받을 수 있도록 서버에 요청했습니다. 아직 전달받지 않았기 때문에 적용하지 않은 상태입니다. (RepositoryImpl에선 코드 return 100으로 되어있습니다.)
- 서버에서 404일때, 현재 ChallengeNotFound로 되어 있습니다. 따라서, 서버 변경 후 이 역시 수정 예정입니다.
- Comment가 2개 이하에서 refresh 한 후에, bottom으로 comment들이 붙지 않는 버그가 발생합니다. 
![Simulator Screen Recording - iPhone 16 Pro - 2025-03-02 at 01 20 48](https://github.com/user-attachments/assets/b5b4c5b5-31d1-4ad5-9d45-8cd509fa8377)

CATransaction을 사용해보고, asyncAfter도 사용해봤지만, 되지 않습니다..ㅜ
