### PR TITLE
[FEAT]: 챌린지 및 챌린지 피드 삭제 API 연결

### DIFF
--- a/Projects/App/Sources/AppContainer.swift
+++ b/Projects/App/Sources/AppContainer.swift
@@ -104,11 +104,15 @@ final class AppContainer:
   }()
   
   lazy var challengeUseCase: ChallengeUseCase = {
-    return ChallengeUseCaseImpl(repository: challengeRepository, authRepository: authRepository)
+    return ChallengeUseCaseImpl(
+      challengeRepository: challengeRepository,
+      feedRepository: feedRepository,
+      authRepository: authRepository
+    )
   }()
   
   lazy var feedUseCase: FeedUseCase = {
-    return FeedUseCaseImpl(repository: challengeRepository)
+    return FeedUseCaseImpl(repository: feedRepository)
   }()
   
   lazy var reportUseCase: ReportUseCase = {
@@ -154,6 +158,10 @@ final class AppContainer:
   
   lazy var challengeRepository: ChallengeRepository = {
     return ChallengeRepositoryImpl(dataMapper: ChallengeDataMapperImpl())
+  }()
+  
+  lazy var feedRepository: FeedRepository = {
+    return FeedRepositoryImpl(dataMapper: ChallengeDataMapperImpl())
   }()
   
   lazy var reportRepository: ReportRepository = {

--- a/Projects/Data/DTO/Challenge/FeedComment/FeedCommentResponseDTO.swift
+++ b/Projects/Data/DTO/Challenge/FeedComment/FeedCommentResponseDTO.swift
@@ -1,0 +1,23 @@
+//
+//  FeedCommentResponseDTO.swift
+//  DTO
+//
+//  Created by jung on 3/13/25.
+//  Copyright © 2025 com.photi. All rights reserved.
+//
+
+public struct FeedCommentResponseDTO: Decodable {
+  public let id: Int
+}
+
+public extension FeedCommentResponseDTO {
+  static let stubData = """
+{
+  "code": "201 CREATED",
+  "message": "성공",
+  "data": {
+    "id": 1
+  }
+}
+"""
+}

--- a/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeAPI.swift
+++ b/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeAPI.swift
@@ -23,6 +23,7 @@ public enum ChallengeAPI {
   case updateChallengeGoal(_ goal: String, challengeId: Int)
   case challengeDescription(id: Int)
   case challengeMember(challengeId: Int)
+  case leaveChallenge(challengeId: Int)
 }
 
 extension ChallengeAPI: TargetType {
@@ -34,7 +35,7 @@ extension ChallengeAPI: TargetType {
   public var path: String {
     switch self {
       case .popularChallenges: return "challenges/popular"
-      case let .challengeDetail(id): return "challenges/\(id)"
+      case let .challengeDetail(id), let .leaveChallenge(id): return "challenges/\(id)"
       case .endedChallenges: return "users/ended-challenges"
       case .myChallenges: return "/users/my-challenges"
       case let .joinChallenge(id): return "challenges/\(id)/join/public"
@@ -58,6 +59,7 @@ extension ChallengeAPI: TargetType {
       case .updateChallengeGoal: return .patch
       case .challengeDescription: return .get
       case .challengeMember: return .get
+      case .leaveChallenge: return .delete
     }
   }
   
@@ -110,7 +112,7 @@ extension ChallengeAPI: TargetType {
         let parameters = ["challengeId": challengeId]
         return .requestParameters(parameters: parameters, encoding: URLEncoding.queryString)
         
-      case let .challengeMember(challengeId):
+      case let .challengeMember(challengeId), let .leaveChallenge(challengeId):
         let parameters = ["challengeId": challengeId]
         return .requestParameters(parameters: parameters, encoding: URLEncoding.queryString)
     }
@@ -142,7 +144,7 @@ extension ChallengeAPI: TargetType {
         
         return .networkResponse(200, jsonData ?? Data(), "OK", "성공")
 
-      case .joinChallenge, .joinPrivateChallenge, .uploadChallengeProof, .updateChallengeGoal:
+      case .joinChallenge, .joinPrivateChallenge, .uploadChallengeProof, .updateChallengeGoal, .leaveChallenge:
         let data = """
           {
             "code": "200 OK",

--- a/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeAPI.swift
+++ b/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeAPI.swift
@@ -187,7 +187,7 @@ extension ChallengeAPI: TargetType {
         return .networkResponse(200, jsonData ?? Data(), "OK", "성공")
 
       // swiftlint:disable line_length 
-      case .joinChallenge, .joinPrivateChallenge, .uploadChallengeProof, .updateLikeState, .uploadFeedComment, .deleteFeedComment, .updateChallengeGoal:
+      case .joinChallenge, .joinPrivateChallenge, .uploadChallengeProof, .updateLikeState, .deleteFeedComment, .updateChallengeGoal:
       // swiftlint:enable line_length
         let data = """
           {
@@ -198,6 +198,12 @@ extension ChallengeAPI: TargetType {
             }
           }
         """
+        let jsonData = data.data(using: .utf8)
+        
+        return .networkResponse(200, jsonData ?? Data(), "OK", "성공")
+        
+      case .uploadFeedComment:
+        let data = FeedCommentResponseDTO.stubData
         let jsonData = data.data(using: .utf8)
         
         return .networkResponse(200, jsonData ?? Data(), "OK", "성공")

--- a/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeAPI.swift
+++ b/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeAPI.swift
@@ -18,14 +18,8 @@ public enum ChallengeAPI {
   case myChallenges(page: Int, size: Int)
   case joinChallenge(id: Int)
   case joinPrivateChallenge(id: Int, code: String)
-  case feeds(id: Int, page: Int, size: Int, sortOrder: String)
   case uploadChallengeProof(id: Int, image: Data, imageType: String)
-  case updateLikeState(challengeId: Int, feedId: Int, isLike: Bool)
   case isProve(challengeId: Int)
-  case feedDetail(challengeId: Int, feedId: Int)
-  case feedComments(feedId: Int, page: Int, size: Int)
-  case uploadFeedComment(challengeId: Int, feedId: Int, comment: String)
-  case deleteFeedComment(challengeId: Int, feedId: Int, commentId: Int)
   case updateChallengeGoal(_ goal: String, challengeId: Int)
   case challengeDescription(id: Int)
   case challengeMember(challengeId: Int)
@@ -45,16 +39,8 @@ extension ChallengeAPI: TargetType {
       case .myChallenges: return "/users/my-challenges"
       case let .joinChallenge(id): return "challenges/\(id)/join/public"
       case let .joinPrivateChallenge(id, _): return "challenges/\(id)/join/private"
-      case let .feeds(id, _, _, _): return "challenges/\(id)/feeds"
       case let .uploadChallengeProof(id, _, _): return "challenges/\(id)/feeds"
-      case let .updateLikeState(challengeId, feedId, _): return "challenges/\(challengeId)/feeds/\(feedId)/like"
       case let .isProve(challengeId): return "/users/challenges/\(challengeId)/prove"
-      case let .feedDetail(challengeId, feedId): return "/challenges/\(challengeId)/feeds/\(feedId)"
-      case let .feedComments(feedId, _, _): return "/challenges/feeds/\(feedId)/comments"
-      case let .uploadFeedComment(challengeId, feedId, _): 
-        return "/challenges/\(challengeId)feeds/\(feedId)/comments"
-      case let .deleteFeedComment(challengeId, feedId, commentId): 
-        return "/challenges/\(challengeId)/feeds/\(feedId)/comments/\(commentId)"
       case let .updateChallengeGoal(_, challengeId): return "/challenges/\(challengeId)/challenge-members/goal"
       case let .challengeDescription(id): return "challenges/\(id)/info"
       case let .challengeMember(challengeId): return "/challenges/\(challengeId)/challenge-members"
@@ -67,14 +53,8 @@ extension ChallengeAPI: TargetType {
       case .challengeDetail: return .get
       case .endedChallenges, .myChallenges: return .get
       case .joinChallenge, .joinPrivateChallenge: return .post
-      case .feeds: return .get
       case .uploadChallengeProof: return .post
-      case let .updateLikeState(_, _, isLike): return isLike ? .post : .delete
       case .isProve: return .get
-      case .feedDetail: return .get
-      case .feedComments: return .get
-      case .uploadFeedComment: return .post
-      case .deleteFeedComment: return .delete
       case .updateChallengeGoal: return .patch
       case .challengeDescription: return .get
       case .challengeMember: return .get
@@ -102,14 +82,7 @@ extension ChallengeAPI: TargetType {
         let urlParameters = ["challengeId": challengeId]
         let bodyParameters = ["invitationCode": code]
         return .requestCompositeParameters(bodyParameters: bodyParameters, urlParameters: urlParameters)
-        
-      case let .feeds(challengeId, page, size, ordered):
-        let parameters = ["challengeId": "\(challengeId)", "page": "\(page)", "size": "\(size)", "sort": ordered]
-        return .requestParameters(
-          parameters: parameters,
-          encoding: URLEncoding.queryString
-        )
-        
+                
       case let .uploadChallengeProof(challengeId, image, imageType):
         let parameters = ["challengeId": challengeId]
 
@@ -123,26 +96,9 @@ extension ChallengeAPI: TargetType {
           multipart: .init(bodyParts: [multiPartBody]),
           urlParameters: parameters
         )
-        
-      case let .updateLikeState(challengeId, feedId, _), let .feedDetail(challengeId, feedId):
-        let parameters = ["challengeId": challengeId, "feedId": feedId]
-        return .requestParameters(parameters: parameters, encoding: URLEncoding.queryString)
-        
+
       case let .isProve(challengeId):
         let parameters = ["challengeId": challengeId]
-        return .requestParameters(parameters: parameters, encoding: URLEncoding.queryString)
-        
-      case let .feedComments(feedId, page, size):
-        let parameters = ["feedId": "\(feedId)", "page": "\(page)", "size": "\(size)"]
-        return .requestParameters(parameters: parameters, encoding: URLEncoding.queryString)
-        
-      case let .uploadFeedComment(challengeId, feedId, comment):
-        let urlParameters = ["challengeId": challengeId, "feedId": feedId]
-        let bodyParameters = ["comment": comment]
-        return .requestCompositeParameters(bodyParameters: bodyParameters, urlParameters: urlParameters)
-        
-      case let .deleteFeedComment(challengeId, feedId, commentId):
-        let parameters = ["challengeId": challengeId, "feedId": feedId, "commentId": commentId]
         return .requestParameters(parameters: parameters, encoding: URLEncoding.queryString)
         
       case let .updateChallengeGoal(goal, challengeId):
@@ -186,9 +142,7 @@ extension ChallengeAPI: TargetType {
         
         return .networkResponse(200, jsonData ?? Data(), "OK", "성공")
 
-      // swiftlint:disable line_length 
-      case .joinChallenge, .joinPrivateChallenge, .uploadChallengeProof, .updateLikeState, .deleteFeedComment, .updateChallengeGoal:
-      // swiftlint:enable line_length
+      case .joinChallenge, .joinPrivateChallenge, .uploadChallengeProof, .updateChallengeGoal:
         let data = """
           {
             "code": "200 OK",
@@ -202,38 +156,12 @@ extension ChallengeAPI: TargetType {
         
         return .networkResponse(200, jsonData ?? Data(), "OK", "성공")
         
-      case .uploadFeedComment:
-        let data = FeedCommentResponseDTO.stubData
-        let jsonData = data.data(using: .utf8)
-        
-        return .networkResponse(200, jsonData ?? Data(), "OK", "성공")
-        
-      case let .feeds(_, page, _, _):
-        let feedsData = [FeedsResponseDTO.stubData, FeedsResponseDTO.stubData2, FeedsResponseDTO.stubData3]
-        let data = feedsData[page]
-        let jsonData = data.data(using: .utf8)
-        
-        return .networkResponse(200, jsonData ?? Data(), "OK", "성공")
-        
       case .isProve:
         let data = ChallengeProveResponseDTO.stubData
         let jsonData = data.data(using: .utf8)
         
         return .networkResponse(200, jsonData ?? Data(), "OK", "성공")
-        
-      case .feedDetail:
-        let data = FeedDetailResponseDTO.stubData
-        let jsonData = data.data(using: .utf8)
-        
-        return .networkResponse(200, jsonData ?? Data(), "OK", "성공")
-        
-      case let .feedComments(_, page, _):
-        let page = min(page, 1)
-        let commentsData = [FeedCommentsResponseDTO.stubData1, FeedCommentsResponseDTO.stubData2]
-        let jsonData = commentsData[page].data(using: .utf8)
-        
-        return .networkResponse(200, jsonData ?? Data(), "OK", "성공")
-        
+ 
       case .challengeDescription:
         let data = ChallengeDescriptionResponseDTO.stubData
         let jsonData = data.data(using: .utf8)

--- a/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeRepositoryImpl.swift
+++ b/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeRepositoryImpl.swift
@@ -173,7 +173,7 @@ public extension ChallengeRepositoryImpl {
       session: .init(interceptor: AuthenticationInterceptor())
     )
     
-    guard let result = try? await provider.request(api).value else {
+    guard let result = try? await provider.request(api, type: FeedCommentResponseDTO.self).value else {
       throw APIError.serverError
     }
     
@@ -183,8 +183,8 @@ public extension ChallengeRepositoryImpl {
       throw APIError.challengeFailed(reason: .challengeNotFound)
     }
       
-    // TODO: 서버 API수정시 Feed CommentID 리턴으로 수정 예정
-    return 100
+    guard let id = result.data?.id else { throw APIError.serverError }
+    return id
   }
   
   func updateChallengeGoal(_ goal: String, challengeId: Int) -> Single<Void> {

--- a/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeRepositoryImpl.swift
+++ b/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeRepositoryImpl.swift
@@ -138,6 +138,18 @@ public extension ChallengeRepositoryImpl {
   }
 }
 
+// MARK: - Delete Methods
+public extension ChallengeRepositoryImpl {
+  func leaveChallenge(id: Int) -> Single<Void> {
+    return requestAuthorizableAPI(
+      api: .leaveChallenge(challengeId: id),
+      responseType: SuccessResponseDTO.self,
+      behavior: .immediate
+    )
+    .map { _ in }
+  }
+}
+
 // MARK: - Private Methods
 private extension ChallengeRepositoryImpl {
   func requestAuthorizableAPI<T: Decodable>(

--- a/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeRepositoryImpl.swift
+++ b/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeRepositoryImpl.swift
@@ -49,64 +49,6 @@ public extension ChallengeRepositoryImpl {
     .map { dataMapper.mapToChallengeDetail(dto: $0, id: id) }
   }
   
-  func fetchFeeds(
-    id: Int,
-    page: Int,
-    size: Int,
-    orderType: ChallengeFeedsOrderType
-  ) async throws -> FeedReturnType {
-    let api = ChallengeAPI.feeds(
-      id: id,
-      page: page,
-      size: size,
-      sortOrder: orderType.rawValue
-    )
-    
-    let value = try await requestAuthorizableAPI(
-      api: api,
-      responseType: FeedsResponseDTO.self,
-      behavior: .immediate
-    ).value
-    
-    let feeds = value.content.map { data in
-      data.feeds.map { dataMapper.mapToFeed(dto: $0) }
-    }
-    
-    return .init(
-      feeds: feeds,
-      isLast: value.last,
-      memberCount: value.content.first?.feedMemberCnt ?? 0
-    )
-  }
-
-  func fetchFeed(challengeId: Int, feedId: Int) async throws -> Feed {
-    let api = ChallengeAPI.feedDetail(challengeId: challengeId, feedId: feedId)
-    let result = try await requestAuthorizableAPI(
-      api: api,
-      responseType: FeedDetailResponseDTO.self,
-      behavior: .immediate
-    ).value
-    
-    return dataMapper.mapToFeed(dto: result, id: challengeId)
-  }
-  
-  func fetchFeedComments(
-    feedId: Int,
-    page: Int,
-    size: Int
-  ) async throws -> (feeds: [FeedComment], isLast: Bool) {
-    let api = ChallengeAPI.feedComments(feedId: feedId, page: page, size: size)
-    let result = try await requestAuthorizableAPI(
-      api: api,
-      responseType: FeedCommentsResponseDTO.self,
-      behavior: .immediate
-    ).value
-    
-    let feeds = result.content.map { dataMapper.mapToFeedComment(dto: $0) }
-    
-    return (feeds, result.last)
-  }
-  
   func isProve(challengeId: Int) async throws -> Bool {
     let api = ChallengeAPI.isProve(challengeId: challengeId)
     let result = try await requestAuthorizableAPI(
@@ -166,27 +108,6 @@ public extension ChallengeRepositoryImpl {
     .map { _ in () }
   }
   
-  func uploadFeedComment(challengeId: Int, feedId: Int, comment: String) async throws -> Int {
-    let api = ChallengeAPI.uploadFeedComment(challengeId: challengeId, feedId: feedId, comment: comment)
-    let provider = Provider<ChallengeAPI>(
-      stubBehavior: .immediate,
-      session: .init(interceptor: AuthenticationInterceptor())
-    )
-    
-    guard let result = try? await provider.request(api, type: FeedCommentResponseDTO.self).value else {
-      throw APIError.serverError
-    }
-    
-    if result.statusCode == 401 || result.statusCode == 403 {
-      throw APIError.authenticationFailed
-    } else if result.statusCode == 404 {
-      throw APIError.challengeFailed(reason: .challengeNotFound)
-    }
-      
-    guard let id = result.data?.id else { throw APIError.serverError }
-    return id
-  }
-  
   func updateChallengeGoal(_ goal: String, challengeId: Int) -> Single<Void> {
     return requestAuthorizableAPI(
       api: ChallengeAPI.updateChallengeGoal(goal, challengeId: challengeId),
@@ -213,45 +134,6 @@ public extension ChallengeRepositoryImpl {
       throw APIError.userNotFound
     } else if result.statusCode == 409 {
       throw APIError.challengeFailed(reason: .alreadyUploadFeed)
-    }
-  }
-  
-  func updateLikeState(challengeId: Int, feedId: Int, isLike: Bool) async throws {
-    let api = ChallengeAPI.updateLikeState(challengeId: challengeId, feedId: feedId, isLike: isLike)
-    let provider = Provider<ChallengeAPI>(
-      stubBehavior: .immediate,
-      session: .init(interceptor: AuthenticationInterceptor())
-    )
-    
-    guard let result = try? await provider.request(api).value else {
-      throw APIError.serverError
-    }
-    
-    if result.statusCode == 401 || result.statusCode == 403 {
-      throw APIError.authenticationFailed
-    } else if result.statusCode == 404 {
-      throw APIError.userNotFound
-    }
-  }
-}
-
-// MARK: - Delete Methods
-public extension ChallengeRepositoryImpl {
-  func deleteFeedComment(challengeId: Int, feedId: Int, commentId: Int) async throws {
-    let api = ChallengeAPI.deleteFeedComment(challengeId: challengeId, feedId: feedId, commentId: commentId)
-    let provider = Provider<ChallengeAPI>(
-      stubBehavior: .immediate,
-      session: .init(interceptor: AuthenticationInterceptor())
-    )
-    
-    guard let result = try? await provider.request(api).value else {
-      throw APIError.serverError
-    }
-    
-    if result.statusCode == 401 || result.statusCode == 403 {
-      throw APIError.authenticationFailed
-    } else if result.statusCode == 404 {
-      throw APIError.challengeFailed(reason: .challengeNotFound)
     }
   }
 }

--- a/Projects/Data/Repository/Implementations/FeedRepositoryImpl/FeedAPI.swift
+++ b/Projects/Data/Repository/Implementations/FeedRepositoryImpl/FeedAPI.swift
@@ -1,0 +1,124 @@
+//
+//  FeedAPI.swift
+//  DTO
+//
+//  Created by jung on 3/13/25.
+//  Copyright © 2025 com.photi. All rights reserved.
+//
+
+import Foundation
+import Core
+import DTO
+import PhotiNetwork
+
+public enum FeedAPI {
+  case feeds(id: Int, page: Int, size: Int, sortOrder: String)
+  case updateLikeState(challengeId: Int, feedId: Int, isLike: Bool)
+  case feedDetail(challengeId: Int, feedId: Int)
+  case feedComments(feedId: Int, page: Int, size: Int)
+  case uploadFeedComment(challengeId: Int, feedId: Int, comment: String)
+  case deleteFeedComment(challengeId: Int, feedId: Int, commentId: Int)
+}
+
+extension FeedAPI: TargetType {
+  public var baseURL: URL {
+    //    return ServiceConfiguration.baseUrl
+    return URL(string: "http://localhost:8080/api")!
+  }
+  
+  public var path: String {
+    switch self {
+      case let .feeds(id, _, _, _): return "challenges/\(id)/feeds"
+      case let .updateLikeState(challengeId, feedId, _): return "challenges/\(challengeId)/feeds/\(feedId)/like"
+      case let .feedDetail(challengeId, feedId): return "/challenges/\(challengeId)/feeds/\(feedId)"
+      case let .feedComments(feedId, _, _): return "/challenges/feeds/\(feedId)/comments"
+      case let .uploadFeedComment(challengeId, feedId, _):
+        return "/challenges/\(challengeId)feeds/\(feedId)/comments"
+      case let .deleteFeedComment(challengeId, feedId, commentId):
+        return "/challenges/\(challengeId)/feeds/\(feedId)/comments/\(commentId)"
+    }
+  }
+  
+  public var method: HTTPMethod {
+    switch self {
+      case .feeds: return .get
+      case let .updateLikeState(_, _, isLike): return isLike ? .post : .delete
+      case .feedDetail: return .get
+      case .feedComments: return .get
+      case .uploadFeedComment: return .post
+      case .deleteFeedComment: return .delete
+    }
+  }
+  
+  public var task: TaskType {
+    switch self {
+      case let .feeds(challengeId, page, size, ordered):
+        let parameters = ["challengeId": "\(challengeId)", "page": "\(page)", "size": "\(size)", "sort": ordered]
+        return .requestParameters(
+          parameters: parameters,
+          encoding: URLEncoding.queryString
+        )
+        
+      case let .updateLikeState(challengeId, feedId, _), let .feedDetail(challengeId, feedId):
+        let parameters = ["challengeId": challengeId, "feedId": feedId]
+        return .requestParameters(parameters: parameters, encoding: URLEncoding.queryString)
+        
+      case let .feedComments(feedId, page, size):
+        let parameters = ["feedId": "\(feedId)", "page": "\(page)", "size": "\(size)"]
+        return .requestParameters(parameters: parameters, encoding: URLEncoding.queryString)
+        
+      case let .uploadFeedComment(challengeId, feedId, comment):
+        let urlParameters = ["challengeId": challengeId, "feedId": feedId]
+        let bodyParameters = ["comment": comment]
+        return .requestCompositeParameters(bodyParameters: bodyParameters, urlParameters: urlParameters)
+        
+      case let .deleteFeedComment(challengeId, feedId, commentId):
+        let parameters = ["challengeId": challengeId, "feedId": feedId, "commentId": commentId]
+        return .requestParameters(parameters: parameters, encoding: URLEncoding.queryString)
+    }
+  }
+  
+  public var sampleResponse: EndpointSampleResponse {
+    switch self {
+      case .updateLikeState, .deleteFeedComment:
+        let data = """
+          {
+            "code": "200 OK",
+            "message": "성공",
+            "data": {
+              "successMessage": "string"
+            }
+          }
+        """
+        let jsonData = data.data(using: .utf8)
+        
+        return .networkResponse(200, jsonData ?? Data(), "OK", "성공")
+        
+      case .uploadFeedComment:
+        let data = FeedCommentResponseDTO.stubData
+        let jsonData = data.data(using: .utf8)
+        
+        return .networkResponse(200, jsonData ?? Data(), "OK", "성공")
+        
+      case let .feeds(_, page, _, _):
+        let feedsData = [FeedsResponseDTO.stubData, FeedsResponseDTO.stubData2, FeedsResponseDTO.stubData3]
+        let data = feedsData[page]
+        let jsonData = data.data(using: .utf8)
+        
+        return .networkResponse(200, jsonData ?? Data(), "OK", "성공")
+        
+      case .feedDetail:
+        let data = FeedDetailResponseDTO.stubData
+        let jsonData = data.data(using: .utf8)
+        
+        return .networkResponse(200, jsonData ?? Data(), "OK", "성공")
+        
+      case let .feedComments(_, page, _):
+        let page = min(page, 1)
+        let commentsData = [FeedCommentsResponseDTO.stubData1, FeedCommentsResponseDTO.stubData2]
+        let jsonData = commentsData[page].data(using: .utf8)
+        
+        return .networkResponse(200, jsonData ?? Data(), "OK", "성공")
+    }
+  }
+}

--- a/Projects/Data/Repository/Implementations/FeedRepositoryImpl/FeedAPI.swift
+++ b/Projects/Data/Repository/Implementations/FeedRepositoryImpl/FeedAPI.swift
@@ -15,6 +15,7 @@ public enum FeedAPI {
   case feeds(id: Int, page: Int, size: Int, sortOrder: String)
   case updateLikeState(challengeId: Int, feedId: Int, isLike: Bool)
   case feedDetail(challengeId: Int, feedId: Int)
+  case deleteFeed(challengeId: Int, feedId: Int)
   case feedComments(feedId: Int, page: Int, size: Int)
   case uploadFeedComment(challengeId: Int, feedId: Int, comment: String)
   case deleteFeedComment(challengeId: Int, feedId: Int, commentId: Int)
@@ -31,6 +32,7 @@ extension FeedAPI: TargetType {
       case let .feeds(id, _, _, _): return "challenges/\(id)/feeds"
       case let .updateLikeState(challengeId, feedId, _): return "challenges/\(challengeId)/feeds/\(feedId)/like"
       case let .feedDetail(challengeId, feedId): return "/challenges/\(challengeId)/feeds/\(feedId)"
+      case let .deleteFeed(challengeId, feedId): return "/challenges/\(challengeId)/feeds/\(feedId)"
       case let .feedComments(feedId, _, _): return "/challenges/feeds/\(feedId)/comments"
       case let .uploadFeedComment(challengeId, feedId, _):
         return "/challenges/\(challengeId)feeds/\(feedId)/comments"
@@ -46,7 +48,7 @@ extension FeedAPI: TargetType {
       case .feedDetail: return .get
       case .feedComments: return .get
       case .uploadFeedComment: return .post
-      case .deleteFeedComment: return .delete
+      case .deleteFeedComment, .deleteFeed: return .delete
     }
   }
   
@@ -60,6 +62,10 @@ extension FeedAPI: TargetType {
         )
         
       case let .updateLikeState(challengeId, feedId, _), let .feedDetail(challengeId, feedId):
+        let parameters = ["challengeId": challengeId, "feedId": feedId]
+        return .requestParameters(parameters: parameters, encoding: URLEncoding.queryString)
+        
+      case let .deleteFeed(challengeId, feedId):
         let parameters = ["challengeId": challengeId, "feedId": feedId]
         return .requestParameters(parameters: parameters, encoding: URLEncoding.queryString)
         
@@ -80,7 +86,7 @@ extension FeedAPI: TargetType {
   
   public var sampleResponse: EndpointSampleResponse {
     switch self {
-      case .updateLikeState, .deleteFeedComment:
+      case .updateLikeState, .deleteFeedComment, .deleteFeed:
         let data = """
           {
             "code": "200 OK",

--- a/Projects/Data/Repository/Implementations/FeedRepositoryImpl/FeedRepositoryImpl.swift
+++ b/Projects/Data/Repository/Implementations/FeedRepositoryImpl/FeedRepositoryImpl.swift
@@ -144,6 +144,15 @@ public extension FeedRepositoryImpl {
       throw APIError.challengeFailed(reason: .challengeNotFound)
     }
   }
+  
+  func deleteFeed(challengeId: Int, feedId: Int) -> Single<Void> {
+    return requestAuthorizableAPI(
+      api: .deleteFeed(challengeId: challengeId, feedId: feedId),
+      responseType: SuccessResponseDTO.self,
+      behavior: .immediate
+    )
+    .map { _ in }
+  }
 }
 
 // MARK: - Private Methods

--- a/Projects/Data/Repository/Implementations/FeedRepositoryImpl/FeedRepositoryImpl.swift
+++ b/Projects/Data/Repository/Implementations/FeedRepositoryImpl/FeedRepositoryImpl.swift
@@ -1,0 +1,214 @@
+//
+//  FeedRepositoryImpl.swift
+//  DTO
+//
+//  Created by jung on 3/13/25.
+//  Copyright © 2025 com.photi. All rights reserved.
+//
+
+import Foundation
+import RxSwift
+import DataMapper
+import DTO
+import Entity
+import PhotiNetwork
+import Repository
+
+public struct FeedRepositoryImpl: FeedRepository {
+  private let dataMapper: ChallengeDataMapper
+  
+  public init(dataMapper: ChallengeDataMapper) {
+    self.dataMapper = dataMapper
+  }
+}
+
+// MARK: - Fetch Methods
+public extension FeedRepositoryImpl {
+  func fetchFeeds(
+    id: Int,
+    page: Int,
+    size: Int,
+    orderType: ChallengeFeedsOrderType
+  ) async throws -> FeedReturnType {
+    let api = FeedAPI.feeds(
+      id: id,
+      page: page,
+      size: size,
+      sortOrder: orderType.rawValue
+    )
+    
+    let value = try await requestAuthorizableAPI(
+      api: api,
+      responseType: FeedsResponseDTO.self,
+      behavior: .immediate
+    ).value
+    
+    let feeds = value.content.map { data in
+      data.feeds.map { dataMapper.mapToFeed(dto: $0) }
+    }
+    
+    return .init(
+      feeds: feeds,
+      isLast: value.last,
+      memberCount: value.content.first?.feedMemberCnt ?? 0
+    )
+  }
+  
+  func fetchFeed(challengeId: Int, feedId: Int) async throws -> Feed {
+    let api = FeedAPI.feedDetail(challengeId: challengeId, feedId: feedId)
+    let result = try await requestAuthorizableAPI(
+      api: api,
+      responseType: FeedDetailResponseDTO.self,
+      behavior: .immediate
+    ).value
+    
+    return dataMapper.mapToFeed(dto: result, id: challengeId)
+  }
+  
+  func fetchFeedComments(
+    feedId: Int,
+    page: Int,
+    size: Int
+  ) async throws -> (feeds: [FeedComment], isLast: Bool) {
+    let api = FeedAPI.feedComments(feedId: feedId, page: page, size: size)
+    let result = try await requestAuthorizableAPI(
+      api: api,
+      responseType: FeedCommentsResponseDTO.self,
+      behavior: .immediate
+    ).value
+    
+    let feeds = result.content.map { dataMapper.mapToFeedComment(dto: $0) }
+    
+    return (feeds, result.last)
+  }
+}
+
+// MARK: - Update Methods
+public extension FeedRepositoryImpl {
+  func uploadFeedComment(challengeId: Int, feedId: Int, comment: String) async throws -> Int {
+    let api = FeedAPI.uploadFeedComment(challengeId: challengeId, feedId: feedId, comment: comment)
+    let provider = Provider<FeedAPI>(
+      stubBehavior: .immediate,
+      session: .init(interceptor: AuthenticationInterceptor())
+    )
+    
+    guard let result = try? await provider.request(api, type: FeedCommentResponseDTO.self).value else {
+      throw APIError.serverError
+    }
+    
+    if result.statusCode == 401 || result.statusCode == 403 {
+      throw APIError.authenticationFailed
+    } else if result.statusCode == 404 {
+      throw APIError.challengeFailed(reason: .challengeNotFound)
+    }
+    
+    guard let id = result.data?.id else { throw APIError.serverError }
+    return id
+  }
+  
+  func updateLikeState(challengeId: Int, feedId: Int, isLike: Bool) async throws {
+    let api = FeedAPI.updateLikeState(challengeId: challengeId, feedId: feedId, isLike: isLike)
+    let provider = Provider<FeedAPI>(
+      stubBehavior: .immediate,
+      session: .init(interceptor: AuthenticationInterceptor())
+    )
+    
+    guard let result = try? await provider.request(api).value else {
+      throw APIError.serverError
+    }
+    
+    if result.statusCode == 401 || result.statusCode == 403 {
+      throw APIError.authenticationFailed
+    } else if result.statusCode == 404 {
+      throw APIError.userNotFound
+    }
+  }
+}
+
+// MARK: - Delete Methods
+public extension FeedRepositoryImpl {
+  func deleteFeedComment(challengeId: Int, feedId: Int, commentId: Int) async throws {
+    let api = FeedAPI.deleteFeedComment(challengeId: challengeId, feedId: feedId, commentId: commentId)
+    let provider = Provider<FeedAPI>(
+      stubBehavior: .immediate,
+      session: .init(interceptor: AuthenticationInterceptor())
+    )
+    
+    guard let result = try? await provider.request(api).value else {
+      throw APIError.serverError
+    }
+    
+    if result.statusCode == 401 || result.statusCode == 403 {
+      throw APIError.authenticationFailed
+    } else if result.statusCode == 404 {
+      throw APIError.challengeFailed(reason: .challengeNotFound)
+    }
+  }
+}
+
+// MARK: - Private Methods
+private extension FeedRepositoryImpl {
+  func requestAuthorizableAPI<T: Decodable>(
+    api: FeedAPI,
+    responseType: T.Type,
+    behavior: StubBehavior = .immediate
+  ) -> Single<T> {
+    return Single.create { single in
+      Task {
+        do {
+          let provider = Provider<FeedAPI>(
+            stubBehavior: behavior,
+            session: .init(interceptor: AuthenticationInterceptor())
+          )
+          
+          let result = try await provider.request(api, type: responseType.self).value
+          
+          if (200..<300).contains(result.statusCode), let data = result.data {
+            single(.success(data))
+          } else if result.statusCode == 400 {
+            single(.failure(APIError.challengeFailed(reason: .invalidInvitationCode)))
+          } else if result.statusCode == 401 || result.statusCode == 403 {
+            single(.failure(APIError.authenticationFailed))
+          } else if result.statusCode == 404 {
+            single(.failure(APIError.challengeFailed(reason: .challengeNotFound)))
+          } else if result.statusCode == 409 {
+            single(.failure(APIError.challengeFailed(reason: .alreadyJoinedChallenge)))
+          } else {
+            single(.failure(APIError.serverError))
+          }
+        } catch {
+          single(.failure(error))
+        }
+      }
+      return Disposables.create()
+    }
+  }
+  
+  func requestUnAuthorizableAPI<T: Decodable>(
+    api: FeedAPI,
+    responseType: T.Type,
+    behavior: StubBehavior = .immediate
+  ) -> Single<T> {
+    Single.create { single in
+      Task {
+        do {
+          let provider = Provider<FeedAPI>(stubBehavior: behavior)
+          let result = try await provider
+            .request(api, type: responseType.self).value
+          
+          if (200..<300).contains(result.statusCode), let data = result.data {
+            single(.success(data))
+          } else if result.statusCode == 404 {
+            single(.failure(APIError.challengeFailed(reason: .challengeNotFound)))
+          } else {
+            single(.failure(APIError.serverError))
+          }
+        } catch {
+          single(.failure(error))
+        }
+      }
+      
+      return Disposables.create()
+    }
+  }
+}

--- a/Projects/DesignSystem/Sources/Button/IconButton/IconButton.swift
+++ b/Projects/DesignSystem/Sources/Button/IconButton/IconButton.swift
@@ -65,6 +65,14 @@ public final class IconButton: UIButton {
     addTarget(self, action: #selector(didTap), for: .touchUpInside)
   }
   
+  public convenience init(selectedIcon: UIImage, size: ButtonSize) {
+    self.init(
+      selectedIcon: selectedIcon,
+      unSelectedIcon: selectedIcon,
+      size: size
+    )
+  }
+  
   public convenience init(size: ButtonSize) {
     self.init(
       selectedIcon: .heartFilledWhite,

--- a/Projects/DesignSystem/Sources/DropDown/DropDownView.swift
+++ b/Projects/DesignSystem/Sources/DropDown/DropDownView.swift
@@ -29,9 +29,7 @@ public final class DropDownView: UIView {
   
   /// DropDown을 display여부를 확인 및 설정할 수 있습니다.
   public var isDisplayed: Bool {
-    get {
-      dropDownMode == .display
-    }
+    get { dropDownMode == .display }
     set {
       if newValue {
         becomeFirstResponder()
@@ -71,6 +69,7 @@ public final class DropDownView: UIView {
   public convenience init(anchorView: UIView) {
     self.init()
     self.anchorView = anchorView
+    setupAnchorView(anchorView)
   }
   
   @available(*, unavailable)
@@ -142,8 +141,8 @@ extension DropDownView: UITableViewDataSource {
 // MARK: - UITableViewDelegate
 extension DropDownView: UITableViewDelegate {
   public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-    delegate?.dropDown(self, didSelectRowAt: indexPath.row)
     resignFirstResponder()
+    delegate?.dropDown(self, didSelectRowAt: indexPath.section)
   }
 }
 
@@ -178,8 +177,8 @@ public extension DropDownView {
     guard let window else { return }
     UIView.transition(with: window, duration: 0.3, options: .transitionCrossDissolve) { [weak self] in
       guard let self else { return }
-      self.dropDownTableView.removeFromSuperview()
       self.dropDownTableView.snp.removeConstraints()
+      self.dropDownTableView.removeFromSuperview()
     }
   }
   

--- a/Projects/DesignSystem/Sources/Popup/Alert/AlertViewController.swift
+++ b/Projects/DesignSystem/Sources/Popup/Alert/AlertViewController.swift
@@ -53,7 +53,12 @@ final public class AlertViewController: UIViewController {
   }()
   
   private let mainTitleLabel = UILabel()
-  private lazy var subTitleLabel = UILabel()
+  private lazy var subTitleLabel: UILabel = {
+    let label = UILabel()
+    label.numberOfLines = 0
+    label.textAlignment = .center
+    return label
+  }()
   
   fileprivate let confirmButton: FilledRoundButton
   fileprivate lazy var cancelButton: FilledRoundButton = FilledRoundButton(type: .quaternary, size: .small, text: "취소")
@@ -80,6 +85,15 @@ final public class AlertViewController: UIViewController {
     
     setupUI()
     bind()
+  }
+  
+  public convenience init(
+    alertType: AlertType,
+    title: String,
+    attributedSubTitle: NSAttributedString
+  ) {
+    self.init(alertType: alertType, title: title, subTitle: "")
+    subTitleLabel.attributedText = attributedSubTitle
   }
   
   @available(*, unavailable)
@@ -213,7 +227,8 @@ private extension AlertViewController {
   func setSubTitle(_ text: String) {
     self.subTitleLabel.attributedText = text.attributedString(
       font: .body2,
-      color: .gray600
+      color: .gray600,
+      alignment: .center
     )
   }
   

--- a/Projects/Domain/Repository/Interfaces/ChallengeRepository.swift
+++ b/Projects/Domain/Repository/Interfaces/ChallengeRepository.swift
@@ -22,4 +22,5 @@ public protocol ChallengeRepository {
   func fetchMyChallenges(page: Int, size: Int) -> Single<[ChallengeSummary]>
   func fetchChallengeDescription(challengeId: Int) -> Single<ChallengeDescription>
   func fetchChallengeMembers(challengeId: Int) -> Single<[ChallengeMember]>
+  func leaveChallenge(id: Int) -> Single<Void>
 }

--- a/Projects/Domain/Repository/Interfaces/ChallengeRepository.swift
+++ b/Projects/Domain/Repository/Interfaces/ChallengeRepository.swift
@@ -10,18 +10,6 @@ import Foundation
 import RxSwift
 import Entity
 
-public struct FeedReturnType {
-  public let feeds: [[Feed]]
-  public let isLast: Bool
-  public let memberCount: Int
-  
-  public init(feeds: [[Feed]], isLast: Bool, memberCount: Int) {
-    self.feeds = feeds
-    self.isLast = isLast
-    self.memberCount = memberCount
-  }
-}
-
 public protocol ChallengeRepository {
   func fetchPopularChallenges() -> Single<[ChallengeDetail]>
   func fetchEndedChallenges(page: Int, size: Int) -> Single<[ChallengeSummary]>
@@ -29,22 +17,7 @@ public protocol ChallengeRepository {
   func joinPublicChallenge(id: Int) -> Single<Void>
   func joinPrivateChallnege(id: Int, code: String) -> Single<Void>
   func uploadChallengeFeedProof(id: Int, image: Data, imageType: String) async throws
-  func updateLikeState(challengeId: Int, feedId: Int, isLike: Bool) async throws
   func isProve(challengeId: Int) async throws -> Bool
-  func fetchFeeds(
-    id: Int,
-    page: Int,
-    size: Int,
-    orderType: ChallengeFeedsOrderType
-  ) async throws -> FeedReturnType
-  func fetchFeed(challengeId: Int, feedId: Int) async throws -> Feed
-  func fetchFeedComments(
-    feedId: Int,
-    page: Int,
-    size: Int
-  ) async throws -> (feeds: [FeedComment], isLast: Bool)
-  func uploadFeedComment(challengeId: Int, feedId: Int, comment: String) async throws -> Int
-  func deleteFeedComment(challengeId: Int, feedId: Int, commentId: Int) async throws
   func updateChallengeGoal(_ goal: String, challengeId: Int) -> Single<Void>
   func fetchMyChallenges(page: Int, size: Int) -> Single<[ChallengeSummary]>
   func fetchChallengeDescription(challengeId: Int) -> Single<ChallengeDescription>

--- a/Projects/Domain/Repository/Interfaces/FeedRepository.swift
+++ b/Projects/Domain/Repository/Interfaces/FeedRepository.swift
@@ -1,0 +1,31 @@
+//
+//  FeedRepository.swift
+//  Entity
+//
+//  Created by jung on 3/13/25.
+//  Copyright © 2025 com.photi. All rights reserved.
+//
+
+import RxSwift
+import Entity
+
+public struct FeedReturnType {
+  public let feeds: [[Feed]]
+  public let isLast: Bool
+  public let memberCount: Int
+  
+  public init(feeds: [[Feed]], isLast: Bool, memberCount: Int) {
+    self.feeds = feeds
+    self.isLast = isLast
+    self.memberCount = memberCount
+  }
+}
+
+public protocol FeedRepository {
+  func updateLikeState(challengeId: Int, feedId: Int, isLike: Bool) async throws
+  func fetchFeeds(id: Int, page: Int, size: Int, orderType: ChallengeFeedsOrderType) async throws -> FeedReturnType
+  func fetchFeed(challengeId: Int, feedId: Int) async throws -> Feed
+  func fetchFeedComments(feedId: Int, page: Int, size: Int) async throws -> (feeds: [FeedComment], isLast: Bool)
+  func uploadFeedComment(challengeId: Int, feedId: Int, comment: String) async throws -> Int
+  func deleteFeedComment(challengeId: Int, feedId: Int, commentId: Int) async throws
+}

--- a/Projects/Domain/Repository/Interfaces/FeedRepository.swift
+++ b/Projects/Domain/Repository/Interfaces/FeedRepository.swift
@@ -28,4 +28,5 @@ public protocol FeedRepository {
   func fetchFeedComments(feedId: Int, page: Int, size: Int) async throws -> (feeds: [FeedComment], isLast: Bool)
   func uploadFeedComment(challengeId: Int, feedId: Int, comment: String) async throws -> Int
   func deleteFeedComment(challengeId: Int, feedId: Int, commentId: Int) async throws
+  func deleteFeed(challengeId: Int, feedId: Int) -> Single<Void>
 }

--- a/Projects/Domain/UseCase/Implementations/ChallengeUseCaseImpl.swift
+++ b/Projects/Domain/UseCase/Implementations/ChallengeUseCaseImpl.swift
@@ -15,13 +15,19 @@ import UseCase
 import Repository
 
 public struct ChallengeUseCaseImpl: ChallengeUseCase {
-  private let repository: ChallengeRepository
+  private let challengeRepository: ChallengeRepository
+  private let feedRepository: FeedRepository
   private let authRepository: AuthRepository
   private let challengeProveMemberCountRelay = BehaviorRelay<Int>(value: 0)
   public let challengeProveMemberCount: Infallible<Int>
   
-  public init(repository: ChallengeRepository, authRepository: AuthRepository) {
-    self.repository = repository
+  public init(
+    challengeRepository: ChallengeRepository,
+    feedRepository: FeedRepository,
+    authRepository: AuthRepository
+  ) {
+    self.challengeRepository = challengeRepository
+    self.feedRepository = feedRepository
     self.authRepository = authRepository
     
     self.challengeProveMemberCount = challengeProveMemberCountRelay.asInfallible()
@@ -31,7 +37,7 @@ public struct ChallengeUseCaseImpl: ChallengeUseCase {
 // MARK: - Fetch Methods
 public extension ChallengeUseCaseImpl {
   func fetchChallengeDetail(id: Int) -> Single<ChallengeDetail> {
-    return repository.fetchChallengeDetail(id: id)
+    return challengeRepository.fetchChallengeDetail(id: id)
   }
   
   func isLogIn() async -> Bool {
@@ -39,7 +45,7 @@ public extension ChallengeUseCaseImpl {
   }
   
   func fetchFeeds(id: Int, page: Int, size: Int, orderType: ChallengeFeedsOrderType) async throws -> PageFeeds {
-    let result = try await repository.fetchFeeds(id: id, page: page, size: size, orderType: orderType)
+    let result = try await feedRepository.fetchFeeds(id: id, page: page, size: size, orderType: orderType)
     
     if challengeProveMemberCountRelay.value != result.memberCount {
       challengeProveMemberCountRelay.accept(result.memberCount)
@@ -49,22 +55,22 @@ public extension ChallengeUseCaseImpl {
   }
   
   func fetchChallengeDescription(id: Int) -> Single<ChallengeDescription> {
-    return repository.fetchChallengeDescription(challengeId: id)
+    return challengeRepository.fetchChallengeDescription(challengeId: id)
   }
   
   func fetchChallengeMembers(challengeId: Int) -> Single<[ChallengeMember]> {
-    return repository.fetchChallengeMembers(challengeId: challengeId)
+    return challengeRepository.fetchChallengeMembers(challengeId: challengeId)
   }
 }
 
 // MARK: - Upload & Update Methods
 public extension ChallengeUseCaseImpl {
   func joinPrivateChallnege(id: Int, code: String) async throws {
-    try await repository.joinPrivateChallnege(id: id, code: code).value
+    try await challengeRepository.joinPrivateChallnege(id: id, code: code).value
   }
   
   func joinPublicChallenge(id: Int) -> Single<Void> {
-    return repository.joinPublicChallenge(id: id)
+    return challengeRepository.joinPublicChallenge(id: id)
   }
   
   func uploadChallengeFeedProof(id: Int, image: UIImageWrapper) async throws {
@@ -72,7 +78,7 @@ public extension ChallengeUseCaseImpl {
       throw APIError.challengeFailed(reason: .fileTooLarge)
     }
     
-    try await repository.uploadChallengeFeedProof(
+    try await challengeRepository.uploadChallengeFeedProof(
       id: id,
       image: data,
       imageType: type
@@ -80,15 +86,15 @@ public extension ChallengeUseCaseImpl {
   }
   
   func updateLikeState(challengeId: Int, feedId: Int, isLike: Bool) async throws {
-    return try await repository.updateLikeState(challengeId: challengeId, feedId: feedId, isLike: isLike)
+    return try await feedRepository.updateLikeState(challengeId: challengeId, feedId: feedId, isLike: isLike)
   }
   
   func isProve(challengeId: Int) async throws -> Bool {
-    return try await repository.isProve(challengeId: challengeId)
+    return try await challengeRepository.isProve(challengeId: challengeId)
   }
   
   func updateChallengeGoal(_ goal: String, challengeId: Int) -> Single<Void> {
-    return repository.updateChallengeGoal(goal, challengeId: challengeId)
+    return challengeRepository.updateChallengeGoal(goal, challengeId: challengeId)
   }
 }
 

--- a/Projects/Domain/UseCase/Implementations/ChallengeUseCaseImpl.swift
+++ b/Projects/Domain/UseCase/Implementations/ChallengeUseCaseImpl.swift
@@ -98,6 +98,13 @@ public extension ChallengeUseCaseImpl {
   }
 }
 
+// MARK: - Delete Methods
+public extension ChallengeUseCaseImpl {
+  func leaveChallenge(id: Int) -> Single<Void> {
+    return challengeRepository.leaveChallenge(id: id)
+  }
+}
+
 // MARK: - Private Methods
 private extension ChallengeUseCaseImpl {
  func imageToData(_ image: UIImageWrapper, maxMB: Int) -> (image: Data, type: String)? {

--- a/Projects/Domain/UseCase/Implementations/FeedUseCaseImpl.swift
+++ b/Projects/Domain/UseCase/Implementations/FeedUseCaseImpl.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2025 com.photi. All rights reserved.
 //
 
+import RxSwift
 import Entity
 import Repository
 import UseCase
@@ -49,5 +50,9 @@ public struct FeedUseCaseImpl: FeedUseCase {
   
   public func deleteFeedComment(challengeId: Int, feedId: Int, commentId: Int) async throws {
     try await repository.deleteFeedComment(challengeId: challengeId, feedId: feedId, commentId: commentId)
+  }
+  
+  public func deleteFeed(challengeId: Int, feedId: Int) -> Single<Void> {
+    return repository.deleteFeed(challengeId: challengeId, feedId: feedId)
   }
 }

--- a/Projects/Domain/UseCase/Implementations/FeedUseCaseImpl.swift
+++ b/Projects/Domain/UseCase/Implementations/FeedUseCaseImpl.swift
@@ -11,9 +11,9 @@ import Repository
 import UseCase
 
 public struct FeedUseCaseImpl: FeedUseCase {
-  private let repository: ChallengeRepository
+  private let repository: FeedRepository
   
-  public init(repository: ChallengeRepository) {
+  public init(repository: FeedRepository) {
     self.repository = repository
   }
   

--- a/Projects/Domain/UseCase/Interfaces/ChallengeUseCase.swift
+++ b/Projects/Domain/UseCase/Interfaces/ChallengeUseCase.swift
@@ -35,4 +35,5 @@ public protocol ChallengeUseCase {
   func updateChallengeGoal(_ goal: String, challengeId: Int) -> Single<Void>
   func fetchChallengeDescription(id: Int) -> Single<ChallengeDescription>
   func fetchChallengeMembers(challengeId: Int) -> Single<[ChallengeMember]>
+  func leaveChallenge(id: Int) -> Single<Void>
 }

--- a/Projects/Domain/UseCase/Interfaces/FeedUseCase.swift
+++ b/Projects/Domain/UseCase/Interfaces/FeedUseCase.swift
@@ -7,6 +7,7 @@
 //
 
 import Entity
+import RxSwift
 
 public enum FeedCommentsPage {
   case `default`([FeedComment])
@@ -19,4 +20,5 @@ public protocol FeedUseCase {
   func fetchFeedComments(feedId: Int, page: Int, size: Int) async throws -> FeedCommentsPage
   func uploadFeedComment(challengeId: Int, feedId: Int, comment: String) async throws -> Int
   func deleteFeedComment(challengeId: Int, feedId: Int, commentId: Int) async throws
+  func deleteFeed(challengeId: Int, feedId: Int) -> Single<Void>
 }

--- a/Projects/Presentation/Challenge/Implementations/Member/ChallengeContainer.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/ChallengeContainer.swift
@@ -8,9 +8,11 @@
 
 import Challenge
 import Core
+import Report
 import UseCase
 
 public protocol ChallengeDependency: Dependency {
+  var reportContainable: ReportContainable { get }
   var challengeUseCase: ChallengeUseCase { get }
   var feedUseCase: FeedUseCase { get }
 }
@@ -34,7 +36,8 @@ public final class ChallengeContainer:
       viewModel: viewModel,
       feedContainer: feedContainer,
       descriptionContainer: descriptionContainer,
-      participantContainer: participantContainer
+      participantContainer: participantContainer,
+      reportContainer: dependency.reportContainable
     )
     coordinator.listener = listener
     return coordinator

--- a/Projects/Presentation/Challenge/Implementations/Member/ChallengeCoordinator.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/ChallengeCoordinator.swift
@@ -8,6 +8,7 @@
 
 import Core
 import Challenge
+import Report
 
 protocol ChallengePresentable {
   func attachViewControllerables(_ viewControllerables: ViewControllerable...)
@@ -31,17 +32,22 @@ final class ChallengeCoordinator: ViewableCoordinator<ChallengePresentable> {
   private let descriptionContainer: DescriptionContainable
   private var descriptionCoordinator: ViewableCoordinating?
   
+  private let reportContainer: ReportContainable
+  private var reportCoordinator: ViewableCoordinating?
+  
   init(
     viewControllerable: ViewControllerable,
     viewModel: ChallengeViewModel,
     feedContainer: FeedContainable,
     descriptionContainer: DescriptionContainable,
-    participantContainer: ParticipantContainable
+    participantContainer: ParticipantContainable,
+    reportContainer: ReportContainable
   ) {
     self.viewModel = viewModel
     self.feedContainer = feedContainer
     self.descriptionContainer = descriptionContainer
     self.participantContainer = participantContainer
+    self.reportContainer = reportContainer
     super.init(viewControllerable)
     viewModel.coordinator = self
   }
@@ -89,7 +95,14 @@ extension ChallengeCoordinator: ChallengeCoordinatable {
     listener?.didTapBackButtonAtChallenge()
   }
   
-  func attachReport() { }
+  func attachReport() {
+    guard reportCoordinator == nil else { return }
+    
+    let coordinator = reportContainer.coordinator(listener: self, reportType: .challenge)
+    addChild(coordinator)
+    viewControllerable.pushViewController(coordinator.viewControllerable, animated: true)
+    self.reportCoordinator = coordinator
+  }
   
   func leaveChallenge(isLastMember: Bool) {
     listener?.leaveChallenge(isDelete: isLastMember)
@@ -146,5 +159,15 @@ extension ChallengeCoordinator: ParticipantListener {
   
   func requestLoginAtPariticipant() {
     listener?.requestLoginAtChallenge()
+  }
+}
+
+// MARK: - ReportListener
+extension ChallengeCoordinator: ReportListener {
+  func detachReport() {
+    guard let coordinator = reportCoordinator else { return }
+    removeChild(coordinator)
+    viewControllerable.popViewController(animated: true)
+    self.reportCoordinator = nil
   }
 }

--- a/Projects/Presentation/Challenge/Implementations/Member/ChallengeCoordinator.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/ChallengeCoordinator.swift
@@ -88,6 +88,12 @@ extension ChallengeCoordinator: ChallengeCoordinatable {
   func didTapBackButton() {
     listener?.didTapBackButtonAtChallenge()
   }
+  
+  func attachReport() { }
+  
+  func leaveChallenge(isLastMember: Bool) {
+    listener?.leaveChallenge(isDelete: isLastMember)
+  }
 }
 
 // MARK: - FeedListener

--- a/Projects/Presentation/Challenge/Implementations/Member/ChallengeViewController.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/ChallengeViewController.swift
@@ -24,20 +24,26 @@ final class ChallengeViewController: UIViewController, ViewControllerable {
   private let viewModel: ChallengeViewModel
   private let disposeBag = DisposeBag()
   private var segmentIndex: Int = 0
+  private var memberCount: Int = 0
+  private let dropDownData = ["챌린지 신고하기", "챌린지 탈퇴하기"]
   
   private let viewDidLoadRelay = PublishRelay<Void>()
   private let didTapConfirmButtonAtAlert = PublishRelay<Void>()
   private let didTapLoginButtonAtAlert = PublishRelay<Void>()
+  private let didTapReportButton = PublishRelay<Void>()
+  private let didTapLeaveButton = PublishRelay<Void>()
   
   // MARK: - UI Components
   private var segmentViewControllers = [UIViewController]()
-  private let navigationBar = PhotiNavigationBar(
+  private let navigationOptionButton = PhotiNavigationButton.optionButton
+  private lazy var navigationBar = PhotiNavigationBar(
     leftView: .backButton,
-    rigthItems: [.shareButton, .optionButton],
+    rigthItems: [.shareButton, navigationOptionButton],
     displayMode: .white
   )
   private let titleView = ChallengeTitleView()
   private let segmentControl = PhotiSegmentControl(items: ["피드", "소개", "파티원"])
+  private lazy var dropDownView = DropDownView(anchorView: navigationOptionButton)
   private let mainView = UIView()
   private let mainContentView: UIView = {
     let view = UIView()
@@ -61,12 +67,19 @@ final class ChallengeViewController: UIViewController, ViewControllerable {
     super.viewDidLoad()
     setupUI()
     bind()
+    dropDownView.dataSource = dropDownData
+    dropDownView.delegate = self
     viewDidLoadRelay.accept(())
   }
   
   override func viewDidAppear(_ animated: Bool) {
     super.viewDidAppear(animated)
     hideTabBar(animated: true)
+  }
+  
+  // MARK: - UI Responder
+  override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+    view.endEditing(true)
   }
 }
 
@@ -78,7 +91,7 @@ private extension ChallengeViewController {
   }
   
   func setViewHierarhcy() {
-    view.addSubviews(titleView, navigationBar, mainView)
+    view.addSubviews(titleView, navigationBar, mainView, dropDownView)
     mainView.addSubviews(segmentControl, mainContentView)
   }
   
@@ -108,6 +121,13 @@ private extension ChallengeViewController {
       $0.top.equalTo(segmentControl.snp.bottom)
       $0.bottom.trailing.leading.equalToSuperview()
     }
+    
+    dropDownView.setConstraints { [weak self] make in
+      guard let self else { return }
+      make.trailing.equalToSuperview().inset(24)
+      make.top.equalTo(view.safeAreaLayoutGuide).offset(44)
+      make.width.equalTo(130)
+    }
   }
 }
 
@@ -118,7 +138,9 @@ private extension ChallengeViewController {
       viewDidLoad: viewDidLoadRelay.asSignal(),
       didTapBackButton: navigationBar.rx.didTapBackButton.asSignal(),
       didTapConfirmButtonAtAlert: didTapConfirmButtonAtAlert.asSignal(),
-      didTapLoginButtonAtAlert: didTapLoginButtonAtAlert.asSignal()
+      didTapLoginButtonAtAlert: didTapLoginButtonAtAlert.asSignal(),
+      didTapLeaveButton: didTapLeaveButton.asSignal(),
+      didTapReportButton: didTapReportButton.asSignal()
     )
     
     let output = viewModel.transform(input: input)
@@ -141,15 +163,25 @@ private extension ChallengeViewController {
       }
       .disposed(by: disposeBag)
     
+    output.memberCount
+      .drive(rx.memberCount)
+      .disposed(by: disposeBag)
+    
     output.challengeNotFound
       .emit(with: self) { owner, _ in
         owner.presentChallengeNotFoundWaring()
       }
       .disposed(by: disposeBag)
     
-    output.requestFailed
+    output.networnUnstable
       .emit(with: self) { owner, _ in
         owner.presentNetworkWarning(reason: nil)
+      }
+      .disposed(by: disposeBag)
+    
+    output.loginTrigger
+      .emit(with: self) { owner, _ in
+        owner.presentLoginTrrigerWarning()
       }
       .disposed(by: disposeBag)
   }
@@ -200,6 +232,17 @@ extension ChallengeViewController: ChallengePresentable {
   }
 }
 
+// MARK: - DropDownDelegate
+extension ChallengeViewController: DropDownDelegate {
+  func dropDown(_ dropDown: DropDownView, didSelectRowAt: Int) {
+    if didSelectRowAt == 0 {
+      didTapReportButton.accept(())
+    } else {
+      presentLeaveChallengeAlert(memberCount: memberCount)
+    }
+  }
+}
+
 // MARK: - Private Methods
 private extension ChallengeViewController {
   func updateSegmentViewController(to index: Int) {
@@ -228,6 +271,40 @@ private extension ChallengeViewController {
     mainContentView.addSubview(viewController.view)
     viewController.view.snp.makeConstraints {
       $0.edges.equalToSuperview()
+    }
+  }
+  
+  func presentLeaveChallengeAlert(memberCount: Int) {
+    let alert = AlertViewController(
+      alertType: .canCancel,
+      title: "챌린지를 탈퇴할까요?",
+      attributedSubTitle: leaveChallengeString(memberCount: 1)
+    )
+    alert.confirmButtonTitle = "탈퇴할게요"
+    alert.cancelButtonTitle = "취소할게요"
+    
+    alert.rx.didTapConfirmButton
+      .bind(to: didTapLeaveButton)
+      .disposed(by: disposeBag)
+    
+    alert.present(to: self, animted: true)
+  }
+  
+  func leaveChallengeString(memberCount: Int) -> NSAttributedString {
+    if memberCount == 1 {
+      return "회원님은 이 챌린지의 마지막 파티원예요.\n지금 탈퇴하면 챌린지가 삭제돼요.\n삭제된 챌린지는 복구할 수 없어요.\n정말 탈퇴하시겠어요?".attributedString(
+        font: .body2,
+        color: .gray600,
+        alignment: .center
+      )
+      .setColor(.red400, for: "챌린지가 삭제돼요.")
+      .setColor(.red400, for: "삭제된 챌린지는 복구할 수 없어요.")
+    } else {
+      return "탈퇴해도 기록은 남아있어요.\n탈퇴하시기 전에 직접 지워주세요.".attributedString(
+        font: .body2,
+        color: .gray600,
+        alignment: .center
+      )
     }
   }
 }

--- a/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedComment/FeedCommentCoordinator.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedComment/FeedCommentCoordinator.swift
@@ -10,6 +10,7 @@ import Core
 
 protocol FeedCommentListener: AnyObject {
   func requestDismissAtFeedComment()
+  func deleteFeed(id: Int)
   func authenticatedFailedAtFeedComment()
   func networkUnstableAtFeedComment(reason: String?)
 }
@@ -35,6 +36,10 @@ final class FeedCommentCoordinator: ViewableCoordinator<FeedCommentPresentable> 
 extension FeedCommentCoordinator: FeedCommentCoordinatable {
   func requestDismiss() {
     listener?.requestDismissAtFeedComment()
+  }
+  
+  func deleteFeed(id: Int) {
+    listener?.deleteFeed(id: id)
   }
   
   func authenticatedFailed() {

--- a/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedComment/FeedCommentViewModel.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedComment/FeedCommentViewModel.swift
@@ -9,6 +9,7 @@
 import Foundation
 import RxCocoa
 import RxSwift
+import Core
 import Entity
 import UseCase
 
@@ -55,6 +56,8 @@ final class FeedCommentViewModel: FeedCommentViewModelType {
     let requestComments: Signal<Void>
     let requestData: Signal<Void>
     let didTapLikeButton: Signal<Bool>
+    let didTapShareButton: Signal<Void>
+    let didTapDeleteButton: Signal<Void>
     let requestDeleteComment: Signal<Int>
     let requestUploadComment: Signal<String>
   }
@@ -63,6 +66,7 @@ final class FeedCommentViewModel: FeedCommentViewModelType {
   struct Output {
     let feedImageURL: Driver<URL?>
     let updateTime: Driver<String>
+    let isEditable: Driver<Bool>
     let author: Driver<AuthorPresentationModel>
     let likeCount: Driver<Int>
     let isLike: Driver<Bool>
@@ -101,9 +105,12 @@ final class FeedCommentViewModel: FeedCommentViewModelType {
       }
       .disposed(by: disposeBag)
     
+    let isEditable = authorRelay.map { $0.name == ServiceConfiguration.shared.userName }
+    
     return Output(
       feedImageURL: feedImageURLRelay.asDriver(),
       updateTime: updateTimeRelay.asDriver(),
+      isEditable: isEditable.asDriver(onErrorJustReturn: false),
       author: authorRelay.asDriver(),
       likeCount: likeCountRelay.asDriver(),
       isLike: isLikeRelay.asDriver(),

--- a/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedComment/Views/FeedCommentTopView.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedComment/Views/FeedCommentTopView.swift
@@ -34,12 +34,17 @@ final class FeedCommentTopView: UIView {
     didSet { likeButton.isSelected = isLike }
   }
   
+  var isEnbledOptionButton: Bool = false {
+    didSet { optionButton.isHidden = !isEnbledOptionButton }
+  }
+  
   // MARK: - UI Components
   private let topGradientLayer = FeedCommentGradientLayer(mode: .topToBottom, maxAlpha: 0.7)
   private let avatarImageView = AvatarImageView(size: .xSmall)
   private let userNameLabel = UILabel()
   private let updateTimeLabel = UILabel()
   fileprivate let likeButton = IconButton(size: .small)
+  let optionButton = IconButton(selectedIcon: .ellipsisVerticalWhite, size: .small)
   private let likeCountLabel = UILabel()
   
   // MARK: - Initializers
@@ -74,6 +79,7 @@ private extension FeedCommentTopView {
       userNameLabel,
       updateTimeLabel,
       likeButton,
+      optionButton,
       likeCountLabel
     )
   }
@@ -96,6 +102,11 @@ private extension FeedCommentTopView {
     
     likeButton.snp.makeConstraints {
       $0.top.trailing.equalToSuperview().inset(18)
+    }
+    
+    optionButton.snp.makeConstraints {
+      $0.centerY.equalTo(likeButton)
+      $0.trailing.equalTo(likeButton.snp.leading).offset(-12)
     }
     
     likeCountLabel.snp.makeConstraints {

--- a/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedCoordinator.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedCoordinator.swift
@@ -15,7 +15,9 @@ protocol FeedListener: AnyObject {
   func challengeNotFoundAtFeed()
 }
 
-protocol FeedPresentable { }
+protocol FeedPresentable {
+  func deleteFeed(feedId: Int)
+}
 
 final class FeedCoordinator: ViewableCoordinator<FeedPresentable> {
   weak var listener: FeedListener?
@@ -58,11 +60,13 @@ extension FeedCoordinator: FeedCoordinatable {
   }
   
   // MARK: - Detach
-  func detachFeedDetail() {
+  func detachFeedDetail(completion: (() -> Void)? = nil) {
     guard let coordinator = feedCommentCoordinator else { return }
     
     removeChild(coordinator)
-    coordinator.viewControllerable.dismiss(animated: true)
+    coordinator.viewControllerable.dismiss(animated: true) {
+      completion?()
+    }
     self.feedCommentCoordinator = nil
   }
   
@@ -87,6 +91,12 @@ extension FeedCoordinator: FeedCoordinatable {
 extension FeedCoordinator: FeedCommentListener {
   func requestDismissAtFeedComment() {
     detachFeedDetail()
+  }
+  
+  func deleteFeed(id: Int) {
+    detachFeedDetail { [weak self] in
+      self?.presenter.deleteFeed(feedId: id)
+    }
   }
   
   func authenticatedFailedAtFeedComment() {

--- a/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedViewController.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedViewController.swift
@@ -277,7 +277,16 @@ private extension FeedViewController {
 }
 
 // MARK: - FeedPresentable
-extension FeedViewController: FeedPresentable { }
+extension FeedViewController: FeedPresentable {
+  func deleteFeed(feedId: Int) {
+    guard let dataSource else { return }
+    var snapshot = dataSource.snapshot()
+    
+    guard let model = snapshot.itemIdentifiers.first(where: { $0.id == feedId }) else { return }
+    snapshot.deleteItems([model])
+    dataSource.apply(snapshot)
+  }
+}
 
 // MARK: - UICollectionViewDiffableDataSource
 extension FeedViewController {

--- a/Projects/Presentation/Challenge/Interfaces/Challenge.swift
+++ b/Projects/Presentation/Challenge/Interfaces/Challenge.swift
@@ -16,4 +16,5 @@ public protocol ChallengeListener: AnyObject {
   func didTapBackButtonAtChallenge()
   func shouldDismissChallenge()
   func requestLoginAtChallenge()
+  func leaveChallenge(isDelete: Bool)
 }


### PR DESCRIPTION
## 관련 이슈

- #222 

## 작업 설명

- 피드 삭제 및 챌린지 삭제 기능 추가 
- 신고하기 기능 추가
- Challenge와 Feed Repository 분리 

Feed와 Challenge Repository가 비대해져서 분리했습니다. 

## 스크린샷
![Simulator Screen Recording - iPhone 16 Pro - 2025-03-18 at 12 54 45](https://github.com/user-attachments/assets/07df3a76-98d5-45bc-bdec-7605b46e17d0)
