### PR TITLE
[FEAT]: Challenge 비공개 및 공개 참여 API 구현 완료

### DIFF
--- a/Projects/Domain/Repository/Interfaces/ChallengeRepository.swift
+++ b/Projects/Domain/Repository/Interfaces/ChallengeRepository.swift
@@ -26,6 +26,7 @@ public protocol ChallengeRepository {
   func fetchPopularChallenges() -> Single<[ChallengeDetail]>
   func fetchEndedChallenges(page: Int, size: Int) -> Single<[ChallengeSummary]>
   func fetchChallengeDetail(id: Int) -> Single<ChallengeDetail>
+  func joinPublicChallenge(id: Int) -> Single<Void>
   func joinPrivateChallnege(id: Int, code: String) -> Single<Void>
   func uploadChallengeFeedProof(id: Int, image: Data, imageType: String) async throws
   func updateLikeState(challengeId: Int, feedId: Int, isLike: Bool) async throws
@@ -44,4 +45,5 @@ public protocol ChallengeRepository {
   ) async throws -> (feeds: [FeedComment], isLast: Bool)
   func uploadFeedComment(challengeId: Int, feedId: Int, comment: String) async throws -> Int
   func deleteFeedComment(challengeId: Int, feedId: Int, commentId: Int) async throws
+  func updateChallengeGoal(_ goal: String, challengeId: Int) -> Single<Void>
 }

--- a/Projects/Domain/UseCase/Implementations/ChallengeUseCaseImpl.swift
+++ b/Projects/Domain/UseCase/Implementations/ChallengeUseCaseImpl.swift
@@ -25,20 +25,19 @@ public struct ChallengeUseCaseImpl: ChallengeUseCase {
     
     self.challengeProveMemberCount = challengeProveMemberCountRelay.asInfallible()
   }
-  
-  public func fetchChallengeDetail(id: Int) -> Single<ChallengeDetail> {
+}
+
+// MARK: - Fetch Methods
+public extension ChallengeUseCaseImpl {
+  func fetchChallengeDetail(id: Int) -> Single<ChallengeDetail> {
     return repository.fetchChallengeDetail(id: id)
   }
   
-  public func isLogIn() async -> Bool {
+  func isLogIn() async -> Bool {
     return await authRepository.isLogIn()
   }
   
-  public func joinPrivateChallnege(id: Int, code: String) async throws {
-    try await repository.joinPrivateChallnege(id: id, code: code).value
-  }
-  
-  public func fetchFeeds(id: Int, page: Int, size: Int, orderType: ChallengeFeedsOrderType) async throws -> PageFeeds {
+  func fetchFeeds(id: Int, page: Int, size: Int, orderType: ChallengeFeedsOrderType) async throws -> PageFeeds {
     let result = try await repository.fetchFeeds(id: id, page: page, size: size, orderType: orderType)
     
     if challengeProveMemberCountRelay.value != result.memberCount {
@@ -47,8 +46,19 @@ public struct ChallengeUseCaseImpl: ChallengeUseCase {
     
     return result.isLast ? .lastPage(result.feeds) : .defaults(result.feeds)
   }
+}
+
+// MARK: - Upload & Update Methods
+public extension ChallengeUseCaseImpl {
+  func joinPrivateChallnege(id: Int, code: String) async throws {
+    try await repository.joinPrivateChallnege(id: id, code: code).value
+  }
   
-  public func uploadChallengeFeedProof(id: Int, image: Data, imageType: String) async throws {
+  func joinPublicChallenge(id: Int) -> Single<Void> {
+    return repository.joinPublicChallenge(id: id)
+  }
+  
+  func uploadChallengeFeedProof(id: Int, image: Data, imageType: String) async throws {
     let type = imageType.lowercased()
     
     guard type == "jpeg" || type == "jpg" || type == "png" else {
@@ -57,11 +67,15 @@ public struct ChallengeUseCaseImpl: ChallengeUseCase {
     return try await repository.uploadChallengeFeedProof(id: id, image: image, imageType: type)
   }
   
-  public func updateLikeState(challengeId: Int, feedId: Int, isLike: Bool) async throws {
+  func updateLikeState(challengeId: Int, feedId: Int, isLike: Bool) async throws {
     return try await repository.updateLikeState(challengeId: challengeId, feedId: feedId, isLike: isLike)
   }
   
-  public func isProve(challengeId: Int) async throws -> Bool {
+  func isProve(challengeId: Int) async throws -> Bool {
     return try await repository.isProve(challengeId: challengeId)
+  }
+  
+  func updateChallengeGoal(_ goal: String, challengeId: Int) -> Single<Void> {
+    return repository.updateChallengeGoal(goal, challengeId: challengeId)
   }
 }

--- a/Projects/Domain/UseCase/Interfaces/ChallengeUseCase.swift
+++ b/Projects/Domain/UseCase/Interfaces/ChallengeUseCase.swift
@@ -22,6 +22,7 @@ public protocol ChallengeUseCase {
   func isLogIn() async -> Bool
   func fetchChallengeDetail(id: Int) -> Single<ChallengeDetail>
   func joinPrivateChallnege(id: Int, code: String) async throws
+  func joinPublicChallenge(id: Int) -> Single<Void>
   func isProve(challengeId: Int) async throws -> Bool
   func uploadChallengeFeedProof(id: Int, image: Data, imageType: String) async throws
   func updateLikeState(challengeId: Int, feedId: Int, isLike: Bool) async throws
@@ -31,4 +32,5 @@ public protocol ChallengeUseCase {
     size: Int,
     orderType: ChallengeFeedsOrderType
   ) async throws -> PageFeeds
+  func updateChallengeGoal(_ goal: String, challengeId: Int) -> Single<Void>
 }

--- a/Projects/Presentation/Challenge/Implementations/EnterChallengeGoal/EnterChallengeGoalContainer.swift
+++ b/Projects/Presentation/Challenge/Implementations/EnterChallengeGoal/EnterChallengeGoalContainer.swift
@@ -7,13 +7,16 @@
 //
 
 import Core
+import UseCase
 
 enum ChallengeGoalMode {
   case edit(goal: String)
   case add
 }
 
-protocol EnterChallengeGoalDependency: Dependency { }
+protocol EnterChallengeGoalDependency: Dependency {
+  var challengeUseCase: ChallengeUseCase { get }
+}
 
 protocol EnterChallengeGoalContainable: Containable {
   func coordinator(
@@ -31,7 +34,7 @@ final class EnterChallengeGoalContainer: Container<EnterChallengeGoalDependency>
     challengeName: String,
     listener: EnterChallengeGoalListener
   ) -> ViewableCoordinating {
-    let viewModel = EnterChallengeGoalViewModel(challengeID: challengeID)
+    let viewModel = EnterChallengeGoalViewModel(challengeID: challengeID, useCase: dependency.challengeUseCase)
     let viewControllerable = EnterChallengeGoalViewController(
       mode: mode,
       challengeName: challengeName,

--- a/Projects/Presentation/Challenge/Implementations/EnterChallengeGoal/EnterChallengeGoalCoordinator.swift
+++ b/Projects/Presentation/Challenge/Implementations/EnterChallengeGoal/EnterChallengeGoalCoordinator.swift
@@ -10,7 +10,8 @@ import Core
 
 protocol EnterChallengeGoalListener: AnyObject {
   func didTapBackButtonAtEnterChallengeGoal()
-  func didEnterChallengeGoal()
+  func didFinishEnterChallengeGoal()
+  func requestLoginAtEnterChallengeGoal()
 }
 
 protocol EnterChallengeGoalPresentable { }
@@ -37,6 +38,14 @@ extension EnterChallengeGoalCoordinator: EnterChallengeGoalCoordinatable {
   }
   
   func didChangeChallengeGoal() {
-    listener?.didEnterChallengeGoal()
+    listener?.didFinishEnterChallengeGoal()
+  }
+  
+  func didSkipEnterChallengeGoal() {
+    listener?.didFinishEnterChallengeGoal()
+  }
+  
+  func requestLogin() {
+    listener?.requestLoginAtEnterChallengeGoal()
   }
 }

--- a/Projects/Presentation/Challenge/Implementations/Member/ChallengeCoordinator.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/ChallengeCoordinator.swift
@@ -158,11 +158,15 @@ extension ChallengeCoordinator: EnterChallengeGoalListener {
   func didTapBackButtonAtEnterChallengeGoal() {
     detachEditChallengeGoal()
   }
-  
-  func didEnterChallengeGoal() {
+
+  func didFinishEnterChallengeGoal() {
     // TODO: API 연결 이후 수정 예정
     detachEditChallengeGoal { [weak self] in
       self?.presenter.presentDidChangeGoalToastView()
     }
+  }
+  
+  func requestLoginAtEnterChallengeGoal() {
+    listener?.requestLoginAtChallenge()
   }
 }

--- a/Projects/Presentation/Challenge/Implementations/Member/ChallengeCoordinator.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/ChallengeCoordinator.swift
@@ -123,7 +123,7 @@ extension ChallengeCoordinator: FeedListener {
   }
   
   func requestLoginAtChallengeFeed() {
-    listener?.requestLogin()
+    listener?.requestLoginAtChallenge()
   }
   
   func shouldDismissChallenge() {

--- a/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedViewController.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedViewController.swift
@@ -344,7 +344,7 @@ extension FeedViewController {
     guard let sectionData = dataSource?.sectionIdentifier(for: indexPath.section) else {
       return headerView
     }
-    if indexPath.section == 0 {
+    if indexPath.section == 0, sectionData == "오늘" {
       switch isProve {
         case let .didNotProve(proveTime):
           headerView.configure(date: sectionData, type: .didNotProve(proveTime))
@@ -367,8 +367,12 @@ extension FeedViewController {
   
   func configureTodayHeaderView(for type: ProveType) {
     let indexPath = IndexPath(row: 0, section: 0)
-    guard let headerView = feedCollectionView.headerView(FeedsHeaderView.self, at: indexPath) else { return }
-    
+    guard
+      let headerView = feedCollectionView.headerView(FeedsHeaderView.self, at: indexPath),
+      let sectionData = dataSource?.sectionIdentifier(for: 0),
+      sectionData == "오늘"
+    else { return }
+
     switch type {
       case let .didNotProve(proveTime):
         headerView.configure(type: .didNotProve(proveTime))

--- a/Projects/Presentation/Challenge/Implementations/NoneMember/NoneMemberChallengeContainer.swift
+++ b/Projects/Presentation/Challenge/Implementations/NoneMember/NoneMemberChallengeContainer.swift
@@ -35,4 +35,6 @@ public final class NoneMemberChallengeContainer:
     coordinator.listener = listener
     return coordinator
   }
+  
+  var challengeUseCase: ChallengeUseCase { dependency.challengeUseCase }
 }

--- a/Projects/Presentation/Challenge/Implementations/NoneMember/NoneMemberChallengeCoordinator.swift
+++ b/Projects/Presentation/Challenge/Implementations/NoneMember/NoneMemberChallengeCoordinator.swift
@@ -92,9 +92,13 @@ extension NoneMemberChallengeCoordinator: EnterChallengeGoalListener {
     detachEnterChallengeGoal()
   }
   
-  func didEnterChallengeGoal() {
+  func didFinishEnterChallengeGoal() {
     detachEnterChallengeGoal()
     listener?.didJoinChallenge()
+  }
+  
+  func requestLoginAtEnterChallengeGoal() {
+    listener?.requestLogInAtNoneMemberChallenge()
   }
 }
 

--- a/Projects/Presentation/Challenge/Implementations/NoneMember/NoneMemberChallengeCoordinator.swift
+++ b/Projects/Presentation/Challenge/Implementations/NoneMember/NoneMemberChallengeCoordinator.swift
@@ -105,6 +105,6 @@ extension NoneMemberChallengeCoordinator: LogInGuideListener {
   }
   
   func didTapLogInButtonAtLogInGuide() {
-    listener?.requestLogIn(for: viewModel.challengeId)
+    listener?.requestLogInAtNoneMemberChallenge()
   }
 }

--- a/Projects/Presentation/Challenge/Implementations/NoneMember/NoneMemberChallengeViewController.swift
+++ b/Projects/Presentation/Challenge/Implementations/NoneMember/NoneMemberChallengeViewController.swift
@@ -334,7 +334,7 @@ private extension NoneMemberChallengeViewController {
   }
   
   func displayAlreadyJoinPopUp() {
-    let popUp = AlertViewController(alertType: .confirm, title: "오류", subTitle: "이미 참여한 챌린지입니다.")
+    let popUp = AlertViewController(alertType: .confirm, title: "이미 참여한 챌린지예요")
     popUp.present(to: self, animted: false)
   }
 }

--- a/Projects/Presentation/Challenge/Interfaces/Challenge.swift
+++ b/Projects/Presentation/Challenge/Interfaces/Challenge.swift
@@ -15,5 +15,5 @@ public protocol ChallengeContainable: Containable {
 public protocol ChallengeListener: AnyObject {
   func didTapBackButtonAtChallenge()
   func shouldDismissChallenge()
-  func requestLogin()
+  func requestLoginAtChallenge()
 }

--- a/Projects/Presentation/Challenge/Interfaces/NoneMemberChallenge.swift
+++ b/Projects/Presentation/Challenge/Interfaces/NoneMemberChallenge.swift
@@ -15,5 +15,5 @@ public protocol NoneMemberChallengeContainable: Containable {
 public protocol NoneMemberChallengeListener: AnyObject {
   func didTapBackButtonAtNoneMemberChallenge()
   func didJoinChallenge()
-  func requestLogIn(for challengeID: Int)
+  func requestLogInAtNoneMemberChallenge()
 }


### PR DESCRIPTION
## 관련 이슈

- #205 

## 작업 설명

- 챌린지 비공개 참여 API 연동
- 챌린지 공개 참여 API 연동
- 이후, Challenge 목표 설정하기 페이지 API 연동 
