### PR TITLE
[REFACT]: 로그인 방식 수정

### DIFF
--- a/Projects/App/Sources/AppContainer.swift
+++ b/Projects/App/Sources/AppContainer.swift
@@ -53,7 +53,8 @@ final class AppContainer:
       viewControllerable: viewControllerable,
       homeContainable: home,
       searchChallengeContainable: searchChallenge,
-      myPageContainable: myPage
+      myPageContainable: myPage,
+      loginContainable: loginContainable
     )
   }
   

--- a/Projects/App/Sources/AppCoordinator.swift
+++ b/Projects/App/Sources/AppCoordinator.swift
@@ -12,11 +12,12 @@ import LogIn
 import SearchChallenge
 import MyPage
 
-protocol AppPresentable {
+@MainActor protocol AppPresentable {
   func attachNavigationControllers(_ viewControllerables: NavigationControllerable...)
   func changeNavigationControllerToHome()
   func changeNavigationControllerToChallenge()
   func changeNavigationControllerToMyPage()
+  func presentWelcomeToastView(_ username: String)
 }
 
 final class AppCoordinator: ViewableCoordinator<AppPresentable> {
@@ -175,7 +176,7 @@ extension AppCoordinator: SearchChallengeListener { }
 // MARK: - MyPageListener
 extension AppCoordinator: MyPageListener {
   func isUserResigned() {
-    presenter.changeNavigationControllerToHome()
+    Task { await presenter.changeNavigationControllerToHome() }
   }
 }
 
@@ -186,6 +187,9 @@ extension AppCoordinator: LogInListener {
     Task {
       await detachLogIn(willPopViewConroller: false)
       await reloadAllTab()
+
+      await presenter.changeNavigationControllerToHome()
+      await presenter.presentWelcomeToastView(ServiceConfiguration.shared.userName)
     }
   }
   

--- a/Projects/App/Sources/AppCoordinator.swift
+++ b/Projects/App/Sources/AppCoordinator.swift
@@ -8,6 +8,7 @@
 
 import Core
 import Home
+import LogIn
 import SearchChallenge
 import MyPage
 
@@ -26,16 +27,21 @@ final class AppCoordinator: ViewableCoordinator<AppPresentable> {
   private let homeContainable: HomeContainable
   private let searchChallengeContainable: SearchChallengeContainable
   private let myPageContainable: MyPageContainable
+  private let loginContainer: LogInContainable
+  private var loginCoordinator: ViewableCoordinating?
+  private var loginPresentNavigationControllerable: NavigationControllerable?
   
   init(
     viewControllerable: ViewControllerable,
     homeContainable: HomeContainable,
     searchChallengeContainable: SearchChallengeContainable,
-    myPageContainable: MyPageContainable
+    myPageContainable: MyPageContainable,
+    loginContainable: LogInContainable
   ) {
-    self.homeContainable = homeContainable
-    self.searchChallengeContainable = searchChallengeContainable
-    self.myPageContainable = myPageContainable
+    self.homeContainer = homeContainable
+    self.searchChallengeContainer = searchChallengeContainable
+    self.myPageContainer = myPageContainable
+    self.loginContainer = loginContainable
     super.init(viewControllerable)
   }
   

--- a/Projects/App/Sources/AppCoordinator.swift
+++ b/Projects/App/Sources/AppCoordinator.swift
@@ -24,9 +24,15 @@ final class AppCoordinator: ViewableCoordinator<AppPresentable> {
   private let searchChallengeNavigationControllerable = NavigationControllerable()
   private let myPageNavigationControllerable = NavigationControllerable()
   
-  private let homeContainable: HomeContainable
-  private let searchChallengeContainable: SearchChallengeContainable
-  private let myPageContainable: MyPageContainable
+  private let homeContainer: HomeContainable
+  private var homeCoorinator: Coordinating?
+  
+  private let searchChallengeContainer: SearchChallengeContainable
+  private var searchChallengeCoordinator: ViewableCoordinating?
+  
+  private let myPageContainer: MyPageContainable
+  private var myPageCoordinator: ViewableCoordinating?
+  
   private let loginContainer: LogInContainable
   private var loginCoordinator: ViewableCoordinating?
   private var loginPresentNavigationControllerable: NavigationControllerable?
@@ -46,34 +52,122 @@ final class AppCoordinator: ViewableCoordinator<AppPresentable> {
   }
   
   override func start() {
-    attachCoordinators()
+    Task { await attachCoordinators() }
   }
-  
-  func attachCoordinators() {
-    let homeCoordinator = homeContainable.coordinator(
-      navigationControllerable: homeNavigationControllerable,
-      listener: self
-    )
-    let searchChallengeCoordinator = searchChallengeContainable.coordinator(listener: self)
-    let myPageCoordinator = myPageContainable.coordinator(listener: self)
+}
+
+// MARK: - LogIn
+private extension AppCoordinator {
+  @MainActor func attachLogIn(at navigationController: NavigationControllerable) {
+    guard loginCoordinator == nil else { return }
+
+    let coordinator = loginContainer.coordinator(listener: self)
+    addChild(coordinator)
+    navigationController.navigationController.hideTabBar(animated: true)
+    navigationController.pushViewController(coordinator.viewControllerable, animated: true)
+    self.loginCoordinator = coordinator
+    self.loginPresentNavigationControllerable = navigationController
+  }
+
+  @MainActor func detachLogIn(willPopViewConroller: Bool) {
+    guard
+      let coordinator = loginCoordinator,
+      let navigation = loginPresentNavigationControllerable
+    else { return }
+
+    removeChild(coordinator)
+    self.loginCoordinator = nil
+    self.loginPresentNavigationControllerable = nil
     
-    searchChallengeNavigationControllerable.setViewControllers([searchChallengeCoordinator.viewControllerable])
-    myPageNavigationControllerable.setViewControllers([myPageCoordinator.viewControllerable])
-        
+    navigation.navigationController.showTabBar(animted: true)
+    if willPopViewConroller { navigation.popViewController(animated: true) }
+  }
+}
+
+// MARK: - Attach Methods
+private extension AppCoordinator {
+  @MainActor func attachCoordinators() {
+    attachHome()
+    attachSearchChallenge()
+    attachMyPage()
+    
     presenter.attachNavigationControllers(
       homeNavigationControllerable,
       searchChallengeNavigationControllerable,
       myPageNavigationControllerable
     )
+  }
+  
+  @MainActor func reloadAllTab() {
+    detachSearchChallenge()
+    detachMyPage()
     
-    addChild(homeCoordinator)
-    addChild(searchChallengeCoordinator)
-    addChild(myPageCoordinator)
+    homeCoorinator?.start()
+    attachSearchChallenge()
+    attachMyPage()
+  }
+}
+
+// MARK: - Home
+private extension AppCoordinator {
+  @MainActor func attachHome() {
+    guard homeCoorinator == nil else { return }
+
+    let coordinator = homeContainer.coordinator(
+      navigationControllerable: homeNavigationControllerable,
+      listener: self
+    )
+    addChild(coordinator)
+    self.homeCoorinator = coordinator
+  }
+}
+
+// MARK: - SearchChallenge
+private extension AppCoordinator {
+  @MainActor func attachSearchChallenge() {
+    guard searchChallengeCoordinator == nil else { return }
+    
+    let coordinator = searchChallengeContainer.coordinator(listener: self)
+    searchChallengeNavigationControllerable.setViewControllers([coordinator.viewControllerable])
+    addChild(coordinator)
+    self.searchChallengeCoordinator = coordinator
+  }
+  
+  @MainActor func detachSearchChallenge() {
+    guard let coordinator = searchChallengeCoordinator else { return }
+    removeChild(coordinator)
+    self.searchChallengeCoordinator = nil
+  }
+}
+
+// MARK: - MyPage
+private extension AppCoordinator {
+  @MainActor func attachMyPage() {
+    guard searchChallengeCoordinator == nil else { return }
+    
+    let coordinator = myPageContainer.coordinator(listener: self)
+    myPageNavigationControllerable.setViewControllers([coordinator.viewControllerable])
+    addChild(coordinator)
+    self.myPageCoordinator = coordinator
+  }
+  
+  @MainActor func detachMyPage() {
+    guard let coordinator = myPageCoordinator else { return }
+    removeChild(coordinator)
+    self.myPageCoordinator = nil
   }
 }
 
 // MARK: - HomeListener
-extension AppCoordinator: HomeListener { }
+extension AppCoordinator: HomeListener {
+  func requestLogInAtHome() {
+    Task { await attachLogIn(at: homeNavigationControllerable) }
+  }
+
+  func authenticatedFailedAtHome() {
+    Task { await reloadAllTab() }
+  }
+}
 
 // MARK: - SearchChallengeListener
 extension AppCoordinator: SearchChallengeListener { }
@@ -82,5 +176,20 @@ extension AppCoordinator: SearchChallengeListener { }
 extension AppCoordinator: MyPageListener {
   func isUserResigned() {
     presenter.changeNavigationControllerToHome()
+  }
+}
+
+// MARK: - LoginListener
+extension AppCoordinator: LogInListener {
+  func didFinishLogIn(userName: String) {
+    // TODO: - 환영합니다" 메시지 띄우기
+    Task {
+      await detachLogIn(willPopViewConroller: false)
+      await reloadAllTab()
+    }
+  }
+  
+  func didTapBackButtonAtLogIn() {
+    Task { await detachLogIn(willPopViewConroller: true) }
   }
 }

--- a/Projects/App/Sources/AppViewController.swift
+++ b/Projects/App/Sources/AppViewController.swift
@@ -44,7 +44,7 @@ extension AppViewController: AppPresentable {
   }
   
   func changeNavigationControllerToHome() {
-    guard let _ = viewControllers else { return }
+    guard viewControllers != nil else { return }
     selectedIndex = 0 // 첫 번째 탭으로 전환
   }
   
@@ -57,6 +57,21 @@ extension AppViewController: AppPresentable {
   func changeNavigationControllerToMyPage() {
     guard let viewControllers, viewControllers.count > 2 else { return }
     selectedIndex = 2 // 세 번째 탭으로 전환
+  }
+  
+  func presentWelcomeToastView(_ username: String) {
+    let toastView = ToastView(
+      tipPosition: .none,
+      text: "\(username)님 환영합니다!",
+      icon: .bulbWhite
+    )
+    
+    toastView.setConstraints {
+      $0.centerX.equalToSuperview()
+      $0.bottom.equalToSuperview().inset(64)
+    }
+    
+    toastView.present(at: self.view)
   }
 }
 

--- a/Projects/Data/Repository/Implementations/AuthRepositoryImpl/AuthRepositoryImpl.swift
+++ b/Projects/Data/Repository/Implementations/AuthRepositoryImpl/AuthRepositoryImpl.swift
@@ -24,7 +24,11 @@ public struct AuthRepositoryImpl: AuthRepository {
         .request(AuthAPI.isLogIn).value
       return result.statusCode == 200
     } catch {
+      if case let NetworkError.networkFailed(reason) = error, reason == .interceptorMapping {
+        return false
+      } else {
       throw APIError.serverError
+      }
     }
   }
 }

--- a/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeAPI.swift
+++ b/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeAPI.swift
@@ -75,14 +75,12 @@ extension ChallengeAPI: TargetType {
         let parameters = ["page": page, "size": size]
         return .requestParameters(parameters: parameters, encoding: URLEncoding.queryString)
         
-      case let .joinChallenge(challengeId):
-        let parameters = ["challengeId": "\(challengeId)"]
-        return .requestParameters(parameters: parameters, encoding: URLEncoding.queryString)
+      case .joinChallenge:
+        return .requestPlain
 
-      case let .joinPrivateChallenge(challengeId, code):
-        let urlParameters = ["challengeId": challengeId]
-        let bodyParameters = ["invitationCode": code]
-        return .requestCompositeParameters(bodyParameters: bodyParameters, urlParameters: urlParameters)
+      case let .joinPrivateChallenge(_, code):
+        let parameters = ["invitationCode": code]
+        return .requestParameters(parameters: parameters, encoding: JSONEncoding.default)
                 
       case let .uploadChallengeProof(_, image, imageType):
         let multiPartBody = MultipartFormDataBodyPart(

--- a/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeRepositoryImpl.swift
+++ b/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeRepositoryImpl.swift
@@ -72,9 +72,7 @@ public extension ChallengeRepositoryImpl {
       api: ChallengeAPI.challengeProveMemberCount(challengeId: challengeId),
       responseType: ChallengeProveMemberCountResponseDTO.self
     ).value
-    
-    print(result.feedMemberCnt)
-    
+        
     return result.feedMemberCnt
   }
     

--- a/Projects/DesignSystem/Resources/Images/Images.xcassets/home/home.member.createChallenge.imageset/Contents.json
+++ b/Projects/DesignSystem/Resources/Images/Images.xcassets/home/home.member.createChallenge.imageset/Contents.json
@@ -8,8 +8,5 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
-  },
-  "properties" : {
-    "preserves-vector-representation" : true
   }
 }

--- a/Projects/DesignSystem/Sources/HashTagView/HashTagCell.swift
+++ b/Projects/DesignSystem/Sources/HashTagView/HashTagCell.swift
@@ -12,7 +12,7 @@ import RxSwift
 import SnapKit
 import Core
 
-public enum HashTagType {
+public enum HashTagType: Equatable {
   case icon(size: ChipSize, type: IconChipType)
   case text(size: ChipSize, type: TextChipType)
   
@@ -28,10 +28,12 @@ public enum HashTagType {
 
 public final class HashTagCell: UICollectionViewCell {
   fileprivate var chip: UIView = UIView()
+  private var type: HashTagType?
   
   public func configure(type: HashTagType, text: String) {
+    guard self.type != type else { return configureText(text) }
+    self.type = type
     self.chip = type.make(with: text)
-    
     setupUI(with: chip)
   }
 }
@@ -44,6 +46,14 @@ private extension HashTagCell {
     
     contentView.addSubview(chip)
     chip.snp.makeConstraints { $0.edges.equalToSuperview() }
+  }
+  
+  func configureText(_ text: String) {
+    if let view = chip as? TextChip {
+      view.text = text
+    } else if let view = chip as? IconChip {
+      view.text = text
+    }
   }
 }
 

--- a/Projects/Presentation/Challenge/Implementations/EnterChallengeGoal/EnterChallengeGoalCoordinator.swift
+++ b/Projects/Presentation/Challenge/Implementations/EnterChallengeGoal/EnterChallengeGoalCoordinator.swift
@@ -11,7 +11,7 @@ import Core
 protocol EnterChallengeGoalListener: AnyObject {
   func didTapBackButtonAtEnterChallengeGoal()
   func didFinishEnterChallengeGoal(_ goal: String)
-  func requestLoginAtEnterChallengeGoal()
+  func authenticatedFailedAtEnterChallengeGoal()
 }
 
 protocol EnterChallengeGoalPresentable { }
@@ -45,7 +45,7 @@ extension EnterChallengeGoalCoordinator: EnterChallengeGoalCoordinatable {
     listener?.didFinishEnterChallengeGoal("")
   }
   
-  func requestLogin() {
-    listener?.requestLoginAtEnterChallengeGoal()
+  func authenticatedFailed() {
+    listener?.authenticatedFailedAtEnterChallengeGoal()
   }
 }

--- a/Projects/Presentation/Challenge/Implementations/EnterChallengeGoal/EnterChallengeGoalViewController.swift
+++ b/Projects/Presentation/Challenge/Implementations/EnterChallengeGoal/EnterChallengeGoalViewController.swift
@@ -27,8 +27,7 @@ final class EnterChallengeGoalViewController: UIViewController, ViewControllerab
   private let challengeName: String
 
   private let didTapSkipButtonRelay = PublishRelay<Void>()
-  private let didTapLoginButtonRelay = PublishRelay<Void>()
-  
+
   // MARK: - UI Components
   private let navigationBar = PhotiNavigationBar(leftView: .backButton, displayMode: .dark)
   private let imageView = UIImageView(image: .challengeEditGoal)
@@ -88,6 +87,7 @@ final class EnterChallengeGoalViewController: UIViewController, ViewControllerab
 // MARK: - UI Methods
 private extension EnterChallengeGoalViewController {
   func setupUI() {
+    view.backgroundColor = .white
     navigationBar.title = challengeName
     
     setViewHierarchy()
@@ -161,8 +161,7 @@ private extension EnterChallengeGoalViewController {
       didTapBackButton: navigationBar.rx.didTapBackButton,
       goalText: textField.rx.text,
       didTapSaveButton: saveButton.rx.tap,
-      didTapSkipButton: didTapSkipButtonRelay.asSignal(),
-      didTapLoginButton: didTapLoginButtonRelay.asSignal()
+      didTapSkipButton: didTapSkipButtonRelay.asSignal()
     )
     let output = viewModel.transform(input: input)
     
@@ -200,21 +199,6 @@ private extension EnterChallengeGoalViewController {
     output.networkUnstable
       .emit(with: self) { owner, _ in
         owner.presentNetworkUnstableAlert()
-      }
-      .disposed(by: disposeBag)
-    
-    output.loginTrigger
-      .emit(with: self) { owner, _ in
-        let alert = owner.presentLoginTriggerAlert()
-        owner.bind(alert: alert)
-      }
-      .disposed(by: disposeBag)
-  }
-  
-  func bind(alert: AlertViewController) {
-    alert.rx.didTapConfirmButton
-      .bind(with: self) { owner, _ in
-        owner.didTapLoginButtonRelay.accept(())
       }
       .disposed(by: disposeBag)
   }

--- a/Projects/Presentation/Challenge/Implementations/Member/ChallengeContainer.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/ChallengeContainer.swift
@@ -8,13 +8,11 @@
 
 import Challenge
 import Core
-import LogIn
 import Report
 import UseCase
 
 public protocol ChallengeDependency: Dependency {
   var reportContainable: ReportContainable { get }
-  var loginContainable: LogInContainable { get }
   var challengeUseCase: ChallengeUseCase { get }
   var feedUseCase: FeedUseCase { get }
 }
@@ -44,7 +42,6 @@ public final class ChallengeContainer:
       feedContainer: feedContainer,
       descriptionContainer: descriptionContainer,
       participantContainer: participantContainer,
-      logInContainer: dependency.loginContainable,
       reportContainer: dependency.reportContainable
     )
     coordinator.listener = listener

--- a/Projects/Presentation/Challenge/Implementations/Member/ChallengeCoordinator.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/ChallengeCoordinator.swift
@@ -8,7 +8,6 @@
 
 import Core
 import Challenge
-import LogIn
 import Report
 
 protocol ChallengePresentable {
@@ -16,7 +15,6 @@ protocol ChallengePresentable {
   func didChangeContentOffsetAtMainContainer(_ offset: Double)
   func presentChallengeNotFoundWaring()
   func presentNetworkWarning(reason: String?)
-  func presentLoginTrrigerWarning()
 }
 
 final class ChallengeCoordinator: ViewableCoordinator<ChallengePresentable> {
@@ -34,9 +32,6 @@ final class ChallengeCoordinator: ViewableCoordinator<ChallengePresentable> {
   private let descriptionContainer: DescriptionContainable
   private var descriptionCoordinator: ViewableCoordinating?
   
-  private let logInContainer: LogInContainable
-  private var logInCoordinator: ViewableCoordinating?
-  
   private let reportContainer: ReportContainable
   private var reportCoordinator: ViewableCoordinating?
   
@@ -47,7 +42,6 @@ final class ChallengeCoordinator: ViewableCoordinator<ChallengePresentable> {
     feedContainer: FeedContainable,
     descriptionContainer: DescriptionContainable,
     participantContainer: ParticipantContainable,
-    logInContainer: LogInContainable,
     reportContainer: ReportContainable
   ) {
     self.viewModel = viewModel
@@ -55,7 +49,6 @@ final class ChallengeCoordinator: ViewableCoordinator<ChallengePresentable> {
     self.feedContainer = feedContainer
     self.descriptionContainer = descriptionContainer
     self.participantContainer = participantContainer
-    self.logInContainer = logInContainer
     self.reportContainer = reportContainer
     super.init(viewControllerable)
     viewModel.coordinator = self
@@ -91,26 +84,6 @@ final class ChallengeCoordinator: ViewableCoordinator<ChallengePresentable> {
     self.feedCoordinator = feedCoordinator
     self.descriptionCoordinator = descriptionCoordinator
     self.participantCoordinator = participantCoordinator
-  }
-}
-
-// MARK: - LogIn
-extension ChallengeCoordinator {
-  func attachLogIn() {
-    guard logInCoordinator == nil else { return }
-    
-    let coordinator = logInContainer.coordinator(listener: self)
-    addChild(coordinator)
-    viewControllerable.pushViewController(coordinator.viewControllerable, animated: true)
-    self.logInCoordinator = coordinator
-  }
-  
-  func detachLogIn() {
-    guard let coordinator = logInCoordinator else { return }
-    
-    removeChild(coordinator)
-    viewControllerable.popViewController(animated: true)
-    self.logInCoordinator = nil
   }
 }
 
@@ -195,21 +168,7 @@ extension ChallengeCoordinator: ParticipantListener {
   
   func networkUnstableAtParticipant() {
     presenter.presentNetworkWarning(reason: nil)
-  }
-  
-  func requestLoginAtPariticipant() { }
 }
-
-// MARK: - LogInListener
-extension ChallengeCoordinator: LogInListener {
-  // TODO: 로그인 여부에 따른 환영합니다.
-  func didFinishLogIn(userName: String) {
-    detachLogIn()
-  }
-  
-  func didTapBackButtonAtLogIn() {
-    detachLogIn()
-  }
 }
 
 // MARK: - ReportListener

--- a/Projects/Presentation/Challenge/Implementations/Member/ChallengeCoordinator.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/ChallengeCoordinator.swift
@@ -116,6 +116,10 @@ extension ChallengeCoordinator: ChallengeCoordinatable {
   func attachChallengeReport() {
     attachReport(reportType: .challenge)
   }
+  
+  func authenticatedFailed() {
+    listener?.authenticatedFailedAtChallenge()
+  }
 }
 
 // MARK: - FeedListener
@@ -125,7 +129,7 @@ extension ChallengeCoordinator: FeedListener {
   }
   
   func authenticatedFailedAtFeed() {
-    presenter.presentLoginTrrigerWarning()
+    listener?.authenticatedFailedAtChallenge()
   }
   
   func networkUnstableAtFeed(reason: String?) {
@@ -144,7 +148,7 @@ extension ChallengeCoordinator: FeedListener {
 // MARK: - DescriptionListener
 extension ChallengeCoordinator: DescriptionListener {
   func authenticatedFailedAtDescription() {
-    presenter.presentLoginTrrigerWarning()
+    listener?.authenticatedFailedAtChallenge()
   }
   
   func networkUnstableAtDescription() {
@@ -163,12 +167,12 @@ extension ChallengeCoordinator: ParticipantListener {
   }
 
   func authenticatedFailedAtParticipant() {
-    presenter.presentLoginTrrigerWarning()
+    listener?.authenticatedFailedAtChallenge()
   }
   
   func networkUnstableAtParticipant() {
     presenter.presentNetworkWarning(reason: nil)
-}
+  }
 }
 
 // MARK: - ReportListener

--- a/Projects/Presentation/Challenge/Implementations/Member/ChallengeViewController.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/ChallengeViewController.swift
@@ -29,7 +29,6 @@ final class ChallengeViewController: UIViewController, ViewControllerable {
   
   private let viewDidLoadRelay = PublishRelay<Void>()
   private let didTapConfirmButtonAtAlert = PublishRelay<Void>()
-  private let didTapLoginButtonAtAlert = PublishRelay<Void>()
   private let didTapReportButton = PublishRelay<Void>()
   private let didTapLeaveButton = PublishRelay<Void>()
   
@@ -138,7 +137,6 @@ private extension ChallengeViewController {
       viewDidLoad: viewDidLoadRelay.asSignal(),
       didTapBackButton: navigationBar.rx.didTapBackButton.asSignal(),
       didTapConfirmButtonAtAlert: didTapConfirmButtonAtAlert.asSignal(),
-      didTapLoginButtonAtAlert: didTapLoginButtonAtAlert.asSignal(),
       didTapLeaveButton: didTapLeaveButton.asSignal(),
       didTapReportButton: didTapReportButton.asSignal()
     )
@@ -176,12 +174,6 @@ private extension ChallengeViewController {
     output.networnUnstable
       .emit(with: self) { owner, _ in
         owner.presentNetworkWarning(reason: nil)
-      }
-      .disposed(by: disposeBag)
-    
-    output.loginTrigger
-      .emit(with: self) { owner, _ in
-        owner.presentLoginTrrigerWarning()
       }
       .disposed(by: disposeBag)
   }
@@ -227,16 +219,6 @@ extension ChallengeViewController: ChallengePresentable {
   
   func presentNetworkWarning(reason: String?) {
     presentNetworkUnstableAlert(reason: reason)
-  }
-  
-  func presentLoginTrrigerWarning() {
-    let alert = self.presentLoginTriggerAlert()
-    
-    alert.rx.didTapConfirmButton
-      .bind(with: self) { owner, _ in
-        owner.didTapLoginButtonAtAlert.accept(())
-      }
-      .disposed(by: disposeBag)
   }
 }
 

--- a/Projects/Presentation/Challenge/Implementations/Member/ChallengeViewModel.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/ChallengeViewModel.swift
@@ -40,14 +40,12 @@ final class ChallengeViewModel: ChallengeViewModelType {
   private let memberCount = BehaviorRelay<Int>(value: 0)
   private let challengeNotFoundRelay = PublishRelay<Void>()
   private let networkUnstable = PublishRelay<Void>()
-  private let loginTriggerRelay = PublishRelay<Void>()
   
   // MARK: - Input
   struct Input {
     let viewDidLoad: Signal<Void>
     let didTapBackButton: Signal<Void>
     let didTapConfirmButtonAtAlert: Signal<Void>
-    let didTapLoginButtonAtAlert: Signal<Void>
     let didTapLeaveButton: Signal<Void>
     let didTapReportButton: Signal<Void>
   }
@@ -58,7 +56,6 @@ final class ChallengeViewModel: ChallengeViewModelType {
     let memberCount: Driver<Int>
     let challengeNotFound: Signal<Void>
     let networnUnstable: Signal<Void>
-    let loginTrigger: Signal<Void>
   }
   
   // MARK: - Initializers
@@ -77,12 +74,6 @@ final class ChallengeViewModel: ChallengeViewModelType {
     input.didTapBackButton
       .emit(with: self) { owner, _ in
         owner.coordinator?.didTapBackButton()
-      }
-      .disposed(by: disposeBag)
-    
-    input.didTapLoginButtonAtAlert
-      .emit(with: self) { owner, _ in
-        owner.coordinator?.attachLogIn()
       }
       .disposed(by: disposeBag)
     
@@ -108,8 +99,7 @@ final class ChallengeViewModel: ChallengeViewModelType {
       challengeInfo: challengeModelRelay.asDriver(),
       memberCount: memberCount.asDriver(),
       challengeNotFound: challengeNotFoundRelay.asSignal(),
-      networnUnstable: networkUnstable.asSignal(),
-      loginTrigger: loginTriggerRelay.asSignal()
+      networnUnstable: networkUnstable.asSignal()
     )
   }
 }
@@ -154,7 +144,7 @@ private extension ChallengeViewModel {
     
     switch error {
       case .authenticationFailed:
-        loginTriggerRelay.accept(())
+        coordinator?.authenticatedFailed()
       case let .challengeFailed(reason) where reason == .challengeNotFound:
         challengeNotFoundRelay.accept(())
       default: networkUnstable.accept(())

--- a/Projects/Presentation/Challenge/Implementations/Member/ChallengeViewModel.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/ChallengeViewModel.swift
@@ -14,7 +14,7 @@ import UseCase
 protocol ChallengeCoordinatable: AnyObject {
   func didTapBackButton()
   func didTapConfirmButtonAtAlert()
-  func attachLogIn()
+  func authenticatedFailed()
   func leaveChallenge(challengeId: Int)
   func attachChallengeReport()
 }

--- a/Projects/Presentation/Challenge/Implementations/Member/Description/DescriptionViewController.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/Description/DescriptionViewController.swift
@@ -117,12 +117,8 @@ private extension DescriptionViewController {
   func bind() {
     let input = DescriptionViewModel.Input(requestData: requestData.asSignal())
     let output = viewModel.transform(input: input)
-    
-    viewBind()
     viewModelBind(for: output)
   }
-  
-  func viewBind() { }
   
   func viewModelBind(for output: DescriptionViewModel.Output) {
     output.rules

--- a/Projects/Presentation/Challenge/Implementations/Member/Participant/ParticipantCoordinator.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/Participant/ParticipantCoordinator.swift
@@ -10,7 +10,6 @@ import Core
 
 protocol ParticipantListener: AnyObject {
   func didChangeContentOffsetAtParticipant(_ offset: Double)
-  func requestLoginAtPariticipant()
   func authenticatedFailedAtParticipant()
   func networkUnstableAtParticipant()
 }
@@ -98,7 +97,7 @@ extension ParticipantCoordinator: EnterChallengeGoalListener {
     }
   }
   
-  func requestLoginAtEnterChallengeGoal() {
-    listener?.requestLoginAtPariticipant()
+  func authenticatedFailedAtEnterChallengeGoal() {
+    listener?.authenticatedFailedAtParticipant()
   }
 }

--- a/Projects/Presentation/Challenge/Implementations/NoneMember/LogInGuide/LogInGuideViewController.swift
+++ b/Projects/Presentation/Challenge/Implementations/NoneMember/LogInGuide/LogInGuideViewController.swift
@@ -56,6 +56,7 @@ final class LogInGuideViewController: UIViewController, ViewControllerable {
 // MARK: - UI Methods
 private extension LogInGuideViewController {
   func setupUI() {
+    view.backgroundColor = .white
     setViewHierarchy()
     setConstraints()
   }

--- a/Projects/Presentation/Challenge/Implementations/NoneMember/NoneMemberChallengeCoordinator.swift
+++ b/Projects/Presentation/Challenge/Implementations/NoneMember/NoneMemberChallengeCoordinator.swift
@@ -10,7 +10,9 @@ import Challenge
 import Core
 import LogIn
 
-protocol NoneMemberChallengePresentable { }
+@MainActor protocol NoneMemberChallengePresentable {
+  func presentWelcomeToastView(_ username: String)
+}
 
 final class NoneMemberChallengeCoordinator: ViewableCoordinator<NoneMemberChallengePresentable> {
   weak var listener: NoneMemberChallengeListener?
@@ -140,6 +142,7 @@ extension NoneMemberChallengeCoordinator: LogInListener {
   func didFinishLogIn(userName: String) {
     detachLogIn(animted: false)
     detachLogInGuide(animted: true)
+    Task { await presenter.presentWelcomeToastView(userName) }
   }
   
   func didTapBackButtonAtLogIn() {

--- a/Projects/Presentation/Challenge/Implementations/NoneMember/NoneMemberChallengeCoordinator.swift
+++ b/Projects/Presentation/Challenge/Implementations/NoneMember/NoneMemberChallengeCoordinator.swift
@@ -52,20 +52,20 @@ private extension NoneMemberChallengeCoordinator {
     viewControllerable.popViewController(animated: true)
   }
   
-  func detachLogInGuide() {
+  func detachLogInGuide(animted: Bool) {
     guard let coordinator = logInGuideCoordinator else { return }
     
     removeChild(coordinator)
     self.logInGuideCoordinator = nil
-    viewControllerable.popViewController(animated: true)
+    viewControllerable.popViewController(animated: animted)
   }
   
-  func detachLogIn() {
+  func detachLogIn(animted: Bool) {
     guard let coordinator = logInCoordinator else { return }
     
     removeChild(coordinator)
     self.logInCoordinator = nil
-    viewControllerable.popViewController(animated: true)
+    viewControllerable.popViewController(animated: animted)
   }
 }
 
@@ -116,19 +116,18 @@ extension NoneMemberChallengeCoordinator: EnterChallengeGoalListener {
   }
   
   func didFinishEnterChallengeGoal(_ goal: String) {
-    detachEnterChallengeGoal()
     listener?.didJoinChallenge()
   }
   
-  func requestLoginAtEnterChallengeGoal() {
-    attachLogIn()
+  func authenticatedFailedAtEnterChallengeGoal() {
+    listener?.authenticatedFailedAtNoneMemberChallenge()
   }
 }
 
 // MARK: - LogInGuideListener
 extension NoneMemberChallengeCoordinator: LogInGuideListener {
   func didTapBackButtonAtLogInGuide() {
-    detachLogInGuide()
+    detachLogInGuide(animted: true)
   }
   
   func didTapLogInButtonAtLogInGuide() {
@@ -139,11 +138,11 @@ extension NoneMemberChallengeCoordinator: LogInGuideListener {
 // MARK: - LogInListener
 extension NoneMemberChallengeCoordinator: LogInListener {
   func didFinishLogIn(userName: String) {
-    detachLogIn()
-    detachLogInGuide()
+    detachLogIn(animted: false)
+    detachLogInGuide(animted: true)
   }
   
   func didTapBackButtonAtLogIn() {
-    detachLogIn()
+    detachLogIn(animted: true)
   }
 }

--- a/Projects/Presentation/Challenge/Implementations/NoneMember/NoneMemberChallengeViewController.swift
+++ b/Projects/Presentation/Challenge/Implementations/NoneMember/NoneMemberChallengeViewController.swift
@@ -80,6 +80,7 @@ final class NoneMemberChallengeViewController: UIViewController, ViewControllera
 // MARK: - UI Methods
 private extension NoneMemberChallengeViewController {
   func setupUI() {
+    view.backgroundColor = .white
     setViewHierarchy()
     setConstraints()
   }
@@ -106,26 +107,25 @@ private extension NoneMemberChallengeViewController {
     
     mainContainerView.snp.makeConstraints {
       $0.top.equalTo(navigationBar.snp.bottom).offset(13)
-      $0.centerX.equalToSuperview()
+      $0.leading.trailing.equalToSuperview().inset(24)
     }
     
     leftView.snp.makeConstraints {
       $0.leading.equalToSuperview()
       $0.top.bottom.equalTo(rightView)
-      $0.width.equalTo(175)
+      $0.width.equalToSuperview().multipliedBy(0.535)
     }
     
     rightView.snp.makeConstraints {
       $0.leading.equalTo(leftView.snp.trailing).offset(16)
       $0.trailing.top.bottom.equalToSuperview()
-      $0.width.equalTo(136)
     }
     
     setLeftViewsConstraints()
     setRightViewsConstraints()
     
     joinButton.snp.makeConstraints {
-      $0.centerX.equalToSuperview()
+      $0.leading.trailing.equalToSuperview().inset(24)
       $0.bottom.equalToSuperview().inset(48)
     }
   }

--- a/Projects/Presentation/Challenge/Implementations/NoneMember/NoneMemberChallengeViewController.swift
+++ b/Projects/Presentation/Challenge/Implementations/NoneMember/NoneMemberChallengeViewController.swift
@@ -279,7 +279,22 @@ private extension NoneMemberChallengeViewController {
 }
 
 // MARK: - NoneMemberChallengePresentable
-extension NoneMemberChallengeViewController: NoneMemberChallengePresentable { }
+extension NoneMemberChallengeViewController: NoneMemberChallengePresentable {
+  func presentWelcomeToastView(_ username: String) {
+    let toastView = ToastView(
+      tipPosition: .none,
+      text: "\(username)님 환영합니다!",
+      icon: .bulbWhite
+    )
+    
+    toastView.setConstraints {
+      $0.centerX.equalToSuperview()
+      $0.bottom.equalToSuperview().inset(64)
+    }
+    
+    toastView.present(at: self.view)
+  }
+}
 
 // MARK: - UICollectionViewDataSource
 extension NoneMemberChallengeViewController: UICollectionViewDataSource {

--- a/Projects/Presentation/Challenge/Implementations/NoneMember/NoneMemberChallengeViewModel.swift
+++ b/Projects/Presentation/Challenge/Implementations/NoneMember/NoneMemberChallengeViewModel.swift
@@ -193,7 +193,7 @@ private extension NoneMemberChallengeViewModel {
   }
   
   func requestJoinChallengeFailed(with error: Error) {
-    guard let error = error as? APIError else { return }
+    guard let error = error as? APIError else { return requestFailedRelay.accept(()) }
     print(error)
     switch error {
       case let .challengeFailed(reason) where reason == .invalidInvitationCode:

--- a/Projects/Presentation/Challenge/Implementations/NoneMember/NoneMemberChallengeViewModel.swift
+++ b/Projects/Presentation/Challenge/Implementations/NoneMember/NoneMemberChallengeViewModel.swift
@@ -192,6 +192,24 @@ private extension NoneMemberChallengeViewModel {
     }
   }
   
+  func requestJoinChallengeFailed(with error: Error) {
+    guard let error = error as? APIError else { return }
+    print(error)
+    switch error {
+      case let .challengeFailed(reason) where reason == .invalidInvitationCode:
+        verifyCodeResultRelay.accept(false)
+      case let .challengeFailed(reason) where reason == .alreadyJoinedChallenge:
+        alreadyJoinedRelay.accept(())
+      case .authenticationFailed:
+        coordinator?.attachLogInGuide()
+      default:
+        requestFailedRelay.accept(())
+    }
+  }
+}
+
+// MARK: - Internal Methods
+extension NoneMemberChallengeViewModel {
   func requestJoinPublicChallenge() async {
     do {
       try await useCase.joinPublicChallenge(id: challengeId).value
@@ -210,21 +228,6 @@ private extension NoneMemberChallengeViewModel {
       verifyCodeResultRelay.accept(true)
     } catch {
       requestJoinChallengeFailed(with: error)
-    }
-  }
-  
-  func requestJoinChallengeFailed(with error: Error) {
-    guard let error = error as? APIError else { return }
-    
-    switch error {
-      case let .challengeFailed(reason) where reason == .invalidInvitationCode:
-        verifyCodeResultRelay.accept(false)
-      case let .challengeFailed(reason) where reason == .alreadyJoinedChallenge:
-        alreadyJoinedRelay.accept(())
-      case .authenticationFailed:
-        coordinator?.attachLogInGuide()
-      default:
-        requestFailedRelay.accept(())
     }
   }
 }

--- a/Projects/Presentation/Challenge/Implementations/NoneMember/Views/ChallengeThumbnailView.swift
+++ b/Projects/Presentation/Challenge/Implementations/NoneMember/Views/ChallengeThumbnailView.swift
@@ -16,13 +16,12 @@ final class ChallengeThumbnailView: UIView, ChallengeInformationPresentable {
   private let dimmedLayer: CALayer = {
     let layer = CALayer()
     layer.backgroundColor = UIColor(red: 0.118, green: 0.136, blue: 0.149, alpha: 0.4).cgColor
-    layer.cornerRadius = 10
     
     return layer
   }()
   private let countLabel = UILabel()
-  private let thumbnailImageView = UIImageView(image: .challengeNonMemberDefaultCard)
-  
+  private let thumbnailImageView = UIImageView()
+
   // MARK: - Initializers
   init() {
     super.init(frame: .zero)
@@ -76,8 +75,8 @@ final class ChallengeThumbnailView: UIView, ChallengeInformationPresentable {
 // MARK: - UI Methods
 private extension ChallengeThumbnailView {
   func setupUI() {
-    thumbnailImageView.layer.cornerRadius = 10
-    thumbnailImageView.clipsToBounds = true
+    self.layer.cornerRadius = 10
+    self.clipsToBounds = true
     setViewHierarchy()
     setConstraints()
   }

--- a/Projects/Presentation/Challenge/Implementations/NoneMember/Views/InvitationCodeView/InvitationCodeViewController.swift
+++ b/Projects/Presentation/Challenge/Implementations/NoneMember/Views/InvitationCodeView/InvitationCodeViewController.swift
@@ -78,8 +78,8 @@ final class InvitationCodeViewController: UIViewController {
     keyboardHideNotification = registerKeyboardHideNotification()
   }
   
-  override func viewDidAppear(_ animated: Bool) {
-    super.viewDidAppear(animated)
+  override func viewIsAppearing(_ animated: Bool) {
+    super.viewIsAppearing(animated)
     presentWithAnimation()
   }
   
@@ -87,11 +87,24 @@ final class InvitationCodeViewController: UIViewController {
     super.viewDidDisappear(animated)
     removeKeyboardNotification(keyboardShowNotification, keyboardHideNotification)
   }
+  
+  // MARK: - UIResponder
+  override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+    view.endEditing(true)
+  }
+}
+
+// MARK: - Internal Methods
+extension InvitationCodeViewController {
+  func present(to viewController: UIViewController) {
+    viewController.present(self, animated: true)
+  }
 }
 
 // MARK: - UI Methods
 private extension InvitationCodeViewController {
   func setupUI() {
+    mainContentView.isHidden = true
     setViewHierarchy()
     setConstraints()
   }
@@ -212,6 +225,7 @@ extension InvitationCodeViewController: KeyboardListener {
 private extension InvitationCodeViewController {
   func presentWithAnimation() {
     mainContentView.frame.origin.y = view.frame.height
+    mainContentView.isHidden = false
     UIView.animate(withDuration: 0.4) {
       self.mainContentView.center.y = self.view.center.y
       self.mainContentView.layoutIfNeeded()

--- a/Projects/Presentation/Challenge/Interfaces/Challenge.swift
+++ b/Projects/Presentation/Challenge/Interfaces/Challenge.swift
@@ -22,6 +22,7 @@ public protocol ChallengeContainable: Containable {
 }
 
 public protocol ChallengeListener: AnyObject {
+  func authenticatedFailedAtChallenge()
   func didTapBackButtonAtChallenge()
   func shouldDismissChallenge()
   func leaveChallenge(challengeId: Int)

--- a/Projects/Presentation/Challenge/Interfaces/NoneMemberChallenge.swift
+++ b/Projects/Presentation/Challenge/Interfaces/NoneMemberChallenge.swift
@@ -15,4 +15,5 @@ public protocol NoneMemberChallengeContainable: Containable {
 public protocol NoneMemberChallengeListener: AnyObject {
   func didTapBackButtonAtNoneMemberChallenge()
   func didJoinChallenge()
+  func authenticatedFailedAtNoneMemberChallenge()
 }

--- a/Projects/Presentation/Home/Implementations/ChallengeHome/ChallengeHomeCoordinator.swift
+++ b/Projects/Presentation/Home/Implementations/ChallengeHome/ChallengeHomeCoordinator.swift
@@ -10,7 +10,7 @@ import Challenge
 import Core
 
 protocol ChallengeHomeListener: AnyObject {
-  func requestLogInAtChallengeHome()
+  func authenticatedFailedAtChallengeHome()
   func requestNoneChallengeHomeAtChallengeHome()
 }
 
@@ -35,8 +35,8 @@ final class ChallengeHomeCoordinator: ViewableCoordinator<ChallengeHomePresentab
     viewModel.coordinator = self
   }
   
-  func requestLogIn() {
-    listener?.requestLogInAtChallengeHome()
+  func authenticatedFailed() {
+    listener?.authenticatedFailedAtChallengeHome()
   }
   
   func requestNoneChallengeHome() {
@@ -86,6 +86,10 @@ extension ChallengeHomeCoordinator {
 
 // MARK: - ChallengeListener
 extension ChallengeHomeCoordinator: ChallengeListener {
+  func authenticatedFailedAtChallenge() {
+    listener?.authenticatedFailedAtChallengeHome()
+  }
+  
   func didTapBackButtonAtChallenge() {
     detachChallenge()
   }

--- a/Projects/Presentation/Home/Implementations/ChallengeHome/ChallengeHomeViewController.swift
+++ b/Projects/Presentation/Home/Implementations/ChallengeHome/ChallengeHomeViewController.swift
@@ -31,7 +31,6 @@ final class ChallengeHomeViewController: UIViewController, CameraRequestable, Vi
   
   private let requestData = PublishRelay<Void>()
   private let uploadChallengeFeed = PublishRelay<(Int, UIImageWrapper)>()
-  private let didTapLoginButton = PublishRelay<Void>()
   private let didTapFeed = PublishRelay<(challengeId: Int, feedId: Int)>()
   
   // MARK: - UI Components
@@ -93,6 +92,7 @@ final class ChallengeHomeViewController: UIViewController, CameraRequestable, Vi
 // MARK: - UI Methods
 private extension ChallengeHomeViewController {
   func setupUI() {
+    view.backgroundColor = .white
     scrollView.showsVerticalScrollIndicator = false
     setViewHierarchy()
     setConstraints()
@@ -146,7 +146,6 @@ private extension ChallengeHomeViewController {
       requestData: requestData.asSignal(),
       didTapChallenge: bottomView.didTapChallenge,
       uploadChallengeFeed: uploadChallengeFeed.asSignal(),
-      didTapLoginButton: didTapLoginButton.asSignal(),
       didTapFeed: didTapFeed.asSignal()
     )
     let output = viewModel.transform(input: input)
@@ -180,13 +179,6 @@ private extension ChallengeHomeViewController {
       }
       .disposed(by: disposeBag)
     
-    output.loginTrigger
-      .emit(with: self) { owner, _ in
-        let alert = owner.presentLoginTriggerAlert()
-        owner.bind(alert: alert)
-      }
-      .disposed(by: disposeBag)
-    
     output.fileTooLarge
       .emit(with: self) { owner, _ in
         owner.presentFileTooLargeAlert()
@@ -205,14 +197,6 @@ private extension ChallengeHomeViewController {
     cell.rx.didTapFeed
       .bind(with: self) { owner, infos in
         owner.didTapFeed.accept(infos)
-      }
-      .disposed(by: disposeBag)
-  }
-  
-  func bind(alert: AlertViewController) {
-    alert.rx.didTapConfirmButton
-      .bind(with: self) { owner, _ in
-        owner.didTapLoginButton.accept(())
       }
       .disposed(by: disposeBag)
   }

--- a/Projects/Presentation/Home/Implementations/HomeContainer.swift
+++ b/Projects/Presentation/Home/Implementations/HomeContainer.swift
@@ -9,11 +9,9 @@
 import Challenge
 import Core
 import Home
-import LogIn
 import UseCase
 
 public protocol HomeDependency: Dependency {
-  var loginContainable: LogInContainable { get }
   var homeUseCae: HomeUseCase { get }
   var challengeContainable: ChallengeContainable { get }
   var noneMemberChallengeContainable: NoneMemberChallengeContainable { get }
@@ -37,7 +35,6 @@ public final class HomeContainer:
     let coordinator = HomeCoordinator(
       useCase: dependency.homeUseCae,
       navigationControllerable: navigationControllerable,
-      loginContainer: dependency.loginContainable,
       challengeHomeContainer: challengeHome,
       noneMemberHomeContainer: noneMemberHome,
       noneChallengeHomeContainer: noneChallengeHome

--- a/Projects/Presentation/Home/Implementations/NoneChallengeHome/NoneChallengeHomeCoordinator.swift
+++ b/Projects/Presentation/Home/Implementations/NoneChallengeHome/NoneChallengeHomeCoordinator.swift
@@ -10,11 +10,13 @@ import Challenge
 import Core
 
 protocol NoneChallengeHomeListener: AnyObject {
-  func requestLoginAtNoneChallengeHome()
+  func authenticatedFailedAtNoneChallengeHome()
   func requstConvertInitialHome()
 }
 
-protocol NoneChallengeHomePresentable { }
+protocol NoneChallengeHomePresentable {
+  func configureUserName(_ username: String)
+}
 
 final class NoneChallengeHomeCoordinator: ViewableCoordinator<NoneChallengeHomePresentable> {
   weak var listener: NoneChallengeHomeListener?
@@ -34,6 +36,10 @@ final class NoneChallengeHomeCoordinator: ViewableCoordinator<NoneChallengeHomeP
     super.init(viewControllerable)
     viewModel.coordinator = self
   }
+  
+  override func start() {
+    presenter.configureUserName(ServiceConfiguration.shared.userName)
+  }
 }
 
 // MARK: - NoneMemberHomeCoordinatable
@@ -44,7 +50,6 @@ extension NoneChallengeHomeCoordinator: NoneChallengeHomeCoordinatable {
     let coordinator = noneMemberChallengeContainer.coordinator(listener: self, challengeId: challengeId)
     addChild(coordinator)
     viewControllerable.pushViewController(coordinator.viewControllerable, animated: true)
-    
     self.noneMemberChallengeCoordinator = coordinator
   }
   
@@ -52,22 +57,22 @@ extension NoneChallengeHomeCoordinator: NoneChallengeHomeCoordinatable {
     guard let coordinator = noneMemberChallengeCoordinator else { return }
     removeChild(coordinator)
     viewControllerable.popViewController(animated: true)
+    viewControllerable.uiviewController.showTabBar(animted: true)
     noneMemberChallengeCoordinator = nil
   }
 }
 
-// MARK: - NoneMem
+// MARK: - NoneMemberChallenge
 extension NoneChallengeHomeCoordinator: NoneMemberChallengeListener {
   func didTapBackButtonAtNoneMemberChallenge() {
     detachNoneMemberChallenge()
   }
   
   func didJoinChallenge() {
-    detachNoneMemberChallenge()
     listener?.requstConvertInitialHome()
   }
   
-  func requestLogInAtNoneMemberChallenge() {
-    listener?.requestLoginAtNoneChallengeHome()
+  func authenticatedFailedAtNoneMemberChallenge() {
+    listener?.authenticatedFailedAtNoneChallengeHome()
   }
 }

--- a/Projects/Presentation/Home/Implementations/NoneChallengeHome/NoneChallengeHomeViewController.swift
+++ b/Projects/Presentation/Home/Implementations/NoneChallengeHome/NoneChallengeHomeViewController.swift
@@ -97,19 +97,6 @@ final class NoneChallengeHomeViewController: UIViewController, ViewControllerabl
     bind()
     viewDidLoadRelay.accept(())
   }
-  
-  override func viewWillAppear(_ animated: Bool) {
-    super.viewWillAppear(animated)
-    configureUserName(ServiceConfiguration.shared.userName)
-  }
-  
-  override func viewDidAppear(_ animated: Bool) {
-    super.viewDidAppear(animated)
-    
-    guard !dataSource.isEmpty else { return }
-    scrollToPage(currentPage)
-    challengeInformationView.configure(with: dataSource[currentPage])
-  }
 }
 
 // MARK: - UI Methods
@@ -153,9 +140,8 @@ private extension NoneChallengeHomeViewController {
 
     challengeInformationView.snp.makeConstraints {
       $0.top.equalTo(challengeImageCollectionView.snp.bottom).offset(24)
-      $0.centerX.equalToSuperview()
+      $0.leading.trailing.equalToSuperview().inset(24)
       $0.height.equalTo(244)
-      $0.width.equalTo(327)
     }
     
     createChallengeInformationView.snp.makeConstraints {
@@ -187,6 +173,8 @@ private extension NoneChallengeHomeViewController {
     output.challenges
       .emit(with: self) { owner, challenges in
         owner.dataSource = challenges
+        guard !challenges.isEmpty else { return }
+        owner.challengeInformationView.configure(with: challenges[owner.currentPage])
       }
       .disposed(by: disposeBag)
     
@@ -199,7 +187,14 @@ private extension NoneChallengeHomeViewController {
 }
 
 // MARK: - NoneChallengeHomePresentable
-extension NoneChallengeHomeViewController: NoneChallengeHomePresentable { }
+extension NoneChallengeHomeViewController: NoneChallengeHomePresentable {
+  func configureUserName(_ username: String) {
+    titleLabel.attributedText = "\(username)님의\n열정을 보여주세요!".attributedString(
+      font: .heading1,
+      color: .gray900
+    )
+  }
+}
 
 // MARK: - UICollectionViewDataSource
 extension NoneChallengeHomeViewController: UICollectionViewDataSource {
@@ -256,7 +251,8 @@ private extension NoneChallengeHomeViewController {
   }
   
   func configureInformatoinView(for page: Int) {
-    guard page <= dataSource.count && page >= 0 else { return }
+    guard !dataSource.isEmpty else { return }
+    guard page <= dataSource.count, page >= 0 else { return }
     guard
       let beforeCell = cellForPage(currentPage),
       let currentCell = cellForPage(page)
@@ -299,20 +295,17 @@ private extension NoneChallengeHomeViewController {
       self.challengeImageCollectionView.scrollToItem(at: indexPath, at: .top, animated: animated)
     }
   }
-  
-  func configureUserName(_ username: String) {
-    titleLabel.attributedText = "\(username)님의\n열정을 보여주세요!".attributedString(
-      font: .heading1,
-      color: .gray900
-    )
-  }
 
   func presentChallengeInformationView() {
+    guard challengeInformationView.isHidden else { return }
+    
     challengeInformationView.isHidden = false
     createChallengeInformationView.isHidden = true
   }
 
   func presentCreateChallengeInformationView() {
+    guard createChallengeInformationView.isHidden else { return }
+    
     challengeInformationView.isHidden = true
     createChallengeInformationView.isHidden = false
   }

--- a/Projects/Presentation/Home/Implementations/NoneChallengeHome/NoneChallengeHomeViewModel.swift
+++ b/Projects/Presentation/Home/Implementations/NoneChallengeHome/NoneChallengeHomeViewModel.swift
@@ -80,8 +80,7 @@ private extension NoneChallengeHomeViewModel {
           
           owner.challengesRelay.accept(models)
         },
-        onFailure: { owner, err in
-          print(err)
+        onFailure: { owner, _ in
           owner.requestFailedRelay.accept(())
         }
       )

--- a/Projects/Presentation/Home/Implementations/NoneChallengeHome/Views/ChallengInformationView/ChallengeInformationView.swift
+++ b/Projects/Presentation/Home/Implementations/NoneChallengeHome/Views/ChallengInformationView/ChallengeInformationView.swift
@@ -16,7 +16,10 @@ import DesignSystem
 
 final class ChallengeInformationView: UIView {
   private var hashTags = [String]() {
-    didSet { hashTagCollectionView.reloadData() }
+    didSet {
+      guard oldValue != hashTags else { return }
+      hashTagCollectionView.reloadData()
+    }
   }
   private(set) var id: Int = 0
   

--- a/Projects/Presentation/Home/Implementations/NoneChallengeHome/Views/ChallengeImageCell.swift
+++ b/Projects/Presentation/Home/Implementations/NoneChallengeHome/Views/ChallengeImageCell.swift
@@ -31,7 +31,7 @@ final class ChallengeImageCell: UICollectionViewCell {
     imageView.layer.masksToBounds = true
     return imageView
   }()
-  private let pinImageView = UIImageView(image: .pinBlue)
+  private let pinImageView = UIImageView(image: .pinBlue.withRenderingMode(.alwaysOriginal))
   private let gradientLayer: CAGradientLayer = {
     let layer = CAGradientLayer()
     layer.colors = [
@@ -85,6 +85,7 @@ private extension ChallengeImageCell {
     contentView.addSubviews(imageView, pinImageView)
     imageView.layer.addSublayer(gradientLayer)
     gradientLayer.frame = .init(x: 0, y: 0, width: 160, height: 160)
+    
     imageView.snp.makeConstraints {
       $0.width.height.equalTo(160)
       $0.bottom.equalToSuperview()

--- a/Projects/Presentation/Home/Implementations/NoneMemberHome/NoneMemberHomeCoordinator.swift
+++ b/Projects/Presentation/Home/Implementations/NoneMemberHome/NoneMemberHomeCoordinator.swift
@@ -9,7 +9,7 @@
 import Core
 
 protocol NoneMemberHomeListener: AnyObject {
-  func didTapLogInButtonAtNoneMemberHome()
+  func requestLogInAtNoneMemberHome()
 }
 
 protocol NoneMemberHomePresentable: AnyObject { }
@@ -32,6 +32,6 @@ final class NoneMemberHomeCoordinator: ViewableCoordinator<NoneMemberHomePresent
 // MARK: - NoneMemberHomeCoordinatable
 extension NoneMemberHomeCoordinator: NoneMemberHomeCoordinatable {
   func didTapLogInButton() {
-    listener?.didTapLogInButtonAtNoneMemberHome()
+    listener?.requestLogInAtNoneMemberHome()
   }
 }

--- a/Projects/Presentation/Home/Interfaces/Home.swift
+++ b/Projects/Presentation/Home/Interfaces/Home.swift
@@ -12,4 +12,7 @@ public protocol HomeContainable: Containable {
   func coordinator(navigationControllerable: NavigationControllerable, listener: HomeListener) -> Coordinating
 }
 
-public protocol HomeListener: AnyObject { }
+public protocol HomeListener: AnyObject {
+  func requestLogInAtHome()
+  func authenticatedFailedAtHome()
+}


### PR DESCRIPTION
## 관련 이슈

- #238 

## 작업 설명

- 로그인 시에 present되는 방식 수정.
- 재로그인 시에 "환영합니다"로고 띄우는 기능. 
- 화면 비율에 맞도록 디자인 수정 

### 로그인 시에 present되는 방식 수정.
기존에는 "토근 만료"로 인한 재로그인시 다음과 같이 구현했습니다. 
1. 해당 뷰에서 로그인 과정 진행 
2. 완료시, 해당 뷰로 리다이렉트. 

하지만, 디자이너팀과 상의중 잘못인지하고 있던 부분이 있어서, 수정했습니다. 
1. "토근 만료"시 로그인 프로세스 진행. 
2. 앱 전체 초기화 및 홈화면 초기로 이동

## 스크린샷
### 토근 만료로 인한 재로그인 후 환영 메시지
https://github.com/user-attachments/assets/ed82b13b-ca59-4a7e-9b19-468991a5a5c1

### 챌린지 참여과정에서 재로그인으로 인한 환영 메시지
https://github.com/user-attachments/assets/4ba5dc66-8b5f-44a9-9409-32f798d30758