### PR TITLE
[FEAT]: 챌린지 검색 결과 UI 구현 

### DIFF
--- a/Projects/Presentation/SearchChallenge/Implementations/PresentationModel/ResultChallengeCardPresentationModel.swift
+++ b/Projects/Presentation/SearchChallenge/Implementations/PresentationModel/ResultChallengeCardPresentationModel.swift
@@ -1,0 +1,19 @@
+//
+//  ResultChallengeCardPresentationModel.swift
+//  HomeImpl
+//
+//  Created by jung on 5/24/25.
+//  Copyright © 2025 com.photi. All rights reserved.
+//
+
+import Foundation
+
+struct ResultChallengeCardPresentationModel: Hashable {
+  let id: Int
+  let hashTags: [String]
+  let title: String
+  let imageUrl: URL?
+  let deadLine: String
+  let memberCount: Int
+  let memberImageUrls: [URL]
+}

--- a/Projects/Presentation/SearchChallenge/Implementations/SearchResult/ChallengeTitleResult/ChallengeTitleResultContainer.swift
+++ b/Projects/Presentation/SearchChallenge/Implementations/SearchResult/ChallengeTitleResult/ChallengeTitleResultContainer.swift
@@ -6,17 +6,24 @@
 //  Copyright © 2025 com.photi. All rights reserved.
 //
 
+import RxCocoa
 import Core
 
 protocol ChallengeTitleResultDependency: Dependency { }
 
 protocol ChallengeTitleResultContainable: Containable {
-  func coordinator(listener: ChallengeTitleResultListener) -> ViewableCoordinating
+  func coordinator(
+    listener: ChallengeTitleResultListener,
+    searchInput: Driver<String>
+  ) -> ViewableCoordinating
 }
 
 final class ChallengeTitleResultContainer: Container<ChallengeTitleResultDependency>, ChallengeTitleResultContainable {
-  func coordinator(listener: ChallengeTitleResultListener) -> ViewableCoordinating {
-    let viewModel = ChallengeTitleResultViewModel()
+  func coordinator(
+    listener: ChallengeTitleResultListener,
+    searchInput: Driver<String>
+  ) -> ViewableCoordinating {
+    let viewModel = ChallengeTitleResultViewModel(searchInput: searchInput)
     let viewControllerable = ChallengeTitleResultViewController(viewModel: viewModel)
     
     let coordinator = ChallengeTitleResultCoordinator(

--- a/Projects/Presentation/SearchChallenge/Implementations/SearchResult/ChallengeTitleResult/ChallengeTitleResultViewController.swift
+++ b/Projects/Presentation/SearchChallenge/Implementations/SearchResult/ChallengeTitleResult/ChallengeTitleResultViewController.swift
@@ -14,11 +14,38 @@ import Core
 import DesignSystem
 
 final class ChallengeTitleResultViewController: UIViewController, ViewControllerable {
+  enum Constants {
+    static let itemSpacing: CGFloat = 11
+    static let groupSpacing: CGFloat = 16
+    static let horizontalContentInset: CGFloat = 24
+  }
+  
+  typealias DataSourceType = UICollectionViewDiffableDataSource<Int, ResultChallengeCardPresentationModel>
+  typealias SnapShot = NSDiffableDataSourceSnapshot<Int, ResultChallengeCardPresentationModel>
+  
   // MARK: - Properties
   private let viewModel: ChallengeTitleResultViewModel
   private let disposeBag = DisposeBag()
+  private var datasource: DataSourceType?
   
   // MARK: - UI Components
+  private let emptyResultLabel: UILabel = {
+    let label = UILabel()
+    label.attributedText = "해당 챌린지가 없어요.".attributedString(font: .body2, color: .gray400)
+    
+    return label
+  }()
+  
+  private let challengeCollectionView: UICollectionView = {
+    let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewLayout())
+    collectionView.registerCell(ChallengeTitleResultCardCell.self)
+    collectionView.backgroundColor = .clear
+    collectionView.contentInsetAdjustmentBehavior = .never
+    collectionView.showsHorizontalScrollIndicator = false
+    collectionView.showsVerticalScrollIndicator = false
+
+    return collectionView
+  }()
   
   // MARK: - Initializers
   init(viewModel: ChallengeTitleResultViewModel) {
@@ -36,6 +63,11 @@ final class ChallengeTitleResultViewController: UIViewController, ViewController
     super.viewDidLoad()
     
     setupUI()
+    bind()
+    challengeCollectionView.collectionViewLayout = compositionalLayout()
+    let datasource = diffableDatasource()
+    self.datasource = datasource
+    challengeCollectionView.dataSource = datasource
   }
 }
 
@@ -46,9 +78,14 @@ private extension ChallengeTitleResultViewController {
     setConstraints()
   }
   
-  func setViewHierarchy() { }
+  func setViewHierarchy() {
+    view.addSubviews(emptyResultLabel, challengeCollectionView)
+  }
   
-  func setConstraints() { }
+  func setConstraints() {
+    challengeCollectionView.snp.makeConstraints { $0.edges.equalToSuperview() }
+    emptyResultLabel.snp.makeConstraints { $0.center.equalToSuperview() }
+  }
 }
 
 // MARK: - Bind Methods
@@ -68,3 +105,76 @@ private extension ChallengeTitleResultViewController {
 
 // MARK: - ChallengeTitleResultPresentable
 extension ChallengeTitleResultViewController: ChallengeTitleResultPresentable { }
+
+// MARK: - UICollectionViewLayout
+private extension ChallengeTitleResultViewController {
+  func compositionalLayout() -> UICollectionViewCompositionalLayout {
+    return .init { _, environment in
+      let itemSpacing = Constants.itemSpacing
+      let horizontalInset = Constants.horizontalContentInset
+      
+      let availableWidth = environment.container.effectiveContentSize.width
+      let itemWidth = ((availableWidth - horizontalInset * 2) - itemSpacing) / 2
+      let itemHeight = itemWidth * 1.15
+      
+      let itemSize = NSCollectionLayoutSize(
+        widthDimension: .absolute(itemWidth),
+        heightDimension: .absolute(itemHeight)
+      )
+      let item = NSCollectionLayoutItem(layoutSize: itemSize)
+      
+      let groupSize = NSCollectionLayoutSize(
+        widthDimension: .fractionalWidth(1),
+        heightDimension: .absolute(itemHeight)
+      )
+      let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item, item])
+      group.interItemSpacing = .fixed(itemSpacing)
+      let section = NSCollectionLayoutSection(group: group)
+      section.contentInsets = .init(
+        top: horizontalInset,
+        leading: horizontalInset,
+        bottom: 40,
+        trailing: horizontalInset
+      )
+      section.interGroupSpacing = Constants.groupSpacing
+      
+      return section
+    }
+  }
+}
+
+// MARK: - UICollectionViewDataSource
+private extension ChallengeTitleResultViewController {
+  func diffableDatasource() -> DataSourceType {
+    return .init(collectionView: challengeCollectionView) { collectionView, indexPath, model in
+      let cell = collectionView.dequeueCell(ChallengeTitleResultCardCell.self, for: indexPath)
+      cell.configure(with: model)
+      return cell
+    }
+  }
+  
+  func initialize(with models: [ResultChallengeCardPresentationModel]) {
+    guard let datasource else { return }
+    var snapshot = datasource.snapshot()
+    snapshot.deleteAllItems()
+    
+    snapshot = append(models: models, to: snapshot)
+    datasource.apply(snapshot)
+  }
+  
+  func append(models: [ResultChallengeCardPresentationModel]) {
+    guard let datasource else { return }
+    let snapshot = append(models: models, to: datasource.snapshot())
+    datasource.apply(snapshot)
+  }
+  
+  func append(models: [ResultChallengeCardPresentationModel], to snapshot: SnapShot) -> SnapShot {
+    var snapshot = snapshot
+    if !snapshot.sectionIdentifiers.contains(0) {
+      snapshot.appendSections([0])
+    }
+    models.forEach { snapshot.appendItems([$0]) }
+    
+    return snapshot
+  }
+}

--- a/Projects/Presentation/SearchChallenge/Implementations/SearchResult/ChallengeTitleResult/ChallengeTitleResultViewModel.swift
+++ b/Projects/Presentation/SearchChallenge/Implementations/SearchResult/ChallengeTitleResult/ChallengeTitleResultViewModel.swift
@@ -22,6 +22,12 @@ final class ChallengeTitleResultViewModel: ChallengeTitleResultViewModelType {
   weak var coordinator: ChallengeTitleResultCoordinatable?
   private let disposeBag = DisposeBag()
   private let searchInput: Driver<String>
+  private var isFetching = false
+  private var isLastPage = false
+  private var currentPage = 0
+  private var fetchingChallengeTask: Task<Void, Never>?
+  
+  private let challengesRelay = BehaviorRelay<[ResultChallengeCardPresentationModel]>(value: [])
 
   // MARK: - Input
   struct Input {
@@ -29,12 +35,74 @@ final class ChallengeTitleResultViewModel: ChallengeTitleResultViewModelType {
   }
   
   // MARK: - Output
-  struct Output { }
+  struct Output {
+    let challenges: Driver<[ResultChallengeCardPresentationModel]>
+  }
   
   // MARK: - Initializers
-  init() { }
+  init(searchInput: Driver<String>) {
+    self.searchInput = searchInput
+  }
   
   func transform(input: Input) -> Output {
-    return Output()
+    input.requestData
+      .withLatestFrom(searchInput)
+      .emit(with: self) { owner, input in
+        owner.fetchingChallengeTask = Task {
+          await owner.resetAndfetchChallenges(for: input)
+        }
+      }
+      .disposed(by: disposeBag)
+    
+    return Output(challenges: challengesRelay.asDriver())
+  }
+}
+
+// MARK: - API Methods
+private extension ChallengeTitleResultViewModel {
+  func resetAndfetchChallenges(for keyword: String) async {
+    guard !keyword.isEmpty else {
+      challengesRelay.accept([])
+      isLastPage = true
+      return
+    }
+  
+    fetchingChallengeTask?.cancel()
+    currentPage = 0
+    isLastPage = false
+    isFetching = false
+    await fetchNextPage(for: keyword)
+  }
+  
+  func fetchNextPage(for keyword: String) async {
+    guard !Task.isCancelled else { return }
+    guard !isLastPage && !isFetching else { return }
+    isFetching = true
+    
+    defer {
+      isFetching = false
+      currentPage += 1
+    }
+    
+    do {
+      try await fetchChallengeData(for: keyword)
+      guard !Task.isCancelled else { return }
+      // 구현 예정
+    } catch {
+      // 구현 예정
+    }
+  }
+  
+  func fetchChallengeData(for keyword: String) async throws { }
+}
+
+// MARK: - Private Methods
+private extension ChallengeTitleResultViewModel {
+  func bind() {
+    searchInput
+      .drive(with: self) { owner, text in
+        Task { await owner.resetAndfetchChallenges(for: text) }
+      }
+      .disposed(by: disposeBag)
   }
 }

--- a/Projects/Presentation/SearchChallenge/Implementations/SearchResult/ChallengeTitleResult/ChallengeTitleResultViewModel.swift
+++ b/Projects/Presentation/SearchChallenge/Implementations/SearchResult/ChallengeTitleResult/ChallengeTitleResultViewModel.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2025 com.photi. All rights reserved.
 //
 
+import RxCocoa
 import RxSwift
 
 protocol ChallengeTitleResultCoordinatable: AnyObject { }
@@ -20,9 +21,12 @@ protocol ChallengeTitleResultViewModelType: AnyObject {
 final class ChallengeTitleResultViewModel: ChallengeTitleResultViewModelType {
   weak var coordinator: ChallengeTitleResultCoordinatable?
   private let disposeBag = DisposeBag()
+  private let searchInput: Driver<String>
 
   // MARK: - Input
-  struct Input { }
+  struct Input {
+    let requestData: Signal<Void>
+  }
   
   // MARK: - Output
   struct Output { }

--- a/Projects/Presentation/SearchChallenge/Implementations/SearchResult/HashTagResult/HashTagResultContainer.swift
+++ b/Projects/Presentation/SearchChallenge/Implementations/SearchResult/HashTagResult/HashTagResultContainer.swift
@@ -6,17 +6,24 @@
 //  Copyright © 2025 com.photi. All rights reserved.
 //
 
+import RxCocoa
 import Core
 
 protocol HashTagResultDependency: Dependency { }
 
 protocol HashTagResultContainable: Containable {
-  func coordinator(listener: HashTagResultListener) -> ViewableCoordinating
+  func coordinator(
+    listener: HashTagResultListener,
+    searchInput: Driver<String>
+  ) -> ViewableCoordinating
 }
 
 final class HashTagResultContainer: Container<HashTagResultDependency>, HashTagResultContainable {
-  func coordinator(listener: HashTagResultListener) -> ViewableCoordinating {
-    let viewModel = HashTagResultViewModel()
+  func coordinator(
+    listener: HashTagResultListener,
+    searchInput: Driver<String>
+  ) -> ViewableCoordinating {
+    let viewModel = HashTagResultViewModel(searchInput: searchInput)
     let viewControllerable = HashTagResultViewController(viewModel: viewModel)
     
     let coordinator = HashTagResultCoordinator(

--- a/Projects/Presentation/SearchChallenge/Implementations/SearchResult/HashTagResult/HashTagResultViewController.swift
+++ b/Projects/Presentation/SearchChallenge/Implementations/SearchResult/HashTagResult/HashTagResultViewController.swift
@@ -14,11 +14,39 @@ import Core
 import DesignSystem
 
 final class HashTagResultViewController: UIViewController, ViewControllerable {
+  enum Constants {
+    static let itemSpacing: CGFloat = 11
+    static let groupSpacing: CGFloat = 16
+    static let horizontalContentInset: CGFloat = 24
+    static let hashTagCollectionViewHeight: CGFloat = 25
+  }
+  
+  typealias DataSourceType = UICollectionViewDiffableDataSource<Int, ResultChallengeCardPresentationModel>
+  typealias SnapShot = NSDiffableDataSourceSnapshot<Int, ResultChallengeCardPresentationModel>
+  
   // MARK: - Properties
   private let viewModel: HashTagResultViewModel
   private let disposeBag = DisposeBag()
+  private var datasource: DataSourceType?
   
   // MARK: - UI Components
+  private let emptyResultLabel: UILabel = {
+    let label = UILabel()
+    label.attributedText = "해당 챌린지가 없어요.".attributedString(font: .body2, color: .gray400)
+    
+    return label
+  }()
+  
+  private let challengeCollectionView: UICollectionView = {
+    let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewLayout())
+    collectionView.registerCell(HashTagResultCardCell.self)
+    collectionView.backgroundColor = .clear
+    collectionView.contentInsetAdjustmentBehavior = .never
+    collectionView.showsHorizontalScrollIndicator = false
+    collectionView.showsVerticalScrollIndicator = false
+
+    return collectionView
+  }()
   
   // MARK: - Initializers
   init(viewModel: HashTagResultViewModel) {
@@ -36,6 +64,12 @@ final class HashTagResultViewController: UIViewController, ViewControllerable {
     super.viewDidLoad()
     
     setupUI()
+    bind()
+    challengeCollectionView.collectionViewLayout = compositionalLayout()
+    let datasource = diffableDatasource()
+    self.datasource = datasource
+    challengeCollectionView.dataSource = datasource
+    initialize(with: Dummy.initialSearchPage)
   }
 }
 
@@ -46,9 +80,14 @@ private extension HashTagResultViewController {
     setConstraints()
   }
   
-  func setViewHierarchy() { }
+  func setViewHierarchy() {
+    view.addSubviews(emptyResultLabel, challengeCollectionView)
+  }
   
-  func setConstraints() { }
+  func setConstraints() {
+    challengeCollectionView.snp.makeConstraints { $0.edges.equalToSuperview() }
+    emptyResultLabel.snp.makeConstraints { $0.center.equalToSuperview() }
+  }
 }
 
 // MARK: - Bind Methods
@@ -68,3 +107,76 @@ private extension HashTagResultViewController {
 
 // MARK: - HashTagResultPresentable
 extension HashTagResultViewController: HashTagResultPresentable { }
+
+// MARK: - UICollectionViewLayout
+private extension HashTagResultViewController {
+  func compositionalLayout() -> UICollectionViewCompositionalLayout {
+    return .init { _, environment in
+      let itemSpacing = Constants.itemSpacing
+      let horizontalInset = Constants.horizontalContentInset
+      
+      let availableWidth = environment.container.effectiveContentSize.width
+      let itemWidth = ((availableWidth - horizontalInset * 2) - itemSpacing) / 2
+      let itemHeight = itemWidth * 1.15 + Constants.hashTagCollectionViewHeight
+      
+      let itemSize = NSCollectionLayoutSize(
+        widthDimension: .absolute(itemWidth),
+        heightDimension: .absolute(itemHeight)
+      )
+      let item = NSCollectionLayoutItem(layoutSize: itemSize)
+      
+      let groupSize = NSCollectionLayoutSize(
+        widthDimension: .fractionalWidth(1),
+        heightDimension: .absolute(itemHeight)
+      )
+      let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item, item])
+      group.interItemSpacing = .fixed(itemSpacing)
+      let section = NSCollectionLayoutSection(group: group)
+      section.contentInsets = .init(
+        top: horizontalInset,
+        leading: horizontalInset,
+        bottom: 40,
+        trailing: horizontalInset
+      )
+      section.interGroupSpacing = Constants.groupSpacing
+      
+      return section
+    }
+  }
+}
+
+// MARK: - UICollectionViewDataSource
+private extension HashTagResultViewController {
+  func diffableDatasource() -> DataSourceType {
+    return .init(collectionView: challengeCollectionView) { collectionView, indexPath, model in
+      let cell = collectionView.dequeueCell(HashTagResultCardCell.self, for: indexPath)
+      cell.configure(with: model)
+      return cell
+    }
+  }
+  
+  func initialize(with models: [ResultChallengeCardPresentationModel]) {
+    guard let datasource else { return }
+    var snapshot = datasource.snapshot()
+    snapshot.deleteAllItems()
+    
+    snapshot = append(models: models, to: snapshot)
+    datasource.apply(snapshot)
+  }
+  
+  func append(models: [ResultChallengeCardPresentationModel]) {
+    guard let datasource else { return }
+    let snapshot = append(models: models, to: datasource.snapshot())
+    datasource.apply(snapshot)
+  }
+  
+  func append(models: [ResultChallengeCardPresentationModel], to snapshot: SnapShot) -> SnapShot {
+    var snapshot = snapshot
+    if !snapshot.sectionIdentifiers.contains(0) {
+      snapshot.appendSections([0])
+    }
+    models.forEach { snapshot.appendItems([$0]) }
+    
+    return snapshot
+  }
+}

--- a/Projects/Presentation/SearchChallenge/Implementations/SearchResult/HashTagResult/HashTagResultViewController.swift
+++ b/Projects/Presentation/SearchChallenge/Implementations/SearchResult/HashTagResult/HashTagResultViewController.swift
@@ -126,7 +126,7 @@ private extension HashTagResultViewController {
       
       let availableWidth = environment.container.effectiveContentSize.width
       let itemWidth = ((availableWidth - horizontalInset * 2) - itemSpacing) / 2
-      let itemHeight = itemWidth * 1.15 + Constants.hashTagCollectionViewHeight
+      let itemHeight = itemWidth * 1.15 + Constants.hashTagCollectionViewHeight + 8
       
       let itemSize = NSCollectionLayoutSize(
         widthDimension: .absolute(itemWidth),

--- a/Projects/Presentation/SearchChallenge/Implementations/SearchResult/HashTagResult/HashTagResultViewModel.swift
+++ b/Projects/Presentation/SearchChallenge/Implementations/SearchResult/HashTagResult/HashTagResultViewModel.swift
@@ -22,12 +22,22 @@ final class HashTagResultViewModel: HashTagResultViewModelType {
   weak var coordinator: HashTagResultCoordinatable?
   private let disposeBag = DisposeBag()
   private let searchInput: Driver<String>
+  private var isFetching = false
+  private var isLastPage = false
+  private var currentPage = 0
+  private var fetchingChallengeTask: Task<Void, Never>?
+  
+  private let challengesRelay = BehaviorRelay<[ResultChallengeCardPresentationModel]>(value: [])
 
   // MARK: - Input
-  struct Input { }
+  struct Input {
+    let requestData: Signal<Void>
+  }
   
   // MARK: - Output
-  struct Output { }
+  struct Output {
+    let challenges: Driver<[ResultChallengeCardPresentationModel]>
+  }
   
   // MARK: - Initializers
   init(searchInput: Driver<String>) {
@@ -35,6 +45,64 @@ final class HashTagResultViewModel: HashTagResultViewModelType {
   }
   
   func transform(input: Input) -> Output {
-    return Output()
+    input.requestData
+      .withLatestFrom(searchInput)
+      .emit(with: self) { owner, input in
+        owner.fetchingChallengeTask = Task {
+          await owner.resetAndfetchChallenges(for: input)
+        }
+      }
+      .disposed(by: disposeBag)
+    
+    return Output(challenges: challengesRelay.asDriver())
+  }
+}
+
+// MARK: - API Methods
+private extension HashTagResultViewModel {
+  func resetAndfetchChallenges(for keyword: String) async {
+    guard !keyword.isEmpty else {
+      challengesRelay.accept([])
+      isLastPage = true
+      return
+    }
+  
+    fetchingChallengeTask?.cancel()
+    currentPage = 0
+    isLastPage = false
+    isFetching = false
+    await fetchNextPage(for: keyword)
+  }
+  
+  func fetchNextPage(for keyword: String) async {
+    guard !Task.isCancelled else { return }
+    guard !isLastPage && !isFetching else { return }
+    isFetching = true
+    
+    defer {
+      isFetching = false
+      currentPage += 1
+    }
+    
+    do {
+      try await fetchChallengeData(for: keyword)
+      guard !Task.isCancelled else { return }
+      // 구현 예정
+    } catch {
+      // 구현 예정
+    }
+  }
+  
+  func fetchChallengeData(for keyword: String) async throws { }
+}
+
+// MARK: - Private Methods
+private extension HashTagResultViewModel {
+  func bind() {
+    searchInput
+      .drive(with: self) { owner, text in
+        Task { await owner.resetAndfetchChallenges(for: text) }
+      }
+      .disposed(by: disposeBag)
   }
 }

--- a/Projects/Presentation/SearchChallenge/Implementations/SearchResult/HashTagResult/HashTagResultViewModel.swift
+++ b/Projects/Presentation/SearchChallenge/Implementations/SearchResult/HashTagResult/HashTagResultViewModel.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2025 com.photi. All rights reserved.
 //
 
+import RxCocoa
 import RxSwift
 
 protocol HashTagResultCoordinatable: AnyObject { }
@@ -20,6 +21,7 @@ protocol HashTagResultViewModelType: AnyObject {
 final class HashTagResultViewModel: HashTagResultViewModelType {
   weak var coordinator: HashTagResultCoordinatable?
   private let disposeBag = DisposeBag()
+  private let searchInput: Driver<String>
 
   // MARK: - Input
   struct Input { }
@@ -28,7 +30,9 @@ final class HashTagResultViewModel: HashTagResultViewModelType {
   struct Output { }
   
   // MARK: - Initializers
-  init() { }
+  init(searchInput: Driver<String>) {
+    self.searchInput = searchInput
+  }
   
   func transform(input: Input) -> Output {
     return Output()

--- a/Projects/Presentation/SearchChallenge/Implementations/SearchResult/SearchResultCoordinator.swift
+++ b/Projects/Presentation/SearchChallenge/Implementations/SearchResult/SearchResultCoordinator.swift
@@ -45,8 +45,14 @@ final class SearchResultCoordinator: ViewableCoordinator<SearchResultPresentable
   }
   
   private func attachSegments() {
-    let challengeTitleReulst = challengeTitleReulstContainable.coordinator(listener: self)
-    let hashTagResult = hashTagResultContainable.coordinator(listener: self)
+    let challengeTitleReulst = challengeTitleReulstContainable.coordinator(
+      listener: self,
+      searchInput: viewModel.titleSearchInput
+    )
+    let hashTagResult = hashTagResultContainable.coordinator(
+      listener: self,
+      searchInput: viewModel.hashTagSearchInput
+    )
     
     presenter.attachViewControllerables(
       challengeTitleReulst.viewControllerable,

--- a/Projects/Presentation/SearchChallenge/Implementations/SearchResult/SearchResultViewController.swift
+++ b/Projects/Presentation/SearchChallenge/Implementations/SearchResult/SearchResultViewController.swift
@@ -189,6 +189,12 @@ private extension SearchResultViewController {
         owner.searchBar.sendActions(for: .editingDidEnd)
       }
       .disposed(by: disposeBag)
+    
+    segmentControl.rx.selectedSegment
+      .bind(with: self) { owner, index in
+        owner.updateSegmentViewController(to: index)
+      }
+      .disposed(by: disposeBag)
   }
   
   func viewModelBind(for output: SearchResultViewModel.Output) {

--- a/Projects/Presentation/SearchChallenge/Implementations/SearchResult/SearchResultViewController.swift
+++ b/Projects/Presentation/SearchChallenge/Implementations/SearchResult/SearchResultViewController.swift
@@ -14,6 +14,11 @@ import Core
 import DesignSystem
 
 final class SearchResultViewController: UIViewController, ViewControllerable {
+  enum SearchMode {
+    case title
+    case hashTag
+  }
+  
   // MARK: - Properties
   private let viewModel: SearchResultViewModel
   private let disposeBag = DisposeBag()
@@ -21,6 +26,7 @@ final class SearchResultViewController: UIViewController, ViewControllerable {
   
   private let searchText = PublishRelay<String>()
   private let viewDidLoadRelay = PublishRelay<Void>()
+  private let searchMode = BehaviorRelay<SearchMode>(value: .title)
   
   // MARK: - UI Components
   private var segmentViewControllers = [UIViewController]()
@@ -173,7 +179,8 @@ private extension SearchResultViewController {
       didTapBackButton: backButton.rx.tap.asSignal(),
       searchText: searchText.asSignal(),
       deleteAllRecentSearchInputs: recentSearchInputView.rx.deleteAllRecentSearchInputs,
-      deleteRecentSearchInput: recentSearchInputView.rx.deleteRecentSearchInput
+      deleteRecentSearchInput: recentSearchInputView.rx.deleteRecentSearchInput,
+      searchMode: searchMode.asDriver()
     )
     let output = viewModel.transform(input: input)
     
@@ -244,6 +251,7 @@ extension SearchResultViewController: SearchResultPresentable {
 private extension SearchResultViewController {
   func updateSegmentViewController(to index: Int) {
     defer { segmentIndex = index }
+    searchMode.accept(index == 0 ? .title : .hashTag)
     removeViewController(segmentIndex: segmentIndex)
     attachViewController(segmentIndex: index)
   }

--- a/Projects/Presentation/SearchChallenge/Implementations/SearchResult/SearchResultViewModel.swift
+++ b/Projects/Presentation/SearchChallenge/Implementations/SearchResult/SearchResultViewModel.swift
@@ -26,12 +26,16 @@ enum SearchResultMode {
 }
 
 final class SearchResultViewModel: SearchResultViewModelType {
+  typealias SearchMode = SearchResultViewController.SearchMode
+  
   weak var coordinator: SearchResultCoordinatable?
+  
   private let disposeBag = DisposeBag()
   // TODO: - API 작업 이후 수정 예정
   private var recentSearchInputs = ["건강", "운동하기", "코딩코딩코딩", "밥 잘먹기"]
   
   private let searchResultModeRelay = BehaviorRelay<SearchResultMode>(value: .searchInputSuggestion(recent: []))
+  private var searchMode = SearchMode.title
 
   // MARK: - Input
   struct Input {
@@ -40,6 +44,7 @@ final class SearchResultViewModel: SearchResultViewModelType {
     let searchText: Signal<String>
     let deleteAllRecentSearchInputs: Signal<Void>
     let deleteRecentSearchInput: Signal<String>
+    let searchMode: Driver<SearchMode>
   }
   
   // MARK: - Output
@@ -73,6 +78,12 @@ final class SearchResultViewModel: SearchResultViewModelType {
     input.deleteAllRecentSearchInputs
       .emit(with: self) { owner, _ in
         owner.deleteAllRecentSearchInputs()
+      }
+      .disposed(by: disposeBag)
+    
+    input.searchMode
+      .drive(with: self) { owner, mode in
+        owner.searchMode = mode
       }
       .disposed(by: disposeBag)
     

--- a/Projects/Presentation/SearchChallenge/Implementations/SearchResult/SearchResultViewModel.swift
+++ b/Projects/Presentation/SearchChallenge/Implementations/SearchResult/SearchResultViewModel.swift
@@ -35,9 +35,9 @@ final class SearchResultViewModel: SearchResultViewModelType {
 
   // MARK: - Input
   struct Input {
+    let viewDidLoad: Signal<Void>
     let didTapBackButton: Signal<Void>
-    let searchText: Driver<String>
-    let didEnterSearchText: Signal<String>
+    let searchText: Signal<String>
     let deleteAllRecentSearchInputs: Signal<Void>
     let deleteRecentSearchInput: Signal<String>
   }
@@ -51,6 +51,12 @@ final class SearchResultViewModel: SearchResultViewModelType {
   init() { }
   
   func transform(input: Input) -> Output {
+    input.viewDidLoad
+      .emit(with: self) { owner, _ in
+        owner.updateSearchResultMode("")
+      }
+      .disposed(by: disposeBag)
+    
     input.didTapBackButton
       .emit(with: self) { owner, _ in
         owner.coordinator?.didTapBackButton()
@@ -58,17 +64,12 @@ final class SearchResultViewModel: SearchResultViewModelType {
       .disposed(by: disposeBag)
     
     input.searchText
-      .drive(with: self) { owner, text in
+      .emit(with: self) { owner, text in
+        owner.enterSearchInput(text)
         owner.updateSearchResultMode(text)
       }
       .disposed(by: disposeBag)
-    
-    input.didEnterSearchText
-      .emit(with: self) { owner, text in
-        owner.enterSearchInput(text)
-      }
-      .disposed(by: disposeBag)
-    
+
     input.deleteAllRecentSearchInputs
       .emit(with: self) { owner, _ in
         owner.deleteAllRecentSearchInputs()
@@ -96,6 +97,7 @@ private extension SearchResultViewModel {
   }
   
   func enterSearchInput(_ input: String) {
+    guard !input.isEmpty && !recentSearchInputs.contains(input) else { return }
     recentSearchInputs = [input] + recentSearchInputs
   }
   

--- a/Projects/Presentation/SearchChallenge/Implementations/SearchResult/Views/ChallengeTitleResultCardCell.swift
+++ b/Projects/Presentation/SearchChallenge/Implementations/SearchResult/Views/ChallengeTitleResultCardCell.swift
@@ -1,0 +1,35 @@
+//
+//  ChallengeTitleResultCardCell.swift
+//  HomeImpl
+//
+//  Created by jung on 5/24/25.
+//  Copyright © 2025 com.photi. All rights reserved.
+//
+
+import UIKit
+import SnapKit
+
+final class ChallengeTitleResultCardCell: UICollectionViewCell {
+  private let cardView = SearchChallengeCard()
+  
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    setupUI()
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  func configure(with model: ResultChallengeCardPresentationModel) {
+    cardView.configure(with: model)
+  }
+}
+
+// MARK: - UI Methods
+private extension ChallengeTitleResultCardCell {
+  func setupUI() {
+    contentView.addSubview(cardView)
+    cardView.snp.makeConstraints { $0.edges.equalToSuperview() }
+  }
+}

--- a/Projects/Presentation/SearchChallenge/Implementations/SearchResult/Views/HashTagResultCardCell.swift
+++ b/Projects/Presentation/SearchChallenge/Implementations/SearchResult/Views/HashTagResultCardCell.swift
@@ -65,7 +65,7 @@ private extension HashTagResultCardCell {
     }
     
     hashTagCollectionView.snp.makeConstraints {
-      $0.top.equalTo(cardView.snp.bottom)
+      $0.top.equalTo(cardView.snp.bottom).offset(8)
       $0.leading.bottom.trailing.equalToSuperview()
       $0.height.equalTo(HashTagResultViewController.Constants.hashTagCollectionViewHeight)
     }

--- a/Projects/Presentation/SearchChallenge/Implementations/SearchResult/Views/HashTagResultCardCell.swift
+++ b/Projects/Presentation/SearchChallenge/Implementations/SearchResult/Views/HashTagResultCardCell.swift
@@ -1,0 +1,115 @@
+//
+//  HashTagResultCardCell.swift
+//  HomeImpl
+//
+//  Created by jung on 5/24/25.
+//  Copyright © 2025 com.photi. All rights reserved.
+//
+
+import UIKit
+import SnapKit
+import Core
+import DesignSystem
+
+final class HashTagResultCardCell: UICollectionViewCell {
+  private var hashTags = [String]() {
+    didSet { hashTagCollectionView.reloadData() }
+  }
+  
+  private let cardView = SearchChallengeCard()
+  private let hashTagCollectionView: UICollectionView = {
+    let layout = UICollectionViewFlowLayout()
+    layout.scrollDirection = .horizontal
+    layout.minimumLineSpacing = 8
+    let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+    collectionView.registerCell(HashTagResultHashTagCell.self)
+    collectionView.backgroundColor = .clear
+    collectionView.showsHorizontalScrollIndicator = false
+    collectionView.automaticallyAdjustsScrollIndicatorInsets = false
+    collectionView.contentInsetAdjustmentBehavior = .never
+    
+    return collectionView
+  }()
+  
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    setupUI()
+    hashTagCollectionView.dataSource = self
+    hashTagCollectionView.delegate = self
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  // MARK: - LayoutSubviews
+  override func layoutSubviews() {
+    super.layoutSubviews()
+    
+    hashTagCollectionView.layoutIfNeeded()
+    centerContentHorizontalyByInsetIfNeeded()
+  }
+  
+  func configure(with model: ResultChallengeCardPresentationModel) {
+    cardView.configure(with: model)
+    hashTags = model.hashTags
+  }
+}
+
+// MARK: - UI Methods
+private extension HashTagResultCardCell {
+  func setupUI() {
+    contentView.addSubviews(cardView, hashTagCollectionView)
+    cardView.snp.makeConstraints {
+      $0.top.leading.trailing.equalToSuperview()
+    }
+    
+    hashTagCollectionView.snp.makeConstraints {
+      $0.top.equalTo(cardView.snp.bottom)
+      $0.leading.bottom.trailing.equalToSuperview()
+      $0.height.equalTo(HashTagResultViewController.Constants.hashTagCollectionViewHeight)
+    }
+  }
+}
+
+// MARK: - UICollectionViewDataSource
+extension HashTagResultCardCell: UICollectionViewDataSource {
+  func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+    return hashTags.count
+  }
+  
+  func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+    let cell = collectionView.dequeueCell(HashTagResultHashTagCell.self, for: indexPath)
+    cell.configure(with: hashTags[indexPath.row])
+    return cell
+  }
+}
+
+extension HashTagResultCardCell: UICollectionViewDelegateFlowLayout {
+  func collectionView(
+    _ collectionView: UICollectionView,
+    layout collectionViewLayout: UICollectionViewLayout,
+    sizeForItemAt indexPath: IndexPath
+  ) -> CGSize {
+    let label = UILabel()
+    label.attributedText = hashTags[indexPath.row].attributedString(font: .caption2, color: .white)
+    label.sizeToFit()
+    return .init(width: label.frame.width + 16, height: label.frame.height + 12)
+  }
+}
+
+// MARK: - private Methods
+private extension HashTagResultCardCell {
+  func centerContentHorizontalyByInsetIfNeeded() {
+    if hashTagCollectionView.contentSize.width > hashTagCollectionView.frame.size.width {
+      hashTagCollectionView.contentInset = .zero
+    } else {
+      hashTagCollectionView.contentInset = UIEdgeInsets(
+        top: 0,
+        left: (hashTagCollectionView.frame.size.width) / 2 - (hashTagCollectionView.contentSize.width) / 2,
+        bottom: 0,
+        right: 0
+      )
+    }
+  }
+}

--- a/Projects/Presentation/SearchChallenge/Implementations/SearchResult/Views/HashTagResultHashTagCell.swift
+++ b/Projects/Presentation/SearchChallenge/Implementations/SearchResult/Views/HashTagResultHashTagCell.swift
@@ -1,0 +1,37 @@
+//
+//  HashTagResultHashTagCell.swift
+//  SearchChallengeImpl
+//
+//  Created by jung on 5/26/25.
+//  Copyright © 2025 com.photi. All rights reserved.
+//
+
+import UIKit
+import SnapKit
+import DesignSystem
+
+final class HashTagResultHashTagCell: UICollectionViewCell {
+  private let chip = TextChip(type: .darkGray, size: .small)
+  
+  override init(frame: CGRect) {
+    super.init(frame: .zero)
+    setupUI()
+  }
+  
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  func configure(with text: String) {
+    chip.text = text
+  }
+}
+
+// MARK: - UI Methods
+private extension HashTagResultHashTagCell {
+  func setupUI() {
+    contentView.addSubview(chip)
+    chip.snp.makeConstraints { $0.edges.equalToSuperview() }
+  }
+}

--- a/Projects/Presentation/SearchChallenge/Implementations/SearchResult/Views/SearchChallengeCard.swift
+++ b/Projects/Presentation/SearchChallenge/Implementations/SearchResult/Views/SearchChallengeCard.swift
@@ -1,0 +1,141 @@
+//
+//  SearchChallengeCard.swift
+//  HomeImpl
+//
+//  Created by jung on 5/24/25.
+//  Copyright © 2025 com.photi. All rights reserved.
+//
+
+import UIKit
+import Kingfisher
+import SnapKit
+import Core
+import DesignSystem
+
+final class SearchChallengeCard: UIView {
+  // MARK: - UI Components
+  private let gradientLayer = GradientLayer(
+    mode: .bottomToTop,
+    minColor: .white,
+    maxColor: .init(white: 0.486, alpha: 1)
+  )
+  
+  private let contentView = UIView()
+  private let thumbnailView = UIImageView()
+  private let titleLabel = UILabel()
+  private let deadLineLabel = UILabel()
+  private let bottomBackgroundView: UIView = {
+    let view = UIView()
+    view.backgroundColor = .init(white: 1, alpha: 0.3)
+    
+    return view
+  }()
+  private let groupAvatarView = GroupAvatarView(size: .xSmall)
+  
+  // MARK: - Initializers
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    setupUI()
+  }
+  
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  // MARK: - LayoutSubvuews
+  override func layoutSubviews() {
+    super.layoutSubviews()
+    gradientLayer.frame = contentView.bounds
+  }
+  
+  // MARK: - Configure
+  func configure(with model: ResultChallengeCardPresentationModel) {
+    thumbnailView.kf.setImage(with: model.imageUrl)
+    configureGroupAvatarView(model.memberImageUrls, memberCount: model.memberCount)
+    titleLabel.attributedText = model.title.attributedString(font: .body1Bold, color: .white)
+    let deadLineTextColor = UIColor(white: 1, alpha: 0.3)
+    deadLineLabel.attributedText = model.deadLine.attributedString(font: .caption1Bold, color: deadLineTextColor)
+  }
+}
+
+// MARK: - UI Methods
+private extension SearchChallengeCard {
+  func setupUI() {
+    contentView.layer.cornerRadius = 8
+    layer.cornerRadius = 8
+    layer.borderWidth = 2
+    layer.borderColor = UIColor.white.cgColor
+    contentView.clipsToBounds = true
+    
+    let shadowColor = UIColor(white: 0.125, alpha: 0.2)
+    drawShadow(color: shadowColor, opacity: 1, radius: 6)
+
+    setViewHierarchy()
+    setConstraints()
+  }
+  
+  func setViewHierarchy() {
+    addSubview(contentView)
+    contentView.addSubview(thumbnailView)
+    contentView.layer.addSublayer(gradientLayer)
+    contentView.addSubviews(titleLabel, deadLineLabel, bottomBackgroundView)
+    bottomBackgroundView.addSubview(groupAvatarView)
+  }
+  
+  func setConstraints() {
+    contentView.snp.makeConstraints { $0.edges.equalToSuperview() }
+    thumbnailView.snp.makeConstraints { $0.edges.equalToSuperview() }
+    
+    titleLabel.snp.makeConstraints {
+      $0.centerX.equalToSuperview()
+      $0.bottom.equalTo(deadLineLabel.snp.top).offset(-8)
+    }
+    
+    deadLineLabel.snp.makeConstraints {
+      $0.centerX.equalToSuperview()
+      $0.bottom.equalTo(bottomBackgroundView.snp.top).offset(-6)
+    }
+    
+    bottomBackgroundView.snp.makeConstraints {
+      $0.leading.bottom.trailing.equalToSuperview()
+      $0.height.equalTo(49)
+    }
+    
+    groupAvatarView.snp.makeConstraints {
+      $0.center.equalToSuperview()
+    }
+  }
+}
+
+// MARK: - Private Methods
+private extension SearchChallengeCard {
+  func configureGroupAvatarView(_ urls: [URL], memberCount: Int) {
+    Task { [weak self] in
+      guard let self else { return }
+      // TODO: - 이미지 다운 샘플링 예정
+      let images = await downLoadImages(with: urls)
+      
+      groupAvatarView.configure(
+        maximumAvatarCount: 2,
+        avatarImages: images,
+        count: memberCount
+      )
+    }
+  }
+  
+  func downLoadImages(with urls: [URL]) async -> [UIImage] {
+    var images = [UIImage]()
+    
+    await withTaskGroup(of: Void.self) { group in
+      urls.forEach { url in
+        group.addTask {
+          guard let image = try? await KingfisherManager.shared.retrieveImage(with: url) else { return }
+          images.append(image.image)
+        }
+      }
+    }
+    
+    return images
+  }
+}


### PR DESCRIPTION
## 관련 이슈

- #251 

## 작업 설명
- 검색 로직 구현: 엔터가 눌러야 요청보내도록 수정
- 챌린지 이름별 검색 결과 화면 구현 완료 
- 챌린지 해시태그별 검색 결과 화면 구현 완료 

### 챌린지 이름별 검색 결과 화면 
![Simulator Screenshot - iPhone 16 Pro - 2025-05-26 at 23 27 29](https://github.com/user-attachments/assets/7cf680f5-028d-43e6-b4cc-41997011979a)

### 챌린지 해시태그별 검색 결과 화면
![Simulator Screenshot - iPhone 16 Pro - 2025-05-26 at 23 27 32](https://github.com/user-attachments/assets/e6980062-fdc8-42ff-b4cb-76d1acc78da9)

### 전체 동작 
![Simulator Screen Recording - iPhone 16 Pro - 2025-05-26 at 23 23 53](https://github.com/user-attachments/assets/11667469-43df-4cf8-8f35-f90548829ab2)