### PR TITLE
[FEAT]: 챌린지 있는 경우, 홈화면 서버 연동완료

### DIFF
--- a/Projects/App/Sources/AppContainer.swift
+++ b/Projects/App/Sources/AppContainer.swift
@@ -39,6 +39,7 @@ final class AppContainer:
   SearchChallengeDependency,
   MyPageDependency,
   ReportDependency,
+  ChallengeDependency,
   NoneMemberChallengeDependency {
   func coordinator() -> ViewableCoordinating {
     let viewControllerable = AppViewController()
@@ -62,6 +63,10 @@ final class AppContainer:
     
   lazy var reportContainable: ReportContainable = {
     return ReportContainer(dependency: self)
+  }()
+  
+  lazy var challengeContainable: ChallengeContainable = {
+    return ChallengeContainer(dependency: self)
   }()
   
   lazy var noneMemberChallengeContainable: NoneMemberChallengeContainable = {

--- a/Projects/App/Sources/AppContainer.swift
+++ b/Projects/App/Sources/AppContainer.swift
@@ -110,17 +110,17 @@ final class AppContainer:
     return HomeUseCaseImpl(challengeRepository: challengeRepository)
   }()
   
-  lazy var challengeUseCase: ChallengeUseCase = {
+  var challengeUseCase: ChallengeUseCase {
     return ChallengeUseCaseImpl(
       challengeRepository: challengeRepository,
       feedRepository: feedRepository,
       authRepository: authRepository
     )
-  }()
+  }
   
-  lazy var feedUseCase: FeedUseCase = {
+  var feedUseCase: FeedUseCase {
     return FeedUseCaseImpl(repository: feedRepository)
-  }()
+  }
   
   lazy var reportUseCase: ReportUseCase = {
     return ReportUseCaseImpl(repository: reportRepository)

--- a/Projects/Core/Extensions/Date+Extension.swift
+++ b/Projects/Core/Extensions/Date+Extension.swift
@@ -45,6 +45,14 @@ public extension Date {
     
     return formatter.string(from: self)
   }
+  
+  func convertTimezone(from fromTimeZone: TimeZone, to toTimeZone: TimeZone? = nil) -> Date {
+    let fromOffset = fromTimeZone.secondsFromGMT(for: self)
+    let toOffset = toTimeZone?.secondsFromGMT(for: self) ?? 0
+    let timeInterval = TimeInterval(toOffset - fromOffset)
+    
+    return self.addingTimeInterval(timeInterval)
+  }
 }
 
 public extension TimeZone {

--- a/Projects/Data/DTO/Challenge/MyChallenge/MyChallengesResponseDTO.swift
+++ b/Projects/Data/DTO/Challenge/MyChallenge/MyChallengesResponseDTO.swift
@@ -20,6 +20,7 @@ public struct MyChallengeResponseDTO: Decodable {
   public let endDate: String
   public let hashtags: [HashTagResponseDTO]
   public let feedImageUrl: String?
+  public let feedId: Int?
   public let isProve: Bool
 }
 

--- a/Projects/Data/DataMapper/ChallengeDataMapper.swift
+++ b/Projects/Data/DataMapper/ChallengeDataMapper.swift
@@ -101,6 +101,7 @@ public struct ChallengeDataMapperImpl: ChallengeDataMapper {
         hashTags: hasTags,
         proveTime: proveTime,
         feedImageURL: feedImageUrl,
+        feedId: $0.feedId,
         isProve: $0.isProve
       )
     }
@@ -162,10 +163,10 @@ public struct ChallengeDataMapperImpl: ChallengeDataMapper {
       return .init(
         id: $0.id,
         name: $0.username,
-        imageUrl: $0.imageUrl,
+        imageUrl: URL(string: $0.imageUrl ?? ""),
         isOwner: $0.isCreator,
         duration: $0.duration,
-        goal: $0.goal
+        goal: $0.goal ?? ""
       )
     }
   }

--- a/Projects/DesignSystem/Sources/Popup/ToastView/ToastView.swift
+++ b/Projects/DesignSystem/Sources/Popup/ToastView/ToastView.swift
@@ -143,15 +143,14 @@ public extension ToastView {
   }
   
   func present(
-    to viewController: UIViewController,
+    at view: UIView,
     duration: CGFloat = 3.0,
     completion: (() -> Void)? = nil
   ) {
     guard let constraint = toastViewConstraints else { return }
-    let superView = viewController.view
     workItem?.cancel()
     self.isRemoved = false
-    superView?.addSubview(self)
+    view.addSubview(self)
     self.snp.makeConstraints(constraint)
     
     let workItem = DispatchWorkItem { [weak self] in
@@ -160,6 +159,15 @@ public extension ToastView {
 
     self.workItem = workItem
     DispatchQueue.main.asyncAfter(deadline: .now() + duration, execute: workItem)
+  }
+  
+  func present(
+    to viewController: UIViewController,
+    duration: CGFloat = 3.0,
+    completion: (() -> Void)? = nil
+  ) {
+    guard let view = viewController.view else { return }
+    present(at: view, duration: duration, completion: completion)
   }
 }
 

--- a/Projects/Domain/Entity/ChallengeSummary.swift
+++ b/Projects/Domain/Entity/ChallengeSummary.swift
@@ -18,6 +18,7 @@ public struct ChallengeSummary {
   // MARK: - Extra Properties
   public let proveTime: Date?
   public let feedImageURL: URL?
+  public let feedId: Int?
   public let memberCount: Int?
   public let memberImages: [URL]?
   public let isProve: Bool
@@ -41,6 +42,7 @@ public extension ChallengeSummary {
     self.feedImageURL = nil
     self.memberCount = nil
     self.memberImages = nil
+    self.feedId = nil
     self.isProve = false
   }
   
@@ -52,6 +54,7 @@ public extension ChallengeSummary {
     hashTags: [String],
     proveTime: Date,
     feedImageURL: URL?,
+    feedId: Int?,
     isProve: Bool = false
   ) {
     self.id = id
@@ -61,6 +64,7 @@ public extension ChallengeSummary {
     self.hashTags = hashTags
     self.proveTime = proveTime
     self.feedImageURL = feedImageURL
+    self.feedId = feedId
     self.memberCount = nil
     self.memberImages = nil
     self.isProve = isProve
@@ -84,6 +88,7 @@ public extension ChallengeSummary {
     self.feedImageURL = nil
     self.memberCount = memberCount
     self.memberImages = memberImages
+    self.feedId = nil
     self.isProve = false
   }
 }

--- a/Projects/Domain/UseCase/Implementations/HomeUseCaseImpl.swift
+++ b/Projects/Domain/UseCase/Implementations/HomeUseCaseImpl.swift
@@ -32,12 +32,12 @@ public struct HomeUseCaseImpl: HomeUseCase {
     return challengeRepository.fetchMyChallenges(page: 0, size: 20)
   }
   
-  public func uploadChallengeFeed(challengeId: Int, image: UIImageWrapper) async throws {
+  public func uploadChallengeFeed(challengeId: Int, image: UIImageWrapper) async throws -> Feed {
     guard let (data, type) = imageToData(image, maxMB: 8) else {
       throw APIError.challengeFailed(reason: .fileTooLarge)
     }
     
-    try await challengeRepository.uploadChallengeFeedProof(
+    return try await challengeRepository.uploadChallengeFeedProof(
       id: challengeId,
       image: data,
       imageType: type

--- a/Projects/Domain/UseCase/Interfaces/HomeUseCase.swift
+++ b/Projects/Domain/UseCase/Interfaces/HomeUseCase.swift
@@ -14,5 +14,5 @@ public protocol HomeUseCase {
   func challengeCount() async throws -> Int
   func fetchPopularChallenge() -> Single<[ChallengeDetail]>
   func fetchMyChallenges() -> Single<[ChallengeSummary]>
-  func uploadChallengeFeed(challengeId: Int, image: UIImageWrapper) async throws
+  func uploadChallengeFeed(challengeId: Int, image: UIImageWrapper) async throws -> Feed
 }

--- a/Projects/Presentation/Challenge/Implementations/Member/ChallengeContainer.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/ChallengeContainer.swift
@@ -25,7 +25,11 @@ public final class ChallengeContainer:
   FeedDependency,
   DescriptionDependency,
   ParticipantDependency {
-  public func coordinator(listener: ChallengeListener, challengeId: Int) -> ViewableCoordinating {
+  public func coordinator(
+    listener: ChallengeListener,
+    challengeId: Int,
+    presentType: ChallengePresentType
+  ) -> ViewableCoordinating {
     let viewModel = ChallengeViewModel(useCase: dependency.challengeUseCase, challengeId: challengeId)
     let viewControllerable = ChallengeViewController(viewModel: viewModel)
     
@@ -36,6 +40,7 @@ public final class ChallengeContainer:
     let coordinator = ChallengeCoordinator(
       viewControllerable: viewControllerable,
       viewModel: viewModel,
+      initialPresentType: presentType,
       feedContainer: feedContainer,
       descriptionContainer: descriptionContainer,
       participantContainer: participantContainer,

--- a/Projects/Presentation/Challenge/Implementations/Member/ChallengeCoordinator.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/ChallengeCoordinator.swift
@@ -23,6 +23,7 @@ final class ChallengeCoordinator: ViewableCoordinator<ChallengePresentable> {
   weak var listener: ChallengeListener?
 
   private let viewModel: ChallengeViewModel
+  private let presentType: ChallengePresentType
   
   private let feedContainer: FeedContainable
   private var feedCoordinator: ViewableCoordinating?
@@ -42,6 +43,7 @@ final class ChallengeCoordinator: ViewableCoordinator<ChallengePresentable> {
   init(
     viewControllerable: ViewControllerable,
     viewModel: ChallengeViewModel,
+    initialPresentType: ChallengePresentType,
     feedContainer: FeedContainable,
     descriptionContainer: DescriptionContainable,
     participantContainer: ParticipantContainable,
@@ -49,6 +51,7 @@ final class ChallengeCoordinator: ViewableCoordinator<ChallengePresentable> {
     reportContainer: ReportContainable
   ) {
     self.viewModel = viewModel
+    self.presentType = initialPresentType
     self.feedContainer = feedContainer
     self.descriptionContainer = descriptionContainer
     self.participantContainer = participantContainer
@@ -65,7 +68,11 @@ final class ChallengeCoordinator: ViewableCoordinator<ChallengePresentable> {
   func attachSegments() {
     let challengeId = viewModel.challengeId
     let challengeName = viewModel.challengeName
-    let feedCoordinator = feedContainer.coordinator(challengeId: challengeId, listener: self)
+    let feedCoordinator = feedContainer.coordinator(
+      challengeId: challengeId,
+      listener: self,
+      presentType: presentType
+    )
     let descriptionCoordinator = descriptionContainer.coordinator(challengeId: challengeId, listener: self)
     let participantCoordinator = participantContainer.coordinator(
       challengeId: challengeId,

--- a/Projects/Presentation/Challenge/Implementations/Member/ChallengeCoordinator.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/ChallengeCoordinator.swift
@@ -136,8 +136,8 @@ extension ChallengeCoordinator: ChallengeCoordinatable {
     listener?.didTapBackButtonAtChallenge()
   }
   
-  func leaveChallenge(isLastMember: Bool) {
-    listener?.leaveChallenge(isDelete: isLastMember)
+  func leaveChallenge(challengeId: Int) {
+    listener?.leaveChallenge(challengeId: challengeId)
   }
   
   func attachChallengeReport() {

--- a/Projects/Presentation/Challenge/Implementations/Member/ChallengeViewController.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/ChallengeViewController.swift
@@ -286,7 +286,7 @@ private extension ChallengeViewController {
     let alert = AlertViewController(
       alertType: .canCancel,
       title: "챌린지를 탈퇴할까요?",
-      attributedSubTitle: leaveChallengeString(memberCount: 1)
+      attributedSubTitle: leaveChallengeString(memberCount: memberCount)
     )
     alert.confirmButtonTitle = "탈퇴할게요"
     alert.cancelButtonTitle = "취소할게요"

--- a/Projects/Presentation/Challenge/Implementations/Member/ChallengeViewModel.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/ChallengeViewModel.swift
@@ -15,7 +15,7 @@ protocol ChallengeCoordinatable: AnyObject {
   func didTapBackButton()
   func didTapConfirmButtonAtAlert()
   func attachLogIn()
-  func leaveChallenge(isLastMember: Bool)
+  func leaveChallenge(challengeId: Int)
   func attachChallengeReport()
 }
 
@@ -98,6 +98,12 @@ final class ChallengeViewModel: ChallengeViewModelType {
       }
       .disposed(by: disposeBag)
     
+    input.didTapConfirmButtonAtAlert
+      .emit(with: self) { owner, _ in
+        owner.coordinator?.didTapConfirmButtonAtAlert()
+      }
+      .disposed(by: disposeBag)
+    
     return Output(
       challengeInfo: challengeModelRelay.asDriver(),
       memberCount: memberCount.asDriver(),
@@ -128,7 +134,7 @@ private extension ChallengeViewModel {
     useCase.leaveChallenge(id: challengeId)
       .observe(on: MainScheduler.instance)
       .subscribe(with: self) { owner, _ in
-        owner.coordinator?.leaveChallenge(isLastMember: owner.memberCount.value == 1)
+        owner.coordinator?.leaveChallenge(challengeId: owner.challengeId)
       } onFailure: { owner, error in
         owner.requestFailed(with: error)
       }

--- a/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedContainer.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedContainer.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2024 com.photi. All rights reserved.
 //
 
+import Challenge
 import Core
 import UseCase
 
@@ -15,7 +16,11 @@ protocol FeedDependency: Dependency {
 }
 
 protocol FeedContainable: Containable {
-  func coordinator(challengeId: Int, listener: FeedListener) -> ViewableCoordinating
+  func coordinator(
+    challengeId: Int,
+    listener: FeedListener,
+    presentType: ChallengePresentType
+  ) -> ViewableCoordinating
 }
 
 final class FeedContainer:
@@ -24,15 +29,21 @@ final class FeedContainer:
   FeedCommentDependency {
   var feedUseCase: FeedUseCase { dependency.feedUseCase }
 
-  func coordinator(challengeId: Int, listener: FeedListener) -> ViewableCoordinating {
+  func coordinator(
+    challengeId: Int,
+    listener: FeedListener,
+    presentType: ChallengePresentType
+  ) -> ViewableCoordinating {
     let viewModel = FeedViewModel(challengeId: challengeId, useCase: dependency.challengeUseCase)
     let viewControllerable = FeedViewController(viewModel: viewModel)
     
     let feedCommentContainer = FeedCommentContainer(dependency: self)
     
     let coordinator = FeedCoordinator(
+      challengeId: challengeId,
       viewControllerable: viewControllerable,
       viewModel: viewModel,
+      initialPresentType: presentType,
       feedCommentContainer: feedCommentContainer
     )
     coordinator.listener = listener

--- a/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedCoordinator.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedCoordinator.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2024 com.photi. All rights reserved.
 //
 
+import Challenge
 import Core
 
 protocol FeedListener: AnyObject {
@@ -24,21 +25,31 @@ protocol FeedPresentable {
 final class FeedCoordinator: ViewableCoordinator<FeedPresentable> {
   weak var listener: FeedListener?
 
+  private let challengeId: Int
   private let viewModel: FeedViewModel
+  private let initialPresentType: ChallengePresentType
   
   private let feedCommentContainer: FeedCommentContainable
   private var feedCommentCoordinator: ViewableCoordinating?
   
   init(
+    challengeId: Int,
     viewControllerable: ViewControllerable,
     viewModel: FeedViewModel,
+    initialPresentType: ChallengePresentType,
     feedCommentContainer: FeedCommentContainable
   ) {
+    self.challengeId = challengeId
     self.viewModel = viewModel
+    self.initialPresentType = initialPresentType
     self.feedCommentContainer = feedCommentContainer
     super.init(viewControllerable)
     viewModel.coordinator = self
-    print(viewModel.coordinator == nil)
+  }
+  
+  override func viewDidAppear() {
+    guard case let .presentWithFeed(feedId) = initialPresentType else { return }
+    attachFeedDetail(challengeId: challengeId, feedId: feedId)
   }
 }
 

--- a/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedViewController.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedViewController.swift
@@ -305,9 +305,7 @@ extension FeedViewController: FeedPresentable {
     
     guard
       let oldItem = snapshot.itemIdentifiers.first(where: { $0.id == feedId }),
-      oldItem.isLike != isLiked,
-      let section = snapshot.sectionIdentifier(containingItem: oldItem),
-      let index = snapshot.indexOfItem(oldItem)
+      oldItem.isLike != isLiked
     else { return }
     
     var updatedItem = oldItem
@@ -408,7 +406,12 @@ extension FeedViewController {
       }
     }
     
-    snapshot.appendItems(models, toSection: firstModel.updateGroup)
+    if let firstItem = snapshot.itemIdentifiers(inSection: firstModel.updateGroup).first {
+      snapshot.insertItems(models, beforeItem: firstItem)
+    } else {
+      snapshot.appendItems(models, toSection: firstModel.updateGroup)
+    }
+    
     dataSource.apply(snapshot)
   }
   
@@ -425,12 +428,7 @@ extension FeedViewController {
         snapshot.appendSections([$0.updateGroup])
         snapshot.appendItems([$0], toSection: $0.updateGroup)
       }
-      
-      if let firstItem = snapshot.itemIdentifiers(inSection: $0.updateGroup).first {
-        snapshot.insertItems(models, beforeItem: firstItem)
-      } else {
-        snapshot.appendItems([$0], toSection: $0.updateGroup)
-      }
+      snapshot.appendItems([$0], toSection: $0.updateGroup)
     }
     
     return snapshot

--- a/Projects/Presentation/Challenge/Implementations/Member/Feed/PresentationModel/FeedPresentatoinModelMapper.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/Feed/PresentationModel/FeedPresentatoinModelMapper.swift
@@ -55,14 +55,14 @@ struct FeedPresentatoinModelMapper {
 
 extension FeedPresentatoinModelMapper {
   func mapToUpdateTimeString(_ date: Date) -> String {
-    let date = date
+    let date = date.convertTimezone(from: .kst)
     let current = Date()
     guard current.year == date.year else {
       return "\(abs(current.year - date.year))년 전"
     }
   
     guard current.month == date.month else {
-      return "\(abs(current.month - date.month))년 전"
+      return "\(abs(current.month - date.month))달 전"
     }
   
     guard current.day == date.day else {
@@ -85,7 +85,7 @@ extension FeedPresentatoinModelMapper {
   }
   
   func mapToUpdateGroup(_ date: Date) -> String {
-    let date = date
+    let date = date.convertTimezone(from: .kst)
     let current = Date()
   
     guard current.year == date.year else {
@@ -93,7 +93,7 @@ extension FeedPresentatoinModelMapper {
     }
   
     guard current.month == date.month else {
-      return "\(abs(current.month - date.month))년 전"
+      return "\(abs(current.month - date.month))달 전"
     }
   
     let temp = abs(current.day - date.day)

--- a/Projects/Presentation/Challenge/Interfaces/Challenge.swift
+++ b/Projects/Presentation/Challenge/Interfaces/Challenge.swift
@@ -24,5 +24,5 @@ public protocol ChallengeContainable: Containable {
 public protocol ChallengeListener: AnyObject {
   func didTapBackButtonAtChallenge()
   func shouldDismissChallenge()
-  func leaveChallenge(isDelete: Bool)
+  func leaveChallenge(challengeId: Int)
 }

--- a/Projects/Presentation/Challenge/Interfaces/Challenge.swift
+++ b/Projects/Presentation/Challenge/Interfaces/Challenge.swift
@@ -8,8 +8,17 @@
 
 import Core
 
+public enum ChallengePresentType {
+  case `default`
+  case presentWithFeed(_ feedId: Int)
+}
+
 public protocol ChallengeContainable: Containable {
-  func coordinator(listener: ChallengeListener, challengeId: Int) -> ViewableCoordinating
+  func coordinator(
+    listener: ChallengeListener,
+    challengeId: Int,
+    presentType: ChallengePresentType
+  ) -> ViewableCoordinating
 }
 
 public protocol ChallengeListener: AnyObject {

--- a/Projects/Presentation/Home/Implementations/ChallengeHome/ChallengeHomeContainer.swift
+++ b/Projects/Presentation/Home/Implementations/ChallengeHome/ChallengeHomeContainer.swift
@@ -6,11 +6,13 @@
 //  Copyright © 2025 com.photi. All rights reserved.
 //
 
+import Challenge
 import Core
 import UseCase
 
 protocol ChallengeHomeDependency: Dependency {
   var homeUseCase: HomeUseCase { get }
+  var challengeContainable: ChallengeContainable { get }
 }
 
 protocol ChallengeHomeContainable: Containable {
@@ -24,7 +26,8 @@ final class ChallengeHomeContainer: Container<ChallengeHomeDependency>, Challeng
     
     let coordinator = ChallengeHomeCoordinator(
       viewControllerable: viewControllerable,
-      viewModel: viewModel
+      viewModel: viewModel,
+      challengeContainer: dependency.challengeContainable
     )
     coordinator.listener = listener
     return coordinator

--- a/Projects/Presentation/Home/Implementations/ChallengeHome/ChallengeHomeCoordinator.swift
+++ b/Projects/Presentation/Home/Implementations/ChallengeHome/ChallengeHomeCoordinator.swift
@@ -9,7 +9,9 @@
 import Challenge
 import Core
 
-protocol ChallengeHomeListener: AnyObject { }
+protocol ChallengeHomeListener: AnyObject {
+  func requestLogInAtChallengeHome()
+}
 
 protocol ChallengeHomePresentable { }
 
@@ -31,11 +33,10 @@ final class ChallengeHomeCoordinator: ViewableCoordinator<ChallengeHomePresentab
     super.init(viewControllerable)
     viewModel.coordinator = self
   }
-}
-
-// MARK: - LogIn
-extension ChallengeHomeCoordinator {
-  func attachLogin() { }
+  
+  func requestLogIn() {
+    listener?.requestLogInAtChallengeHome()
+  }
 }
 
 // MARK: - Challenge
@@ -70,7 +71,7 @@ extension ChallengeHomeCoordinator: ChallengeListener {
     detachChallenge()
   }
   
-  func requestLoginAtChallenge() { }
+  // 이거 제대로 삭제되는지 확인해봐야겠다~!
   
   func leaveChallenge(isDelete: Bool) { }
 }

--- a/Projects/Presentation/Home/Implementations/ChallengeHome/ChallengeHomeCoordinator.swift
+++ b/Projects/Presentation/Home/Implementations/ChallengeHome/ChallengeHomeCoordinator.swift
@@ -37,3 +37,40 @@ final class ChallengeHomeCoordinator: ViewableCoordinator<ChallengeHomePresentab
 extension ChallengeHomeCoordinator {
   func attachLogin() { }
 }
+
+// MARK: - Challenge
+extension ChallengeHomeCoordinator {
+  func attachChallenge(id: Int) {
+    guard challengeCoordinator == nil else { return }
+    
+    let coordinator = challengeContainer.coordinator(listener: self, challengeId: id)
+    addChild(coordinator)
+    viewControllerable.pushViewController(coordinator.viewControllerable, animated: true)
+    
+    self.challengeCoordinator = coordinator
+  }
+  
+  func detachChallenge() {
+    guard let coordinator = challengeCoordinator else { return }
+    
+    removeChild(coordinator)
+    viewControllerable.popViewController(animated: true)
+    viewControllerable.uiviewController.showTabBar(animted: true)
+    self.challengeCoordinator = nil
+  }
+}
+
+// MARK: - ChallengeListener
+extension ChallengeHomeCoordinator: ChallengeListener {
+  func didTapBackButtonAtChallenge() {
+    detachChallenge()
+  }
+  
+  func shouldDismissChallenge() {
+    detachChallenge()
+  }
+  
+  func requestLoginAtChallenge() { }
+  
+  func leaveChallenge(isDelete: Bool) { }
+}

--- a/Projects/Presentation/Home/Implementations/ChallengeHome/ChallengeHomeCoordinator.swift
+++ b/Projects/Presentation/Home/Implementations/ChallengeHome/ChallengeHomeCoordinator.swift
@@ -11,6 +11,7 @@ import Core
 
 protocol ChallengeHomeListener: AnyObject {
   func requestLogInAtChallengeHome()
+  func requestNoneChallengeHomeAtChallengeHome()
 }
 
 protocol ChallengeHomePresentable { }
@@ -37,6 +38,10 @@ final class ChallengeHomeCoordinator: ViewableCoordinator<ChallengeHomePresentab
   func requestLogIn() {
     listener?.requestLogInAtChallengeHome()
   }
+  
+  func requestNoneChallengeHome() {
+    listener?.requestNoneChallengeHomeAtChallengeHome()
+  }
 }
 
 // MARK: - Challenge
@@ -44,7 +49,25 @@ extension ChallengeHomeCoordinator {
   func attachChallenge(id: Int) {
     guard challengeCoordinator == nil else { return }
     
-    let coordinator = challengeContainer.coordinator(listener: self, challengeId: id)
+    let coordinator = challengeContainer.coordinator(
+      listener: self,
+      challengeId: id,
+      presentType: .default
+    )
+    addChild(coordinator)
+    viewControllerable.pushViewController(coordinator.viewControllerable, animated: true)
+    
+    self.challengeCoordinator = coordinator
+  }
+  
+  func attachChallengeWithFeed(challengeId: Int, feedId: Int) {
+    guard challengeCoordinator == nil else { return }
+    
+    let coordinator = challengeContainer.coordinator(
+      listener: self,
+      challengeId: challengeId,
+      presentType: .presentWithFeed(feedId)
+    )
     addChild(coordinator)
     viewControllerable.pushViewController(coordinator.viewControllerable, animated: true)
     
@@ -70,8 +93,9 @@ extension ChallengeHomeCoordinator: ChallengeListener {
   func shouldDismissChallenge() {
     detachChallenge()
   }
-  
-  // 이거 제대로 삭제되는지 확인해봐야겠다~!
-  
-  func leaveChallenge(isDelete: Bool) { }
+
+  func leaveChallenge(challengeId: Int) {
+    detachChallenge()
+    viewModel.reloadData()
+  }
 }

--- a/Projects/Presentation/Home/Implementations/ChallengeHome/ChallengeHomeCoordinator.swift
+++ b/Projects/Presentation/Home/Implementations/ChallengeHome/ChallengeHomeCoordinator.swift
@@ -6,28 +6,34 @@
 //  Copyright © 2025 com.photi. All rights reserved.
 //
 
+import Challenge
 import Core
 
 protocol ChallengeHomeListener: AnyObject { }
 
 protocol ChallengeHomePresentable { }
 
-final class ChallengeHomeCoordinator: ViewableCoordinator<ChallengeHomePresentable> {
+final class ChallengeHomeCoordinator: ViewableCoordinator<ChallengeHomePresentable>, ChallengeHomeCoordinatable {
   weak var listener: ChallengeHomeListener?
 
   private let viewModel: ChallengeHomeViewModel
   
+  private let challengeContainer: ChallengeContainable
+  private var challengeCoordinator: ViewableCoordinating?
+  
   init(
     viewControllerable: ViewControllerable,
-    viewModel: ChallengeHomeViewModel
+    viewModel: ChallengeHomeViewModel,
+    challengeContainer: ChallengeContainable
   ) {
     self.viewModel = viewModel
+    self.challengeContainer = challengeContainer 
     super.init(viewControllerable)
     viewModel.coordinator = self
   }
 }
 
-// MARK: - Coordinatable
-extension ChallengeHomeCoordinator: ChallengeHomeCoordinatable {
+// MARK: - LogIn
+extension ChallengeHomeCoordinator {
   func attachLogin() { }
 }

--- a/Projects/Presentation/Home/Implementations/ChallengeHome/ChallengeHomeViewController.swift
+++ b/Projects/Presentation/Home/Implementations/ChallengeHome/ChallengeHomeViewController.swift
@@ -15,8 +15,9 @@ import Core
 
 final class ChallengeHomeViewController: UIViewController, CameraRequestable, ViewControllerable {
   enum Constants {
-    static let itemWidth: CGFloat = 288
     static let groupSpacing: CGFloat = 16
+    static let itemLeading: CGFloat = 24
+    static let itemTrailing: CGFloat = 45
   }
   
   typealias MyChallengeFeedDataSourceType = UICollectionViewDiffableDataSource<Int, MyChallengeFeedPresentationModel>
@@ -46,8 +47,8 @@ final class ChallengeHomeViewController: UIViewController, CameraRequestable, Vi
     return label
   }()
   
-  private let proofChallengeCollectionView: UICollectionView = {
-    let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewLayout())
+  private let proofChallengeCollectionView: SelfVerticalSizingCollectionView = {
+    let collectionView = SelfVerticalSizingCollectionView(layout: UICollectionViewLayout())
     collectionView.registerCell(ProofChallengeCell.self)
     collectionView.decelerationRate = .fast
     collectionView.isPagingEnabled = true
@@ -123,7 +124,7 @@ private extension ChallengeHomeViewController {
     proofChallengeCollectionView.snp.makeConstraints {
       $0.leading.trailing.equalToSuperview()
       $0.top.equalTo(titleLabel.snp.bottom).offset(24)
-      $0.height.equalTo(298)
+      $0.height.equalTo(proofChallengeCollectionView.snp.width).multipliedBy(0.83)
     }
     
     bottomView.snp.makeConstraints {
@@ -279,7 +280,9 @@ extension ChallengeHomeViewController: UploadPhotoPopOverDelegate {
 // MARK: - Private Methods
 private extension ChallengeHomeViewController {
   func compositionalLayout() -> UICollectionViewCompositionalLayout {
-    return .init { _, _ in
+    return .init { _, environment in
+      let containerWidth = environment.container.effectiveContentSize.width
+      let availableWidth = containerWidth - Constants.itemLeading - Constants.itemTrailing
       let itemSize = NSCollectionLayoutSize(
         widthDimension: .fractionalWidth(1),
         heightDimension: .fractionalHeight(1)
@@ -287,7 +290,7 @@ private extension ChallengeHomeViewController {
       let item = NSCollectionLayoutItem(layoutSize: itemSize)
       
       let groupSize = NSCollectionLayoutSize(
-        widthDimension: .absolute(Constants.itemWidth),
+        widthDimension: .absolute(availableWidth),
         heightDimension: .fractionalHeight(1)
       )
       let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
@@ -295,7 +298,12 @@ private extension ChallengeHomeViewController {
       let section = NSCollectionLayoutSection(group: group)
       section.orthogonalScrollingBehavior = .groupPagingCentered
       section.interGroupSpacing = Constants.groupSpacing
-      
+      section.contentInsets = NSDirectionalEdgeInsets(
+        top: 0,
+        leading: Constants.itemLeading,
+        bottom: 0,
+        trailing: Constants.itemTrailing
+      )
       return section
     }
   }

--- a/Projects/Presentation/Home/Implementations/ChallengeHome/ChallengeHomeViewController.swift
+++ b/Projects/Presentation/Home/Implementations/ChallengeHome/ChallengeHomeViewController.swift
@@ -32,6 +32,7 @@ final class ChallengeHomeViewController: UIViewController, CameraRequestable, Vi
   private let requestData = PublishRelay<Void>()
   private let uploadChallengeFeed = PublishRelay<(Int, UIImageWrapper)>()
   private let didTapLoginButton = PublishRelay<Void>()
+  private let didTapFeed = PublishRelay<(challengeId: Int, feedId: Int)>()
   
   // MARK: - UI Components
   private let navigationBar = PhotiNavigationBar(leftView: .logo, displayMode: .dark)
@@ -145,7 +146,8 @@ private extension ChallengeHomeViewController {
       requestData: requestData.asSignal(),
       didTapChallenge: bottomView.didTapChallenge,
       uploadChallengeFeed: uploadChallengeFeed.asSignal(),
-      didTapLoginButton: didTapLoginButton.asSignal()
+      didTapLoginButton: didTapLoginButton.asSignal(),
+      didTapFeed: didTapFeed.asSignal()
     )
     let output = viewModel.transform(input: input)
     viewModelBind(for: output)
@@ -193,11 +195,16 @@ private extension ChallengeHomeViewController {
   }
   
   func bind(for cell: ProofChallengeCell, isNotProof: Bool) {
-    cell.rx.didTapImage
-      .filter { _ in isNotProof }
+    cell.rx.didTapCameraButton
       .bind(with: self) { owner, _ in
         owner.uploadChallengeId = cell.challengeId
         owner.requestOpenCamera(delegate: owner)
+      }
+      .disposed(by: disposeBag)
+    
+    cell.rx.didTapFeed
+      .bind(with: self) { owner, infos in
+        owner.didTapFeed.accept(infos)
       }
       .disposed(by: disposeBag)
   }

--- a/Projects/Presentation/Home/Implementations/ChallengeHome/ChallengeHomeViewController.swift
+++ b/Projects/Presentation/Home/Implementations/ChallengeHome/ChallengeHomeViewController.swift
@@ -138,6 +138,7 @@ private extension ChallengeHomeViewController {
   func bind() {
     let input = ChallengeHomeViewModel.Input(
       requestData: requestData.asSignal(),
+      didTapChallenge: bottomView.didTapChallenge,
       uploadChallengeFeed: uploadChallengeFeed.asSignal(),
       didTapLoginButton: didTapLoginButton.asSignal()
     )

--- a/Projects/Presentation/Home/Implementations/ChallengeHome/ChallengeHomeViewController.swift
+++ b/Projects/Presentation/Home/Implementations/ChallengeHome/ChallengeHomeViewController.swift
@@ -167,8 +167,8 @@ private extension ChallengeHomeViewController {
     output.didUploadChallengeFeed
       .emit(with: self) { owner, result in
         LoadingAnimation.logo.stop()
-        if case let .success(challengeId, image) = result {
-          owner.update(challengeId: challengeId, image: image.image)
+        if case let .success(challengeId, feedId, url) = result {
+          owner.update(challengeId: challengeId, feedId: feedId, url: url)
           owner.presentVerificationSuccessToast()
         }
       }
@@ -247,15 +247,15 @@ extension ChallengeHomeViewController {
     datasource.apply(snapshot)
   }
   
-  func update(challengeId: Int, image: UIImage) {
+  func update(challengeId: Int, feedId: Int, url: URL?) {
     guard let datasource else { return }
     var snapshot = datasource.snapshot()
     
-    guard let index = snapshot.itemIdentifiers.firstIndex(where: { $0.id == challengeId }) else { return }
+    guard let index = snapshot.itemIdentifiers.firstIndex(where: { $0.challengeId == challengeId }) else { return }
 
     let existingModel = snapshot.itemIdentifiers[index]
     var updatedModel = existingModel
-    updatedModel.type = .proofImage(image)
+    updatedModel.type = .didProof(url, feedId: feedId)
     
     snapshot.deleteItems([existingModel])
     snapshot.appendItems([updatedModel])

--- a/Projects/Presentation/Home/Implementations/ChallengeHome/ChallengeHomeViewController.swift
+++ b/Projects/Presentation/Home/Implementations/ChallengeHome/ChallengeHomeViewController.swift
@@ -81,6 +81,10 @@ final class ChallengeHomeViewController: UIViewController, CameraRequestable, Vi
     self.datasource = dataSource
     setupUI()
     bind()
+  }
+  
+  override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
     requestData.accept(())
   }
 }

--- a/Projects/Presentation/Home/Implementations/ChallengeHome/ChallengeHomeViewController.swift
+++ b/Projects/Presentation/Home/Implementations/ChallengeHome/ChallengeHomeViewController.swift
@@ -167,6 +167,7 @@ private extension ChallengeHomeViewController {
         LoadingAnimation.logo.stop()
         if case let .success(challengeId, image) = result {
           owner.update(challengeId: challengeId, image: image.image)
+          owner.presentVerificationSuccessToast()
         }
       }
       .disposed(by: disposeBag)
@@ -317,6 +318,21 @@ private extension ChallengeHomeViewController {
     
     let snapshot = datasource.snapshot()
     return snapshot.numberOfItems - 1 == row
+  }
+  
+  func presentVerificationSuccessToast() {
+    let toastView = ToastView(
+      tipPosition: .none,
+      text: "인증 완료! 오늘도 수고했어요!",
+      icon: .bulbWhite
+    )
+    
+    toastView.setConstraints {
+      $0.centerX.equalToSuperview()
+      $0.bottom.equalToSuperview().offset(-64)
+    }
+    
+    toastView.present(at: self.view.window ?? self.view)
   }
   
   func presentFileTooLargeAlert() {

--- a/Projects/Presentation/Home/Implementations/ChallengeHome/ChallengeHomeViewModel.swift
+++ b/Projects/Presentation/Home/Implementations/ChallengeHome/ChallengeHomeViewModel.swift
@@ -15,6 +15,7 @@ import UseCase
 
 protocol ChallengeHomeCoordinatable: AnyObject {
   func requestLogIn()
+  func requestNoneChallengeHome()
   func attachChallenge(id: Int)
   func attachChallengeWithFeed(challengeId: Int, feedId: Int)
 }
@@ -69,6 +70,10 @@ final class ChallengeHomeViewModel: ChallengeHomeViewModelType {
     self.useCase = useCase
   }
   
+  func reloadData() {
+    fetchInitialData()
+  }
+  
   func transform(input: Input) -> Output {
     input.requestData
       .emit(with: self) { owner, _ in
@@ -118,6 +123,11 @@ private extension ChallengeHomeViewModel {
     useCase.fetchMyChallenges()
       .observe(on: MainScheduler.instance)
       .subscribe(with: self) { owner, challenges in
+        guard !challenges.isEmpty else {
+          owner.coordinator?.requestNoneChallengeHome()
+          return
+        }
+        
         let feedModels = owner.mapToMyChallengeFeeds(challenges)
         let challengeModels = owner.mapToMyChallenges(challenges)
         owner.myChallengeFeedsRelay.accept(feedModels)

--- a/Projects/Presentation/Home/Implementations/ChallengeHome/ChallengeHomeViewModel.swift
+++ b/Projects/Presentation/Home/Implementations/ChallengeHome/ChallengeHomeViewModel.swift
@@ -14,7 +14,7 @@ import Entity
 import UseCase
 
 protocol ChallengeHomeCoordinatable: AnyObject {
-  func attachLogin()
+  func requestLogIn()
   func attachChallenge(id: Int)
 }
 
@@ -82,7 +82,7 @@ final class ChallengeHomeViewModel: ChallengeHomeViewModelType {
     
     input.didTapLoginButton
       .emit(with: self) { owner, _ in
-        owner.coordinator?.attachLogin()
+        owner.coordinator?.requestLogIn()
       }
       .disposed(by: disposeBag)
     

--- a/Projects/Presentation/Home/Implementations/ChallengeHome/ChallengeHomeViewModel.swift
+++ b/Projects/Presentation/Home/Implementations/ChallengeHome/ChallengeHomeViewModel.swift
@@ -27,7 +27,7 @@ protocol ChallengeHomeViewModelType: AnyObject {
 }
 
 enum UploadChallnegeFeedResult {
-  case success(id: Int, image: UIImageWrapper)
+  case success(challengeId: Int, feedId: Int, url: URL?)
   case failure
 }
 
@@ -130,8 +130,8 @@ private extension ChallengeHomeViewModel {
   
   func uploadChallengeFeed(id: Int, image: UIImageWrapper) async {
     do {
-      try await useCase.uploadChallengeFeed(challengeId: id, image: image)
-      didUploadChallengeFeed.accept(.success(id: id, image: image))
+      let feed = try await useCase.uploadChallengeFeed(challengeId: id, image: image)
+      didUploadChallengeFeed.accept(.success(challengeId: id, feedId: feed.id, url: feed.imageURL))
     } catch {
       didUploadChallengeFeed.accept(.failure)
       requestFailed(with: error, message: "네트워크가 불안정해, 챌린지 인증에 실패했어요.\n다시 시도해주세요.")

--- a/Projects/Presentation/Home/Implementations/ChallengeHome/ChallengeHomeViewModel.swift
+++ b/Projects/Presentation/Home/Implementations/ChallengeHome/ChallengeHomeViewModel.swift
@@ -45,6 +45,7 @@ final class ChallengeHomeViewModel: ChallengeHomeViewModelType {
   // MARK: - Input
   struct Input {
     let requestData: Signal<Void>
+    let didTapChallenge: Signal<Int>
     let uploadChallengeFeed: Signal<(Int, UIImageWrapper)>
     let didTapLoginButton: Signal<Void>
   }

--- a/Projects/Presentation/Home/Implementations/ChallengeHome/ChallengeHomeViewModel.swift
+++ b/Projects/Presentation/Home/Implementations/ChallengeHome/ChallengeHomeViewModel.swift
@@ -15,6 +15,7 @@ import UseCase
 
 protocol ChallengeHomeCoordinatable: AnyObject {
   func attachLogin()
+  func attachChallenge(id: Int)
 }
 
 protocol ChallengeHomeViewModelType: AnyObject {
@@ -82,6 +83,12 @@ final class ChallengeHomeViewModel: ChallengeHomeViewModelType {
     input.didTapLoginButton
       .emit(with: self) { owner, _ in
         owner.coordinator?.attachLogin()
+      }
+      .disposed(by: disposeBag)
+    
+    input.didTapChallenge
+      .emit(with: self) { owner, id in
+        owner.coordinator?.attachChallenge(id: id)
       }
       .disposed(by: disposeBag)
     

--- a/Projects/Presentation/Home/Implementations/ChallengeHome/Views/HomeBottomView/HomeBottomView.swift
+++ b/Projects/Presentation/Home/Implementations/ChallengeHome/Views/HomeBottomView/HomeBottomView.swift
@@ -7,6 +7,8 @@
 //
 
 import UIKit
+import RxCocoa
+import RxRelay
 import Core
 import DesignSystem
 
@@ -14,6 +16,9 @@ final class HomeBottomView: UIView {
   var dataSources = [MyChallengePresentationModel]() {
     didSet { tableView.reloadData() }
   }
+  
+  let didTapChallenge: Signal<Int>
+  private let didTapChallengeRelay: PublishRelay<Int>
   
   // MARK: - UI Components
   private let seperatorView: UIImageView = {
@@ -48,6 +53,9 @@ final class HomeBottomView: UIView {
   
   // MARK: - Initializers
   init() {
+    let relay = PublishRelay<Int>()
+    self.didTapChallengeRelay = relay
+    self.didTapChallenge = relay.asSignal()
     super.init(frame: .zero)
     setupUI()
     tableView.dataSource = self
@@ -123,5 +131,11 @@ extension HomeBottomView: UITableViewDelegate {
     let view = UIView(frame: .init(x: 0, y: 0, width: tableView.frame.width, height: 16))
     
     return view
+  }
+  
+  func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    let challengeId = dataSources[indexPath.section].id
+    
+    didTapChallengeRelay.accept(challengeId)
   }
 }

--- a/Projects/Presentation/Home/Implementations/ChallengeHome/Views/HomeBottomView/HomeBottomView.swift
+++ b/Projects/Presentation/Home/Implementations/ChallengeHome/Views/HomeBottomView/HomeBottomView.swift
@@ -98,7 +98,7 @@ private extension HomeBottomView {
     }
     
     tableView.snp.makeConstraints {
-      $0.width.equalTo(330)
+      $0.leading.trailing.equalToSuperview().inset(24)
       $0.top.equalTo(titleLabel.snp.bottom).offset(24)
       $0.centerX.equalToSuperview()
       $0.bottom.equalToSuperview().inset(40)

--- a/Projects/Presentation/Home/Implementations/ChallengeHome/Views/MyChallengeFeedPresentationModel.swift
+++ b/Projects/Presentation/Home/Implementations/ChallengeHome/Views/MyChallengeFeedPresentationModel.swift
@@ -10,17 +10,16 @@ import UIKit
 
 struct MyChallengeFeedPresentationModel: Hashable {
   enum ModelType: Equatable {
-    case proofURL(_ url: URL?)
-    case proofImage(_ image: UIImage)
+    case didProof(_ url: URL?, feedId: Int)
     case didNotProof
   }
   
-  let id: Int
+  let challengeId: Int
   let title: String
   let deadLine: String
   var type: ModelType
   
   func hash(into hasher: inout Hasher) {
-    hasher.combine(id)
+    hasher.combine(challengeId)
   }
 }

--- a/Projects/Presentation/Home/Implementations/ChallengeHome/Views/ProofChallegneCell/ChallengeImageView.swift
+++ b/Projects/Presentation/Home/Implementations/ChallengeHome/Views/ProofChallegneCell/ChallengeImageView.swift
@@ -62,16 +62,12 @@ private extension ChallengeImageView {
   
   func setupUI(for type: ModelType) {
     switch type {
-      case let .proofURL(url):
+      case let .didProof(url, _):
         setupDidProofUI()
         imageView.kf.setImage(with: url) { [weak self] _ in
           guard let self else { return }
           bringSubviewToFront(cornerView)
         }
-        
-      case let .proofImage(image):
-        setupDidProofUI()
-        imageView.image = image
         
       case .didNotProof:
         setupNotProofUI(image: .cameraPlusLightBlue)
@@ -122,8 +118,8 @@ private extension ChallengeImageView {
 
 extension Reactive where Base: ChallengeImageView {
   var didTapImage: ControlEvent<Void> {
-    let observable = base.imageView.rx.tapGesture().when(.recognized)
-      .filter { _ in base.modelType == .didNotProof }
+    let observable = base.imageView.rx.tapGesture()
+      .when(.recognized)
       .map { _ in }
     return ControlEvent(events: observable)
   }

--- a/Projects/Presentation/Home/Implementations/ChallengeHome/Views/ProofChallegneCell/ChallengeTitleView.swift
+++ b/Projects/Presentation/Home/Implementations/ChallengeHome/Views/ProofChallegneCell/ChallengeTitleView.swift
@@ -73,7 +73,7 @@ private extension ChallengeTitleView {
 
   func configureBackgounrd(type: ModelType) {
     switch type {
-      case .proofURL, .proofImage:
+      case .didProof:
         self.backgroundColor = .green400
       case .didNotProof:
         self.backgroundColor = .blue400
@@ -82,7 +82,7 @@ private extension ChallengeTitleView {
   
   func configureImageView(type: ModelType) {
     switch type {
-      case .proofURL, .proofImage:
+      case .didProof:
         self.imageView.image = .cloverGreen
       case .didNotProof:
         self.imageView.image = .timeLightBlue

--- a/Projects/Presentation/Home/Implementations/ChallengeHome/Views/ProofChallegneCell/ProofChallengeCell.swift
+++ b/Projects/Presentation/Home/Implementations/ChallengeHome/Views/ProofChallegneCell/ProofChallengeCell.swift
@@ -107,8 +107,17 @@ private extension ProofChallengeCell {
     switch type {
       case .didNotProof:
         seperatorView.backgroundColor = .blue100
-      case .proofURL, .proofImage:
+      case .didProof:
         seperatorView.backgroundColor = .green0
+    }
+  }
+  
+  func configureDeadLineChip(_ deadLine: String) {
+    switch type {
+      case .didNotProof:
+        deadLineChip.text = deadLine
+      case .didProof:
+        deadLineChip.text = "인증완료!"
     }
   }
 }

--- a/Projects/Presentation/Home/Implementations/ChallengeHome/Views/ProofChallegneCell/ProofChallengeCell.swift
+++ b/Projects/Presentation/Home/Implementations/ChallengeHome/Views/ProofChallegneCell/ProofChallengeCell.swift
@@ -66,7 +66,7 @@ private extension ProofChallengeCell {
     seperatorView.snp.makeConstraints {
       $0.leading.equalTo(deadLineChip.snp.trailing).offset(14)
       $0.trailing.equalToSuperview()
-      $0.height.equalTo(1)
+      $0.height.equalTo(2)
       $0.centerY.equalTo(deadLineChip)
     }
     
@@ -78,7 +78,8 @@ private extension ProofChallengeCell {
     
     challengeImageView.snp.makeConstraints {
       $0.centerX.equalToSuperview()
-      $0.height.width.equalTo(184)
+      $0.leading.trailing.equalToSuperview().inset(52)
+      $0.height.equalTo(challengeImageView.snp.width)
       $0.top.equalTo(titleView).offset(48)
     }
   }

--- a/Projects/Presentation/Home/Implementations/HomeContainer.swift
+++ b/Projects/Presentation/Home/Implementations/HomeContainer.swift
@@ -15,6 +15,7 @@ import UseCase
 public protocol HomeDependency: Dependency {
   var loginContainable: LogInContainable { get }
   var homeUseCae: HomeUseCase { get }
+  var challengeContainable: ChallengeContainable { get }
   var noneMemberChallengeContainable: NoneMemberChallengeContainable { get }
 }
 
@@ -26,6 +27,7 @@ public final class HomeContainer:
   NoneChallengeHomeDependency {
   var homeUseCase: HomeUseCase { dependency.homeUseCae }
   var noneMemberChallengeContainable: NoneMemberChallengeContainable { dependency.noneMemberChallengeContainable }
+  var challengeContainable: ChallengeContainable { dependency.challengeContainable }
   
   public func coordinator(navigationControllerable: NavigationControllerable, listener: HomeListener) -> Coordinating {
     let challengeHome = ChallengeHomeContainer(dependency: self)

--- a/Projects/Presentation/Home/Implementations/HomeCoordinator.swift
+++ b/Projects/Presentation/Home/Implementations/HomeCoordinator.swift
@@ -140,7 +140,11 @@ private extension HomeCoordinator {
 }
 
 // MARK: - ChallengeHome Listener
-extension HomeCoordinator: ChallengeHomeListener { }
+extension HomeCoordinator: ChallengeHomeListener {
+  func requestLogInAtChallengeHome() {
+    Task { await attachLogIn() }
+  }
+}
 
 // MARK: - NoneMemberHome Listener
 extension HomeCoordinator: NoneMemberHomeListener {

--- a/Projects/Presentation/Home/Implementations/HomeCoordinator.swift
+++ b/Projects/Presentation/Home/Implementations/HomeCoordinator.swift
@@ -144,6 +144,13 @@ extension HomeCoordinator: ChallengeHomeListener {
   func requestLogInAtChallengeHome() {
     Task { await attachLogIn() }
   }
+  
+  func requestNoneChallengeHomeAtChallengeHome() {
+    Task {
+      await detachChallengeHome()
+      await attachNoneChallengeHome()
+    }
+  }
 }
 
 // MARK: - NoneMemberHome Listener
@@ -160,7 +167,10 @@ extension HomeCoordinator: NoneChallengeHomeListener {
   }
   
   func requstConvertInitialHome() {
-    Task { await attachInitialScreenIfNeeded() }
+    Task {
+      await detachNoneChallengeHome()
+      await attachInitialScreenIfNeeded()
+    }
   }
 }
 


### PR DESCRIPTION
## 관련 이슈

- #232 

## 작업 설명
- 홈화면에서 챌린지 인증할 수 있는 기능 추가. 
- 인증안한 챌린지 피드 클릭시 챌린지 인증할 수 있는 기능 추가. 
- 인증한 챌린지 피드 클릭시 피드화면으로 이동하는 기능 추가. 
- 챌린지 삭제시 기능 추가 


## 스크린샷

### 챌린지 가입 

https://github.com/user-attachments/assets/4508a85e-e884-4ec2-ac8f-791e7b0dc325


### 챌린지 홈에서 인증 

https://github.com/user-attachments/assets/43b35799-3c4e-4f32-aeb3-d30a61306959


### 챌린지 탈퇴(탈퇴 후, 가입 챌린지 0개로 다른 화면으로 진입) 

https://github.com/user-attachments/assets/040fe3c1-e2e0-4021-b4fe-a8683544f0d1

