### PR TITLE
[FEAT]: 챌린지 없을 경우 Home 실제 서버와 연동 완료

### DIFF
--- a/Projects/App/Sources/AppContainer.swift
+++ b/Projects/App/Sources/AppContainer.swift
@@ -37,7 +37,6 @@ final class AppContainer:
   SearchChallengeDependency,
   MyPageDependency,
   ReportDependency {
-  
   func coordinator() -> ViewableCoordinating {
     let viewControllerable = AppViewController()
     
@@ -96,7 +95,7 @@ final class AppContainer:
   }()
   
   lazy var homeUseCae: HomeUseCase = {
-    return HomeUseCaseImpl(repository: challengeRepository)
+    return HomeUseCaseImpl(challengeRepository: challengeRepository)
   }()
   
   lazy var challengeUseCase: ChallengeUseCase = {

--- a/Projects/App/Sources/AppContainer.swift
+++ b/Projects/App/Sources/AppContainer.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2024 com.alloon. All rights reserved.
 //
 
+import Challenge
+import ChallengeImpl
 import Core
 import DataMapper
 import Home
@@ -36,7 +38,8 @@ final class AppContainer:
   HomeDependency,
   SearchChallengeDependency,
   MyPageDependency,
-  ReportDependency {
+  ReportDependency,
+  NoneMemberChallengeDependency {
   func coordinator() -> ViewableCoordinating {
     let viewControllerable = AppViewController()
     
@@ -59,6 +62,10 @@ final class AppContainer:
     
   lazy var reportContainable: ReportContainable = {
     return ReportContainer(dependency: self)
+  }()
+  
+  lazy var noneMemberChallengeContainable: NoneMemberChallengeContainable = {
+    return NoneMemberChallengeContainer(dependency: self)
   }()
   
   // MARK: - UseCase

--- a/Projects/Data/DTO/Challenge/ChallengeCount/ChallengeCountResponseDTO.swift
+++ b/Projects/Data/DTO/Challenge/ChallengeCount/ChallengeCountResponseDTO.swift
@@ -1,0 +1,25 @@
+//
+//  ChallengeCountResponseDTO.swift
+//  DTO
+//
+//  Created by jung on 4/8/25.
+//  Copyright © 2025 com.photi. All rights reserved.
+//
+
+public struct ChallengeCountResponseDTO: Decodable {
+  public let username: String
+  public let challengeCnt: Int
+}
+
+public extension ChallengeCountResponseDTO {
+  static let stubData = """
+{
+  "code": "200 OK",
+  "message": "성공",
+  "data": {
+    "username": "photi",
+    "challengeCnt": 5
+  }
+}
+"""
+}

--- a/Projects/Data/DTO/Challenge/MemberImageResponseDTO.swift
+++ b/Projects/Data/DTO/Challenge/MemberImageResponseDTO.swift
@@ -9,5 +9,5 @@
 import Foundation
 
 public struct MemberImageResponseDTO: Decodable {
-  public let memberImage: URL
+  public let memberImage: String?
 }

--- a/Projects/Data/DTO/Challenge/PopularChallenge/PopularChallengeResponseDTO.swift
+++ b/Projects/Data/DTO/Challenge/PopularChallenge/PopularChallengeResponseDTO.swift
@@ -22,38 +22,39 @@ public struct PopularChallengeResponseDTO: Decodable {
 
 public extension PopularChallengeResponseDTO {
   static let stubData = """
-  {
-    "code": "200 OK",
-    "message": "성공",
-    "data": [
-      {
-        "id": 1,
-        "name": "신나게 하는 러닝 챌린지",
-        "imageUrl": "https://url.kr/5MhHhD",
-        "goal": "하루에 한 번씩 꼭 러닝을 하는 것이 우리 챌린지의 목표입니다.",
-        "proveTime": "13:00",
-        "endDate": "2024-12-01",
-        "hashtags": [
-          {
-            "hashtag": "러닝"
-          },
-          {
-            "hashtag": "건강"
-          }
-        ],
-        "memberImages": [
-          {
-             "memberImage": "https://url.kr/5MhHhD"
-          },
-          {
-             "memberImage": "https://url.kr/5MhHhD"
-          },
-          {
-             "memberImage": "https://url.kr/5MhHhD"
-          }
-         ]
-      }
-    ]
-  }
+{
+  "code": "200 OK",
+  "message": "성공",
+  "data": [
+    {
+      "id": 1,
+      "name": "신나게 하는 러닝 챌린지",
+      "imageUrl": "https://url.kr/5MhHhD",
+      "goal": "하루에 한 번씩 꼭 러닝을 하는 것이 우리 챌린지의 목표입니다.",
+      "currentMemberCnt": 5,
+      "proveTime": "13:00",
+      "endDate": "2024-12-01",
+      "hashtags": [
+        {
+          "hashtag": "러닝"
+        },
+        {
+          "hashtag": "건강"
+        }
+      ],
+      "memberImages": [
+        {
+          "memberImage": "https://url.kr/5MhHhD"
+        },
+        {
+          "memberImage": "https://url.kr/5MhHhD"
+        },
+        {
+          "memberImage": "https://url.kr/5MhHhD"
+        }
+      ]
+    }
+  ]
+}
 """
 }

--- a/Projects/Data/DataMapper/ChallengeDataMapper.swift
+++ b/Projects/Data/DataMapper/ChallengeDataMapper.swift
@@ -42,7 +42,7 @@ public struct ChallengeDataMapperImpl: ChallengeDataMapper {
       proveTime: proveTime,
       goal: dto.goal,
       memberCount: dto.currentMemberCnt,
-      memberImages: memberImages
+      memberImages: memberImages.compactMap { URL(string: $0 ?? "") }
     )
   }
   
@@ -62,7 +62,7 @@ public struct ChallengeDataMapperImpl: ChallengeDataMapper {
       proveTime: proveTime,
       goal: dto.goal,
       memberCount: dto.currentMemberCnt,
-      memberImages: memberImages,
+      memberImages: memberImages.compactMap { URL(string: $0 ?? "") },
       isPublic: dto.isPublic,
       rules: rules
     )
@@ -80,7 +80,7 @@ public struct ChallengeDataMapperImpl: ChallengeDataMapper {
         endDate: endDate,
         hashTags: [],
         memberCount: $0.currentMemberCnt,
-        memberImages: memberImages
+        memberImages: memberImages.compactMap { URL(string: $0 ?? "") }
       )
     }
   }

--- a/Projects/Data/Repository/Implementations/AuthRepositoryImpl/AuthAPI.swift
+++ b/Projects/Data/Repository/Implementations/AuthRepositoryImpl/AuthAPI.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import Core
 import DTO
 import PhotiNetwork
 
@@ -16,13 +17,12 @@ public enum AuthAPI {
 
 extension AuthAPI: TargetType {
   public var baseURL: URL {
-    //    return ServiceConfiguration.baseUrl
-    return URL(string: "http://localhost:8080/api")!
+    return ServiceConfiguration.shared.baseUrl
   }
   
   public var path: String {
     switch self {
-      case .isLogIn: return "auth/validate/access-token"
+      case .isLogIn: return "api/auth/validate/access-token"
     }
   }
   
@@ -42,7 +42,7 @@ extension AuthAPI: TargetType {
     switch self {
       case .isLogIn:
         let data = AuthAPI.sampleData.data(using: .utf8) ?? Data()
-      
+        
         return .networkResponse(200, data, "", "")
     }
   }

--- a/Projects/Data/Repository/Implementations/AuthRepositoryImpl/AuthRepositoryImpl.swift
+++ b/Projects/Data/Repository/Implementations/AuthRepositoryImpl/AuthRepositoryImpl.swift
@@ -6,25 +6,25 @@
 //  Copyright © 2025 com.photi. All rights reserved.
 //
 
+import Entity
 import PhotiNetwork
 import Repository
 
 public struct AuthRepositoryImpl: AuthRepository {
   public init() { }
   
-  public func isLogIn() async -> Bool {
+  public func isLogIn() async throws -> Bool {
     let provider = Provider<AuthAPI>(
-      stubBehavior: .immediate,
+      stubBehavior: .never,
       session: .init(interceptor: AuthenticationInterceptor())
     )
     
     do {
       let result = try await provider
         .request(AuthAPI.isLogIn).value
-      
       return result.statusCode == 200
     } catch {
-      return false
+      throw APIError.serverError
     }
   }
 }

--- a/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeAPI.swift
+++ b/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeAPI.swift
@@ -28,23 +28,23 @@ public enum ChallengeAPI {
 
 extension ChallengeAPI: TargetType {
   public var baseURL: URL {
-    //    return ServiceConfiguration.baseUrl
-    return URL(string: "http://localhost:8080/api")!
+    return ServiceConfiguration.shared.baseUrl
   }
   
   public var path: String {
     switch self {
-      case .popularChallenges: return "challenges/popular"
-      case let .challengeDetail(id), let .leaveChallenge(id): return "challenges/\(id)"
-      case .endedChallenges: return "users/ended-challenges"
-      case .myChallenges: return "/users/my-challenges"
-      case let .joinChallenge(id): return "challenges/\(id)/join/public"
-      case let .joinPrivateChallenge(id, _): return "challenges/\(id)/join/private"
-      case let .uploadChallengeProof(id, _, _): return "challenges/\(id)/feeds"
-      case let .isProve(challengeId): return "/users/challenges/\(challengeId)/prove"
-      case let .updateChallengeGoal(_, challengeId): return "/challenges/\(challengeId)/challenge-members/goal"
-      case let .challengeDescription(id): return "challenges/\(id)/info"
-      case let .challengeMember(challengeId): return "/challenges/\(challengeId)/challenge-members"
+      case .popularChallenges: return "api/challenges/popular"
+      case let .challengeDetail(id), let .leaveChallenge(id): return "api/challenges/\(id)"
+      case .endedChallenges: return "api/users/ended-challenges"
+      case .myChallenges: return "api/users/my-challenges"
+      case let .joinChallenge(id): return "api/challenges/\(id)/join/public"
+      case let .joinPrivateChallenge(id, _): return "api/challenges/\(id)/join/private"
+      case let .uploadChallengeProof(id, _, _): return "api/challenges/\(id)/feeds"
+      case let .isProve(challengeId): return "api/users/challenges/\(challengeId)/prove"
+      case let .updateChallengeGoal(_, challengeId): return "api/challenges/\(challengeId)/challenge-members/goal"
+      case let .challengeDescription(id): return "api/challenges/\(id)/info"
+      case let .challengeMember(challengeId): return "api/challenges/\(challengeId)/challenge-members"
+      case .challengeCount: return "api/users/challenges"
     }
   }
   

--- a/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeAPI.swift
+++ b/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeAPI.swift
@@ -20,6 +20,7 @@ public enum ChallengeAPI {
   case joinPrivateChallenge(id: Int, code: String)
   case uploadChallengeProof(id: Int, image: Data, imageType: String)
   case isProve(challengeId: Int)
+  case challengeCount
   case updateChallengeGoal(_ goal: String, challengeId: Int)
   case challengeDescription(id: Int)
   case challengeMember(challengeId: Int)
@@ -55,7 +56,7 @@ extension ChallengeAPI: TargetType {
       case .endedChallenges, .myChallenges: return .get
       case .joinChallenge, .joinPrivateChallenge: return .post
       case .uploadChallengeProof: return .post
-      case .isProve: return .get
+      case .isProve, .challengeCount: return .get
       case .updateChallengeGoal: return .patch
       case .challengeDescription: return .get
       case .challengeMember: return .get
@@ -65,7 +66,7 @@ extension ChallengeAPI: TargetType {
   
   public var task: TaskType {
     switch self {
-      case .popularChallenges:
+      case .popularChallenges, .challengeCount:
         return .requestPlain
         
       case let .challengeDetail(challengeId):
@@ -172,6 +173,12 @@ extension ChallengeAPI: TargetType {
         
       case .challengeMember:
         let data = ChallengeMemberResponseDTO.stubData
+        let jsonData = data.data(using: .utf8)
+        
+        return .networkResponse(200, jsonData ?? Data(), "OK", "성공")
+        
+      case .challengeCount:
+        let data = ChallengeCountResponseDTO.stubData
         let jsonData = data.data(using: .utf8)
         
         return .networkResponse(200, jsonData ?? Data(), "OK", "성공")

--- a/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeRepositoryImpl.swift
+++ b/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeRepositoryImpl.swift
@@ -59,6 +59,16 @@ public extension ChallengeRepositoryImpl {
     
     return result.isProve
   }
+  
+  func challengeCount() async throws -> Int {
+    let result = try await requestAuthorizableAPI(
+        api: ChallengeAPI.challengeCount,
+        responseType: ChallengeCountResponseDTO.self,
+        behavior: .never
+      ).value
+      
+    return result.challengeCnt
+  }
     
   func fetchMyChallenges(page: Int, size: Int) -> Single<[ChallengeSummary]> {
     return requestAuthorizableAPI(

--- a/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeRepositoryImpl.swift
+++ b/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeRepositoryImpl.swift
@@ -183,7 +183,11 @@ private extension ChallengeRepositoryImpl {
             single(.failure(APIError.serverError))
           }
         } catch {
-          single(.failure(error))
+          if case NetworkError.networkFailed(reason: .interceptorMapping) = error {
+            single(.failure(APIError.authenticationFailed))
+          } else {
+            single(.failure(error))
+          }
         }
       }
       return Disposables.create()

--- a/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeRepositoryImpl.swift
+++ b/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeRepositoryImpl.swift
@@ -27,7 +27,8 @@ public extension ChallengeRepositoryImpl {
   func fetchPopularChallenges() -> Single<[ChallengeDetail]> {
     return requestUnAuthorizableAPI(
       api: ChallengeAPI.popularChallenges,
-      responseType: [PopularChallengeResponseDTO].self
+      responseType: [PopularChallengeResponseDTO].self,
+      behavior: .never
     )
     .map { $0.map { dataMapper.mapToChallengeDetail(dto: $0) } }
   }
@@ -157,7 +158,7 @@ private extension ChallengeRepositoryImpl {
   func requestAuthorizableAPI<T: Decodable>(
     api: ChallengeAPI,
     responseType: T.Type,
-    behavior: StubBehavior = .immediate
+    behavior: StubBehavior = .never
   ) -> Single<T> {
     return Single.create { single in
       Task {
@@ -192,7 +193,7 @@ private extension ChallengeRepositoryImpl {
   func requestUnAuthorizableAPI<T: Decodable>(
     api: ChallengeAPI,
     responseType: T.Type,
-    behavior: StubBehavior = .immediate
+    behavior: StubBehavior = .never
   ) -> Single<T> {
     Single.create { single in
       Task {

--- a/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeRepositoryImpl.swift
+++ b/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeRepositoryImpl.swift
@@ -45,7 +45,7 @@ public extension ChallengeRepositoryImpl {
     return requestUnAuthorizableAPI(
       api: ChallengeAPI.challengeDetail(id: id),
       responseType: ChallengeDetailResponseDTO.self,
-      behavior: .immediate
+      behavior: .never
     )
     .map { dataMapper.mapToChallengeDetail(dto: $0, id: id) }
   }
@@ -75,7 +75,7 @@ public extension ChallengeRepositoryImpl {
     return requestAuthorizableAPI(
       api: ChallengeAPI.myChallenges(page: page, size: size),
       responseType: MyChallengesResponseDTO.self,
-      behavior: .immediate
+      behavior: .never
     )
     .map { dataMapper.mapToChallengeSummaryFromMyChallenge(dto: $0) }
   }
@@ -84,7 +84,7 @@ public extension ChallengeRepositoryImpl {
     return requestAuthorizableAPI(
       api: ChallengeAPI.challengeDescription(id: challengeId),
       responseType: ChallengeDescriptionResponseDTO.self,
-      behavior: .immediate
+      behavior: .never
     )
     .map { dataMapper.mapToChallengeDescription(dto: $0, id: challengeId) }
   }

--- a/Projects/Domain/Entity/APIError.swift
+++ b/Projects/Domain/Entity/APIError.swift
@@ -54,9 +54,13 @@ extension APIError {
 extension APIError {
   public enum ChallengeFailedReason {
     case challengeNotFound
+    case notChallengeMemeber
+    case userNotFound
     case alreadyJoinedChallenge
     case invalidInvitationCode
     case alreadyUploadFeed
     case fileTooLarge
+    case challengeLimitExceed
+    case invalidFileFormat
   }
 }

--- a/Projects/Domain/Repository/Interfaces/AuthRepository.swift
+++ b/Projects/Domain/Repository/Interfaces/AuthRepository.swift
@@ -7,5 +7,5 @@
 //
 
 public protocol AuthRepository {
-  func isLogIn() async -> Bool
+  func isLogIn() async throws -> Bool
 }

--- a/Projects/Domain/Repository/Interfaces/ChallengeRepository.swift
+++ b/Projects/Domain/Repository/Interfaces/ChallengeRepository.swift
@@ -18,6 +18,7 @@ public protocol ChallengeRepository {
   func joinPrivateChallnege(id: Int, code: String) -> Single<Void>
   func uploadChallengeFeedProof(id: Int, image: Data, imageType: String) async throws
   func isProve(challengeId: Int) async throws -> Bool
+  func challengeCount() async throws -> Int
   func updateChallengeGoal(_ goal: String, challengeId: Int) -> Single<Void>
   func fetchMyChallenges(page: Int, size: Int) -> Single<[ChallengeSummary]>
   func fetchChallengeDescription(challengeId: Int) -> Single<ChallengeDescription>

--- a/Projects/Domain/UseCase/Implementations/ChallengeUseCaseImpl.swift
+++ b/Projects/Domain/UseCase/Implementations/ChallengeUseCaseImpl.swift
@@ -40,8 +40,8 @@ public extension ChallengeUseCaseImpl {
     return challengeRepository.fetchChallengeDetail(id: id)
   }
   
-  func isLogIn() async -> Bool {
-    return await authRepository.isLogIn()
+  func isLogIn() async throws -> Bool {
+    return try await authRepository.isLogIn()
   }
   
   func fetchFeeds(id: Int, page: Int, size: Int, orderType: ChallengeFeedsOrderType) async throws -> PageFeeds {

--- a/Projects/Domain/UseCase/Implementations/HomeUseCaseImpl.swift
+++ b/Projects/Domain/UseCase/Implementations/HomeUseCaseImpl.swift
@@ -14,18 +14,22 @@ import UseCase
 import Repository
 
 public struct HomeUseCaseImpl: HomeUseCase {
-  private let repository: ChallengeRepository
+  private let challengeRepository: ChallengeRepository
   
-  public init(repository: ChallengeRepository) {
-    self.repository = repository
+  public init(challengeRepository: ChallengeRepository) {
+    self.challengeRepository = challengeRepository
+  }
+
+  public func challengeCount() async throws -> Int {
+    return try await challengeRepository.challengeCount()
   }
   
   public func fetchPopularChallenge() -> Single<[ChallengeDetail]> {
-    return repository.fetchPopularChallenges()
+    return challengeRepository.fetchPopularChallenges()
   }
   
   public func fetchMyChallenges() -> Single<[ChallengeSummary]> {
-    return repository.fetchMyChallenges(page: 0, size: 20)
+    return challengeRepository.fetchMyChallenges(page: 0, size: 20)
   }
   
   public func uploadChallengeFeed(challengeId: Int, image: UIImageWrapper) async throws {
@@ -33,7 +37,7 @@ public struct HomeUseCaseImpl: HomeUseCase {
       throw APIError.challengeFailed(reason: .fileTooLarge)
     }
     
-    try await repository.uploadChallengeFeedProof(
+    try await challengeRepository.uploadChallengeFeedProof(
       id: challengeId,
       image: data,
       imageType: type

--- a/Projects/Domain/UseCase/Interfaces/ChallengeUseCase.swift
+++ b/Projects/Domain/UseCase/Interfaces/ChallengeUseCase.swift
@@ -19,7 +19,7 @@ public enum PageFeeds {
 public protocol ChallengeUseCase {
   var challengeProveMemberCount: Infallible<Int> { get }
   
-  func isLogIn() async -> Bool
+  func isLogIn() async throws -> Bool
   func fetchChallengeDetail(id: Int) -> Single<ChallengeDetail>
   func joinPrivateChallnege(id: Int, code: String) async throws
   func joinPublicChallenge(id: Int) -> Single<Void>

--- a/Projects/Domain/UseCase/Interfaces/HomeUseCase.swift
+++ b/Projects/Domain/UseCase/Interfaces/HomeUseCase.swift
@@ -11,6 +11,7 @@ import Core
 import Entity
 
 public protocol HomeUseCase {
+  func challengeCount() async throws -> Int
   func fetchPopularChallenge() -> Single<[ChallengeDetail]>
   func fetchMyChallenges() -> Single<[ChallengeSummary]>
   func uploadChallengeFeed(challengeId: Int, image: UIImageWrapper) async throws

--- a/Projects/Presentation/Challenge/Implementations/NoneMember/NoneMemberChallengeContainer.swift
+++ b/Projects/Presentation/Challenge/Implementations/NoneMember/NoneMemberChallengeContainer.swift
@@ -8,10 +8,12 @@
 
 import Challenge
 import Core
+import LogIn
 import UseCase
 
 public protocol NoneMemberChallengeDependency: Dependency {
   var challengeUseCase: ChallengeUseCase { get }
+  var loginContainable: LogInContainable { get }
 }
 
 public final class NoneMemberChallengeContainer:
@@ -30,7 +32,8 @@ public final class NoneMemberChallengeContainer:
       viewControllerable: viewControllerable,
       viewModel: viewModel,
       enterChallengeGoalContainer: enterChallengeGoalContainer,
-      logInGuideContainer: logInGuideContainer
+      logInGuideContainer: logInGuideContainer,
+      logInContainer: dependency.loginContainable
     )
     coordinator.listener = listener
     return coordinator

--- a/Projects/Presentation/Challenge/Implementations/NoneMember/NoneMemberChallengeViewModel.swift
+++ b/Projects/Presentation/Challenge/Implementations/NoneMember/NoneMemberChallengeViewModel.swift
@@ -157,9 +157,7 @@ private extension NoneMemberChallengeViewModel {
     if isPrivateChallenge {
       displayUnlockViewRelay.accept(())
     } else {
-      coordinator?.attachEnterChallengeGoal(
-        challengeName: challengeName, challengeID: challengeId
-      )
+      Task { await requestJoinPublicChallenge() }
     }
   }
 }
@@ -197,7 +195,10 @@ private extension NoneMemberChallengeViewModel {
   func requestJoinPublicChallenge() async {
     do {
       try await useCase.joinPublicChallenge(id: challengeId).value
-      coordinator?.attachEnterChallengeGoal(challengeName: challengeName, challengeID: challengeId)
+      DispatchQueue.main.async { [weak self] in
+        guard let self else { return }
+        coordinator?.attachEnterChallengeGoal(challengeName: challengeName, challengeID: challengeId)
+      }
     } catch {
       requestJoinChallengeFailed(with: error)
     }

--- a/Projects/Presentation/Challenge/Implementations/NoneMember/NoneMemberChallengeViewModel.swift
+++ b/Projects/Presentation/Challenge/Implementations/NoneMember/NoneMemberChallengeViewModel.swift
@@ -137,14 +137,18 @@ final class NoneMemberChallengeViewModel: NoneMemberChallengeViewModelType, @unc
 private extension NoneMemberChallengeViewModel {
   func didTapJoinButton() {
     Task {
-      let isLogin = await useCase.isLogIn()
-      
-      DispatchQueue.main.async { [weak self] in
-        if isLogin {
-          self?.joinChallenge()
-        } else {
-          self?.coordinator?.attachLogInGuide()
+      do {
+        let isLogin = try await useCase.isLogIn()
+        
+        DispatchQueue.main.async { [weak self] in
+          if isLogin {
+            self?.joinChallenge()
+          } else {
+            self?.coordinator?.attachLogInGuide()
+          }
         }
+      } catch {
+        requestFailedRelay.accept(())
       }
     }
   }

--- a/Projects/Presentation/Challenge/Implementations/NoneMember/Views/ChallengeThumbnailView.swift
+++ b/Projects/Presentation/Challenge/Implementations/NoneMember/Views/ChallengeThumbnailView.swift
@@ -76,6 +76,8 @@ final class ChallengeThumbnailView: UIView, ChallengeInformationPresentable {
 // MARK: - UI Methods
 private extension ChallengeThumbnailView {
   func setupUI() {
+    thumbnailImageView.layer.cornerRadius = 10
+    thumbnailImageView.clipsToBounds = true
     setViewHierarchy()
     setConstraints()
   }

--- a/Projects/Presentation/Challenge/Interfaces/NoneMemberChallenge.swift
+++ b/Projects/Presentation/Challenge/Interfaces/NoneMemberChallenge.swift
@@ -15,5 +15,4 @@ public protocol NoneMemberChallengeContainable: Containable {
 public protocol NoneMemberChallengeListener: AnyObject {
   func didTapBackButtonAtNoneMemberChallenge()
   func didJoinChallenge()
-  func requestLogInAtNoneMemberChallenge()
 }

--- a/Projects/Presentation/Home/Implementations/HomeContainer.swift
+++ b/Projects/Presentation/Home/Implementations/HomeContainer.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2024 com.alloon. All rights reserved.
 //
 
+import Challenge
 import Core
 import Home
 import LogIn
@@ -14,6 +15,7 @@ import UseCase
 public protocol HomeDependency: Dependency {
   var loginContainable: LogInContainable { get }
   var homeUseCae: HomeUseCase { get }
+  var noneMemberChallengeContainable: NoneMemberChallengeContainable { get }
 }
 
 public final class HomeContainer:
@@ -23,6 +25,7 @@ public final class HomeContainer:
   NoneMemberHomeDependency,
   NoneChallengeHomeDependency {
   var homeUseCase: HomeUseCase { dependency.homeUseCae }
+  var noneMemberChallengeContainable: NoneMemberChallengeContainable { dependency.noneMemberChallengeContainable }
   
   public func coordinator(navigationControllerable: NavigationControllerable, listener: HomeListener) -> Coordinating {
     let challengeHome = ChallengeHomeContainer(dependency: self)

--- a/Projects/Presentation/Home/Implementations/HomeContainer.swift
+++ b/Projects/Presentation/Home/Implementations/HomeContainer.swift
@@ -30,6 +30,7 @@ public final class HomeContainer:
     let noneChallengeHome = NoneChallengeHomeContainer(dependency: self)
     
     let coordinator = HomeCoordinator(
+      useCase: dependency.homeUseCae,
       navigationControllerable: navigationControllerable,
       loginContainer: dependency.loginContainable,
       challengeHomeContainer: challengeHome,

--- a/Projects/Presentation/Home/Implementations/HomeCoordinator.swift
+++ b/Projects/Presentation/Home/Implementations/HomeCoordinator.swift
@@ -173,7 +173,7 @@ private extension HomeCoordinator {
       count == 0 ? await attachNoneChallengeHome() : await attachChallengeHome()
     } catch {
       if let error = error as? APIError, case .authenticationFailed = error {
-        await attachLogIn()
+        await attachNoneMemberHome()
       } else {
         await presentNetworkUnstableAlert()
       }

--- a/Projects/Presentation/Home/Implementations/HomeCoordinator.swift
+++ b/Projects/Presentation/Home/Implementations/HomeCoordinator.swift
@@ -150,7 +150,15 @@ extension HomeCoordinator: NoneMemberHomeListener {
 }
 
 // MARK: - NoneChallengeHomeListener
-extension HomeCoordinator: NoneChallengeHomeListener { }
+extension HomeCoordinator: NoneChallengeHomeListener {
+  func requestLoginAtNoneChallengeHome() {
+    Task { await attachLogIn() }
+  }
+  
+  func requstConvertInitialHome() {
+    Task { await attachInitialScreenIfNeeded() }
+  }
+}
 
 // MARK: - LogInListener
 extension HomeCoordinator: LogInListener {
@@ -158,7 +166,6 @@ extension HomeCoordinator: LogInListener {
     Task { await detachLogIn() }
   }
   
-  // TODO: 어디로 넘어갈지 판별 필요
   func didFinishLogIn(userName: String) {
     Task {
       await detachLogIn()

--- a/Projects/Presentation/Home/Implementations/HomeCoordinator.swift
+++ b/Projects/Presentation/Home/Implementations/HomeCoordinator.swift
@@ -160,7 +160,10 @@ extension HomeCoordinator: LogInListener {
   
   // TODO: 어디로 넘어갈지 판별 필요
   func didFinishLogIn(userName: String) {
-    Task { await detachLogIn() }
+    Task {
+      await detachLogIn()
+      await attachInitialScreenIfNeeded()
+    }
   }
 }
 

--- a/Projects/Presentation/Home/Implementations/NoneChallengeHome/NoneChallengeHomeContainer.swift
+++ b/Projects/Presentation/Home/Implementations/NoneChallengeHome/NoneChallengeHomeContainer.swift
@@ -29,7 +29,7 @@ final class NoneChallengeHomeContainer:
     let coordinator = NoneChallengeHomeCoordinator(
       viewControllerable: viewControllerable,
       viewModel: viewModel,
-      noneMemberChallengeContainable: dependency.noneMemberChallengeContainable
+      noneMemberChallengeContainer: dependency.noneMemberChallengeContainable
     )
     coordinator.listener = listener
     

--- a/Projects/Presentation/Home/Implementations/NoneChallengeHome/NoneChallengeHomeContainer.swift
+++ b/Projects/Presentation/Home/Implementations/NoneChallengeHome/NoneChallengeHomeContainer.swift
@@ -6,11 +6,13 @@
 //  Copyright © 2024 com.photi. All rights reserved.
 //
 
+import Challenge
 import Core
 import UseCase
 
 protocol NoneChallengeHomeDependency: Dependency {
   var homeUseCase: HomeUseCase { get }
+  var noneMemberChallengeContainable: NoneMemberChallengeContainable { get }
 }
 
 protocol NoneChallengeHomeContainable: Containable {
@@ -26,7 +28,8 @@ final class NoneChallengeHomeContainer:
     
     let coordinator = NoneChallengeHomeCoordinator(
       viewControllerable: viewControllerable,
-      viewModel: viewModel
+      viewModel: viewModel,
+      noneMemberChallengeContainable: dependency.noneMemberChallengeContainable
     )
     coordinator.listener = listener
     

--- a/Projects/Presentation/Home/Implementations/NoneChallengeHome/NoneChallengeHomeCoordinator.swift
+++ b/Projects/Presentation/Home/Implementations/NoneChallengeHome/NoneChallengeHomeCoordinator.swift
@@ -14,9 +14,7 @@ protocol NoneChallengeHomeListener: AnyObject {
   func requstConvertInitialHome()
 }
 
-protocol NoneChallengeHomePresentable {
-  func configureUserName(_ username: String)
-}
+protocol NoneChallengeHomePresentable { }
 
 final class NoneChallengeHomeCoordinator: ViewableCoordinator<NoneChallengeHomePresentable> {
   weak var listener: NoneChallengeHomeListener?
@@ -35,10 +33,6 @@ final class NoneChallengeHomeCoordinator: ViewableCoordinator<NoneChallengeHomeP
     self.noneMemberChallengeContainer = noneMemberChallengeContainer
     super.init(viewControllerable)
     viewModel.coordinator = self
-  }
-  
-  override func start() {
-    presenter.configureUserName(ServiceConfiguration.shared.userName)
   }
 }
 

--- a/Projects/Presentation/Home/Implementations/NoneChallengeHome/NoneChallengeHomeCoordinator.swift
+++ b/Projects/Presentation/Home/Implementations/NoneChallengeHome/NoneChallengeHomeCoordinator.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2024 com.photi. All rights reserved.
 //
 
+import Challenge
 import Core
 
 protocol NoneChallengeHomeListener: AnyObject { }
@@ -19,11 +20,16 @@ final class NoneChallengeHomeCoordinator: ViewableCoordinator<NoneChallengeHomeP
 
   private let viewModel: NoneChallengeHomeViewModel
   
+  private let noneMemberChallengeContainable: NoneMemberChallengeContainable
+  private var noneMemberChallengeCoordinator: ViewableCoordinating?
+  
   init(
     viewControllerable: ViewControllerable,
-    viewModel: NoneChallengeHomeViewModel
+    viewModel: NoneChallengeHomeViewModel,
+    noneMemberChallengeContainable: NoneMemberChallengeContainable
   ) {
     self.viewModel = viewModel
+    self.noneMemberChallengeContainable = noneMemberChallengeContainable
     super.init(viewControllerable)
     viewModel.coordinator = self
   }

--- a/Projects/Presentation/Home/Implementations/NoneChallengeHome/NoneChallengeHomeCoordinator.swift
+++ b/Projects/Presentation/Home/Implementations/NoneChallengeHome/NoneChallengeHomeCoordinator.swift
@@ -10,7 +10,9 @@ import Core
 
 protocol NoneChallengeHomeListener: AnyObject { }
 
-protocol NoneChallengeHomePresentable { }
+protocol NoneChallengeHomePresentable {
+  func configureUserName(_ username: String)
+}
 
 final class NoneChallengeHomeCoordinator: ViewableCoordinator<NoneChallengeHomePresentable> {
   weak var listener: NoneChallengeHomeListener?
@@ -24,6 +26,10 @@ final class NoneChallengeHomeCoordinator: ViewableCoordinator<NoneChallengeHomeP
     self.viewModel = viewModel
     super.init(viewControllerable)
     viewModel.coordinator = self
+  }
+  
+  override func start() {
+    presenter.configureUserName(ServiceConfiguration.shared.userName)
   }
 }
 

--- a/Projects/Presentation/Home/Implementations/NoneChallengeHome/NoneChallengeHomeCoordinator.swift
+++ b/Projects/Presentation/Home/Implementations/NoneChallengeHome/NoneChallengeHomeCoordinator.swift
@@ -9,7 +9,10 @@
 import Challenge
 import Core
 
-protocol NoneChallengeHomeListener: AnyObject { }
+protocol NoneChallengeHomeListener: AnyObject {
+  func requestLoginAtNoneChallengeHome()
+  func requstConvertInitialHome()
+}
 
 protocol NoneChallengeHomePresentable {
   func configureUserName(_ username: String)
@@ -20,16 +23,16 @@ final class NoneChallengeHomeCoordinator: ViewableCoordinator<NoneChallengeHomeP
 
   private let viewModel: NoneChallengeHomeViewModel
   
-  private let noneMemberChallengeContainable: NoneMemberChallengeContainable
+  private let noneMemberChallengeContainer: NoneMemberChallengeContainable
   private var noneMemberChallengeCoordinator: ViewableCoordinating?
   
   init(
     viewControllerable: ViewControllerable,
     viewModel: NoneChallengeHomeViewModel,
-    noneMemberChallengeContainable: NoneMemberChallengeContainable
+    noneMemberChallengeContainer: NoneMemberChallengeContainable
   ) {
     self.viewModel = viewModel
-    self.noneMemberChallengeContainable = noneMemberChallengeContainable
+    self.noneMemberChallengeContainer = noneMemberChallengeContainer
     super.init(viewControllerable)
     viewModel.coordinator = self
   }
@@ -40,4 +43,37 @@ final class NoneChallengeHomeCoordinator: ViewableCoordinator<NoneChallengeHomeP
 }
 
 // MARK: - NoneMemberHomeCoordinatable
-extension NoneChallengeHomeCoordinator: NoneChallengeHomeCoordinatable { }
+extension NoneChallengeHomeCoordinator: NoneChallengeHomeCoordinatable {
+  func attachNoneMemberChallenge(challengeId: Int) {
+    guard noneMemberChallengeCoordinator == nil else { return }
+    
+    let coordinator = noneMemberChallengeContainer.coordinator(listener: self, challengeId: challengeId)
+    addChild(coordinator)
+    viewControllerable.pushViewController(coordinator.viewControllerable, animated: true)
+    
+    self.noneMemberChallengeCoordinator = coordinator
+  }
+  
+  func detachNoneMemberChallenge() {
+    guard let coordinator = noneMemberChallengeCoordinator else { return }
+    removeChild(coordinator)
+    viewControllerable.popViewController(animated: true)
+    noneMemberChallengeCoordinator = nil
+  }
+}
+
+// MARK: - NoneMem
+extension NoneChallengeHomeCoordinator: NoneMemberChallengeListener {
+  func didTapBackButtonAtNoneMemberChallenge() {
+    detachNoneMemberChallenge()
+  }
+  
+  func didJoinChallenge() {
+    detachNoneMemberChallenge()
+    listener?.requstConvertInitialHome()
+  }
+  
+  func requestLogInAtNoneMemberChallenge() {
+    listener?.requestLoginAtNoneChallengeHome()
+  }
+}

--- a/Projects/Presentation/Home/Implementations/NoneChallengeHome/NoneChallengeHomeViewController.swift
+++ b/Projects/Presentation/Home/Implementations/NoneChallengeHome/NoneChallengeHomeViewController.swift
@@ -32,7 +32,7 @@ final class NoneChallengeHomeViewController: UIViewController, ViewControllerabl
     }
   }
   
-  private let viewWillAppear = PublishRelay<Void>()
+  private let viewDidLoadRelay = PublishRelay<Void>()
   
   // MARK: - UI Components
   private let logoImageView: UIImageView = {
@@ -98,12 +98,7 @@ final class NoneChallengeHomeViewController: UIViewController, ViewControllerabl
     challengeImageCollectionView.dataSource = self
     setupUI()
     bind()
-  }
-  
-  override func viewWillAppear(_ animated: Bool) {
-    super.viewWillAppear(animated)
-    
-    viewWillAppear.accept(())
+    viewDidLoadRelay.accept(())
   }
   
   override func viewDidAppear(_ animated: Bool) {
@@ -171,7 +166,7 @@ private extension NoneChallengeHomeViewController {
 private extension NoneChallengeHomeViewController {
   func bind() {
     let input = NoneChallengeHomeViewModel.Input(
-      viewWillAppear: viewWillAppear.asSignal()
+      viewDidLoad: viewDidLoadRelay.asSignal()
     )
     
     let output = viewModel.transform(input: input)

--- a/Projects/Presentation/Home/Implementations/NoneChallengeHome/NoneChallengeHomeViewController.swift
+++ b/Projects/Presentation/Home/Implementations/NoneChallengeHome/NoneChallengeHomeViewController.swift
@@ -98,6 +98,11 @@ final class NoneChallengeHomeViewController: UIViewController, ViewControllerabl
     viewDidLoadRelay.accept(())
   }
   
+  override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+    configureUserName(ServiceConfiguration.shared.userName)
+  }
+  
   override func viewDidAppear(_ animated: Bool) {
     super.viewDidAppear(animated)
     
@@ -194,14 +199,7 @@ private extension NoneChallengeHomeViewController {
 }
 
 // MARK: - NoneChallengeHomePresentable
-extension NoneChallengeHomeViewController: NoneChallengeHomePresentable {
-  func configureUserName(_ username: String) {
-    titleLabel.attributedText = "\(username)님의\n열정을 보여주세요!".attributedString(
-      font: .heading1,
-      color: .gray900
-    )
-  }
-}
+extension NoneChallengeHomeViewController: NoneChallengeHomePresentable { }
 
 // MARK: - UICollectionViewDataSource
 extension NoneChallengeHomeViewController: UICollectionViewDataSource {
@@ -300,6 +298,13 @@ private extension NoneChallengeHomeViewController {
     DispatchQueue.main.async {
       self.challengeImageCollectionView.scrollToItem(at: indexPath, at: .top, animated: animated)
     }
+  }
+  
+  func configureUserName(_ username: String) {
+    titleLabel.attributedText = "\(username)님의\n열정을 보여주세요!".attributedString(
+      font: .heading1,
+      color: .gray900
+    )
   }
 
   func presentChallengeInformationView() {

--- a/Projects/Presentation/Home/Implementations/NoneChallengeHome/NoneChallengeHomeViewController.swift
+++ b/Projects/Presentation/Home/Implementations/NoneChallengeHome/NoneChallengeHomeViewController.swift
@@ -33,6 +33,7 @@ final class NoneChallengeHomeViewController: UIViewController, ViewControllerabl
   }
   
   private let viewDidLoadRelay = PublishRelay<Void>()
+  private let requestJoinChallenge = PublishRelay<Int>()
   
   // MARK: - UI Components
   private let logoImageView: UIImageView = {
@@ -162,11 +163,19 @@ private extension NoneChallengeHomeViewController {
 private extension NoneChallengeHomeViewController {
   func bind() {
     let input = NoneChallengeHomeViewModel.Input(
-      viewDidLoad: viewDidLoadRelay.asSignal()
+      viewDidLoad: viewDidLoadRelay.asSignal(),
+      requestJoinChallenge: requestJoinChallenge.asSignal()
     )
     
     let output = viewModel.transform(input: input)
+    viewBind()
     bind(for: output)
+  }
+  
+  func viewBind() {
+    challengeInformationView.rx.didTapJoinButton
+      .bind(to: requestJoinChallenge)
+      .disposed(by: disposeBag)
   }
   
   func bind(for output: NoneChallengeHomeViewModel.Output) {

--- a/Projects/Presentation/Home/Implementations/NoneChallengeHome/NoneChallengeHomeViewController.swift
+++ b/Projects/Presentation/Home/Implementations/NoneChallengeHome/NoneChallengeHomeViewController.swift
@@ -46,11 +46,7 @@ final class NoneChallengeHomeViewController: UIViewController, ViewControllerabl
   private let titleLabel: UILabel = {
     let label = UILabel()
     label.numberOfLines = 0
-    label.attributedText = "photi님의\n열정을 보여주세요!".attributedString(
-      font: .heading1,
-      color: .gray900
-    )
-    
+
     return label
   }()
   
@@ -189,7 +185,14 @@ private extension NoneChallengeHomeViewController {
 }
 
 // MARK: - NoneChallengeHomePresentable
-extension NoneChallengeHomeViewController: NoneChallengeHomePresentable { }
+extension NoneChallengeHomeViewController: NoneChallengeHomePresentable {
+  func configureUserName(_ username: String) {
+    titleLabel.attributedText = "\(username)님의\n열정을 보여주세요!".attributedString(
+      font: .heading1,
+      color: .gray900
+    )
+  }
+}
 
 // MARK: - UICollectionViewDataSource
 extension NoneChallengeHomeViewController: UICollectionViewDataSource {

--- a/Projects/Presentation/Home/Implementations/NoneChallengeHome/NoneChallengeHomeViewModel.swift
+++ b/Projects/Presentation/Home/Implementations/NoneChallengeHome/NoneChallengeHomeViewModel.swift
@@ -11,7 +11,9 @@ import RxSwift
 import Entity
 import UseCase
 
-protocol NoneChallengeHomeCoordinatable: AnyObject { }
+protocol NoneChallengeHomeCoordinatable: AnyObject {
+  func attachNoneMemberChallenge(challengeId: Int)
+}
 
 protocol NoneChallengeHomeViewModelType: AnyObject {
   associatedtype Input
@@ -33,6 +35,7 @@ final class NoneChallengeHomeViewModel: NoneChallengeHomeViewModelType {
   // MARK: - Input
   struct Input {
     let viewDidLoad: Signal<Void>
+    let requestJoinChallenge: Signal<Int>
   }
   
   // MARK: - Output
@@ -50,6 +53,12 @@ final class NoneChallengeHomeViewModel: NoneChallengeHomeViewModelType {
     input.viewDidLoad
       .emit(with: self) { owner, _ in
         owner.fetchPopularChallenge()
+      }
+      .disposed(by: disposeBag)
+    
+    input.requestJoinChallenge
+      .emit(with: self) { owner, id in
+        owner.coordinator?.attachNoneMemberChallenge(challengeId: id)
       }
       .disposed(by: disposeBag)
     
@@ -84,6 +93,7 @@ private extension NoneChallengeHomeViewModel {
     let endDate = challenge.endDate.toString("yyyy.MM.dd")
     
     return .init(
+      id: challenge.id,
       name: challenge.name,
       imageURL: challenge.imageUrl,
       goal: challenge.goal,

--- a/Projects/Presentation/Home/Implementations/NoneChallengeHome/NoneChallengeHomeViewModel.swift
+++ b/Projects/Presentation/Home/Implementations/NoneChallengeHome/NoneChallengeHomeViewModel.swift
@@ -32,7 +32,7 @@ final class NoneChallengeHomeViewModel: NoneChallengeHomeViewModelType {
 
   // MARK: - Input
   struct Input {
-    let viewWillAppear: Signal<Void>
+    let viewDidLoad: Signal<Void>
   }
   
   // MARK: - Output
@@ -47,7 +47,7 @@ final class NoneChallengeHomeViewModel: NoneChallengeHomeViewModelType {
   }
   
   func transform(input: Input) -> Output {
-    input.viewWillAppear
+    input.viewDidLoad
       .emit(with: self) { owner, _ in
         owner.fetchPopularChallenge()
       }

--- a/Projects/Presentation/Home/Implementations/NoneChallengeHome/NoneChallengeHomeViewModel.swift
+++ b/Projects/Presentation/Home/Implementations/NoneChallengeHome/NoneChallengeHomeViewModel.swift
@@ -89,8 +89,9 @@ private extension NoneChallengeHomeViewModel {
       goal: challenge.goal,
       proveTime: proveTime,
       endDate: endDate,
-      numberOfPersons: 0,
-      hashTags: challenge.hashTags
+      numberOfPersons: challenge.memberCount,
+      hashTags: challenge.hashTags,
+      memberImageURLs: challenge.memberImages
     )
   }
 }

--- a/Projects/Presentation/Home/Implementations/NoneChallengeHome/Views/ChallengInformationView/ChallengeInformationView.swift
+++ b/Projects/Presentation/Home/Implementations/NoneChallengeHome/Views/ChallengInformationView/ChallengeInformationView.swift
@@ -7,6 +7,8 @@
 //
 
 import UIKit
+import RxCocoa
+import RxSwift
 import SnapKit
 import Kingfisher
 import Core
@@ -16,6 +18,7 @@ final class ChallengeInformationView: UIView {
   private var hashTags = [String]() {
     didSet { hashTagCollectionView.reloadData() }
   }
+  private(set) var id: Int = 0
   
   // MARK: - UI Components
   private let challengeNameLabel = UILabel()
@@ -34,7 +37,7 @@ final class ChallengeInformationView: UIView {
   }()
   private let avatarImageView = GroupAvatarView(size: .small)
   private let participateCountLabel = UILabel()
-  private let participateButton = FilledRoundButton(type: .primary, size: .small, text: "나도 함께하기")
+  fileprivate let joinButton = FilledRoundButton(type: .primary, size: .small, text: "나도 함께하기")
   
   // MARK: - Initializers
   init() {
@@ -51,6 +54,7 @@ final class ChallengeInformationView: UIView {
   
   // MARK: - Configure Methods
   func configure(with model: ChallengePresentationModel) {
+    self.id = model.id
     goalContentView.configure(firstContent: model.goal)
     challengeTimeContentView.configure(
       firstContent: model.proveTime,
@@ -81,7 +85,7 @@ private extension ChallengeInformationView {
       goalContentView,
       challengeTimeContentView,
       participateCountView,
-      participateButton
+      joinButton
     )
     
     participateCountView.addSubviews(avatarImageView, participateCountLabel)
@@ -108,13 +112,13 @@ private extension ChallengeInformationView {
     challengeTimeContentView.snp.makeConstraints {
       $0.top.height.equalTo(goalContentView)
       $0.trailing.equalToSuperview()
-      $0.width.equalTo(participateButton)
+      $0.width.equalTo(joinButton)
     }
     
     participateCountView.snp.makeConstraints {
       $0.leading.trailing.equalTo(goalContentView)
       $0.top.equalTo(goalContentView.snp.bottom).offset(10)
-      $0.height.equalTo(participateButton)
+      $0.height.equalTo(joinButton)
     }
     
     avatarImageView.snp.makeConstraints {
@@ -127,7 +131,7 @@ private extension ChallengeInformationView {
       $0.centerY.equalToSuperview()
     }
     
-    participateButton.snp.makeConstraints {
+    joinButton.snp.makeConstraints {
       $0.top.equalTo(challengeTimeContentView.snp.bottom).offset(10)
       $0.leading.equalTo(challengeTimeContentView)
     }
@@ -178,5 +182,13 @@ private extension ChallengeInformationView {
     }
     
     return images
+  }
+}
+
+extension Reactive where Base == ChallengeInformationView {
+  var didTapJoinButton: ControlEvent<Int> {
+    let source = base.joinButton.rx.tap.map { _ in base.id }
+    
+    return .init(events: source)
   }
 }

--- a/Projects/Presentation/Home/Implementations/NoneChallengeHome/Views/ChallengePresentationModel.swift
+++ b/Projects/Presentation/Home/Implementations/NoneChallengeHome/Views/ChallengePresentationModel.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 struct ChallengePresentationModel {
+  let id: Int
   let name: String
   let imageURL: URL?
   let goal: String

--- a/Projects/Presentation/Home/Implementations/NoneChallengeHome/Views/ChallengePresentationModel.swift
+++ b/Projects/Presentation/Home/Implementations/NoneChallengeHome/Views/ChallengePresentationModel.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2024 com.photi. All rights reserved.
 //
 
-import UIKit
+import Foundation
 
 struct ChallengePresentationModel {
   let name: String
@@ -16,4 +16,5 @@ struct ChallengePresentationModel {
   let endDate: String
   let numberOfPersons: Int
   let hashTags: [String]
+  let memberImageURLs: [URL]
 }


### PR DESCRIPTION
## 관련 이슈

- #149 

## 작업 설명

- 챌린지 없을 경우, Home 실제 서버와 연동 작업 완료 
- Home화면 진입시 로그인 여부, 챌린지 여부에 따른 초기 화면 결정

현재 Home화면 진입 여부 판별 로직은 다음과 같습니다. 
```swift 
// HomeCoordinator.swift
func attachInitialScreenIfNeeded() async {
  do {
    let count = try await useCase.challengeCount()
    count == 0 ? await attachNoneChallengeHome() : await attachChallengeHome()
  } catch {
    if let error = error as? APIError, case .authenticationFailed = error {
      await attachNoneMemberHome()
    } else {
      await presentNetworkUnstableAlert()
    }
  }
}
```
다음과 같이, Coordinator에서 UseCase에 대한 의존성이 생기게 됩니다. 
저희 앱 내에서는 해당 역할을 ViewModel이 담당했었기에, 
- ViewModel이 담당하는 것 
- 지금과 같이 Coordinator가 담당하는 것 
2가지를 고려했습니다.

ViewModel이 담당하자고 하니, 실질적인 View가 없기에 MVVM에서 ViewModel의 역할과 멀어지는 느낌을 받았습니다. 
따라서, UseCase하나를 위한 ViewModel을 만드니, Coordinator에서 담당하는 것으로 해당 로직을 결정했습니다.
더 좋은 방법 있으면 공유 부탁드리겠습니다!
## 스크린샷
**사진 플로우는 다음과 같습니다.**
1. 로그인화면 
2. 로그인 이후, 챌린지가 없기에 해당 홈화면 attach
![Simulator Screen Recording - iPhone 16 Pro - 2025-04-10 at 22 24 02](https://github.com/user-attachments/assets/f3f4538f-07c9-4bd7-8436-a98ce2632bfe)

## PR 특이 사항
챌린지 참여까지 구현 및 테스트까지 해놓은 상황이나, 해당 부분에서 서버 오류로 인해 챌린지가 아예 삭제가 되어 해당 스크린샷을 찍지 못했습니다.
