### PR TITLE
[FEAT]: 검색화면에서 추천순 페이지 API 연결

### DIFF
--- a/Projects/App/Sources/AppContainer.swift
+++ b/Projects/App/Sources/AppContainer.swift
@@ -128,6 +128,10 @@ final class AppContainer:
     return FeedUseCaseImpl(repository: feedRepository)
   }
   
+  lazy var searchUseCase: SearchUseCase = {
+    return SearchUseCaseImpl(challengeRepository: challengeRepository)
+  }()
+  
   lazy var reportUseCase: ReportUseCase = {
     return ReportUseCaseImpl(repository: reportRepository)
   }()

--- a/Projects/App/Sources/AppCoordinator.swift
+++ b/Projects/App/Sources/AppCoordinator.swift
@@ -171,7 +171,14 @@ extension AppCoordinator: HomeListener {
 }
 
 // MARK: - SearchChallengeListener
-extension AppCoordinator: SearchChallengeListener { }
+extension AppCoordinator: SearchChallengeListener {
+  func authenticatedFailedAtSearchChallenge() {
+    Task {
+      await reloadAllTab()
+      await presenter.changeNavigationControllerToHome()
+    }
+  }
+}
 
 // MARK: - MyPageListener
 extension AppCoordinator: MyPageListener {
@@ -183,7 +190,6 @@ extension AppCoordinator: MyPageListener {
 // MARK: - LoginListener
 extension AppCoordinator: LogInListener {
   func didFinishLogIn(userName: String) {
-    // TODO: - 환영합니다" 메시지 띄우기
     Task {
       await detachLogIn(willPopViewConroller: false)
       await reloadAllTab()

--- a/Projects/Data/DTO/Challenge/ChallengeByHashTag/ChallengesByHashTagResponseDTO.swift
+++ b/Projects/Data/DTO/Challenge/ChallengeByHashTag/ChallengesByHashTagResponseDTO.swift
@@ -1,0 +1,57 @@
+//
+//  ChallengesByHashTagResponseDTO.swift
+//  DTO
+//
+//  Created by jung on 5/27/25.
+//  Copyright © 2025 com.photi. All rights reserved.
+//
+
+import Foundation
+
+public struct ChallengesByHashTagResponseDTO: Decodable {
+  public let content: [ChallengeByHashTag]
+  public let page: Int
+  public let size: Int
+  public let first: Bool
+  public let last: Bool
+}
+
+public struct ChallengeByHashTag: Decodable {
+  public let id: Int
+  public let name: String
+  public let imageUrl: String?
+  public let endDate: String
+  public let hashtags: [HashTagResponseDTO]
+}
+
+public extension ChallengesByHashTagResponseDTO {
+  static let stubData = """
+{
+  "code": "200 OK",
+  "message": "성공",
+  "data": {
+    "content": [
+      {
+        "id": 1,
+        "name": "신나게 하는 러닝 챌린지",
+        "imageUrl": "https://url.kr/5MhHhD",
+        "endDate": "2024-12-01",
+        "hashtags": [
+          {
+            "hashtag": "러닝"
+          },
+          {
+            "hashtag": "건강"
+          }
+        ]
+      }
+    ],
+    "page": 0,
+    "size": 0,
+    "first": true,
+    "last": true
+  }
+}
+
+"""
+}

--- a/Projects/Data/DataMapper/ChallengeDataMapper.swift
+++ b/Projects/Data/DataMapper/ChallengeDataMapper.swift
@@ -16,6 +16,7 @@ public protocol ChallengeDataMapper {
   func mapToChallengeDetail(dto: ChallengeDetailResponseDTO, id: Int) -> ChallengeDetail
   func mapToChallengeSummaryFromEnded(dto: EndedChallengeResponseDTO) -> [ChallengeSummary]
   func mapToChallengeSummaryFromMyChallenge(dto: MyChallengesResponseDTO) -> [ChallengeSummary]
+  func mapToChallengeSummaryFromChallengeByHashTag(dto: ChallengesByHashTagResponseDTO) -> [ChallengeSummary]
   func mapToFeed(dto: FeedResponseDTO) -> Feed
   func mapToFeed(dto: FeedDetailResponseDTO, id: Int) -> Feed
   func mapToFeedComment(dto: CommentResponseDTO) -> FeedComment
@@ -103,6 +104,22 @@ public struct ChallengeDataMapperImpl: ChallengeDataMapper {
         feedImageURL: feedImageUrl,
         feedId: $0.feedId,
         isProve: $0.isProve
+      )
+    }
+  }
+  
+  public func mapToChallengeSummaryFromChallengeByHashTag(dto: ChallengesByHashTagResponseDTO) -> [ChallengeSummary] {
+    return dto.content.map {
+      let endDate = $0.endDate.toDate() ?? Date()
+      let hasTags = $0.hashtags.map { $0.hashtag }
+      let imageUrl = URL(string: $0.imageUrl ?? "")
+      
+      return .init(
+        id: $0.id,
+        name: $0.name,
+        imageUrl: imageUrl,
+        endDate: endDate,
+        hashTags: hasTags
       )
     }
   }

--- a/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeAPI.swift
+++ b/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeAPI.swift
@@ -13,6 +13,7 @@ import PhotiNetwork
 
 public enum ChallengeAPI {
   case popularChallenges
+  case popularHashTags
   case challengeDetail(id: Int)
   case endedChallenges(page: Int, size: Int)
   case myChallenges(page: Int, size: Int)
@@ -36,6 +37,7 @@ extension ChallengeAPI: TargetType {
   public var path: String {
     switch self {
       case .popularChallenges: return "api/challenges/popular"
+      case .popularHashTags: return "api/challenges/hashtags"
       case let .challengeDetail(id), let .leaveChallenge(id): return "api/challenges/\(id)"
       case .endedChallenges: return "api/users/ended-challenges"
       case .myChallenges: return "api/users/my-challenges"
@@ -53,7 +55,7 @@ extension ChallengeAPI: TargetType {
   
   public var method: HTTPMethod {
     switch self {
-      case .popularChallenges: return .get
+      case .popularChallenges, .popularHashTags: return .get
       case .challengeDetail: return .get
       case .endedChallenges, .myChallenges: return .get
       case .joinChallenge, .joinPrivateChallenge: return .post
@@ -68,14 +70,14 @@ extension ChallengeAPI: TargetType {
   
   public var task: TaskType {
     switch self {
-      case .popularChallenges, .challengeCount, .challengeDetail, .challengeProveMemberCount:
+      case .popularChallenges, .challengeCount, .challengeDetail, .popularHashTags:
         return .requestPlain
         
       case let .endedChallenges(page, size), let .myChallenges(page, size):
         let parameters = ["page": page, "size": size]
         return .requestParameters(parameters: parameters, encoding: URLEncoding.queryString)
         
-      case .joinChallenge:
+      case .joinChallenge, .challengeProveMemberCount:
         return .requestPlain
 
       case let .joinPrivateChallenge(_, code):
@@ -172,6 +174,19 @@ extension ChallengeAPI: TargetType {
         let jsonData = data.data(using: .utf8)
         
         return .networkResponse(200, jsonData ?? Data(), "OK", "성공")
-    }
+        
+      case .popularHashTags:
+        let data = """
+          {
+            "code": "200 OK",
+            "message": "성공",
+            "data": [
+              { "hashtag": "러닝" }, { "hashtag": "코딩" }
+            ]          
+          }
+        """
+        let jsonData = data.data(using: .utf8)
+        
+        return .networkResponse(200, jsonData ?? Data(), "OK", "성공")    }
   }
 }

--- a/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeAPI.swift
+++ b/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeAPI.swift
@@ -17,6 +17,7 @@ public enum ChallengeAPI {
   case challengeDetail(id: Int)
   case endedChallenges(page: Int, size: Int)
   case myChallenges(page: Int, size: Int)
+  case challengesByHashTag(_ hashTag: String, page: Int, size: Int)
   case joinChallenge(id: Int)
   case joinPrivateChallenge(id: Int, code: String)
   case uploadChallengeProof(id: Int, image: Data, imageType: String)
@@ -38,6 +39,7 @@ extension ChallengeAPI: TargetType {
     switch self {
       case .popularChallenges: return "api/challenges/popular"
       case .popularHashTags: return "api/challenges/hashtags"
+      case .challengesByHashTag: return "api/challenges/by-hashtags"
       case let .challengeDetail(id), let .leaveChallenge(id): return "api/challenges/\(id)"
       case .endedChallenges: return "api/users/ended-challenges"
       case .myChallenges: return "api/users/my-challenges"
@@ -56,7 +58,7 @@ extension ChallengeAPI: TargetType {
   public var method: HTTPMethod {
     switch self {
       case .popularChallenges, .popularHashTags: return .get
-      case .challengeDetail: return .get
+      case .challengeDetail, .challengesByHashTag: return .get
       case .endedChallenges, .myChallenges: return .get
       case .joinChallenge, .joinPrivateChallenge: return .post
       case .uploadChallengeProof: return .post
@@ -75,6 +77,10 @@ extension ChallengeAPI: TargetType {
         
       case let .endedChallenges(page, size), let .myChallenges(page, size):
         let parameters = ["page": page, "size": size]
+        return .requestParameters(parameters: parameters, encoding: URLEncoding.queryString)
+        
+      case let .challengesByHashTag(hashTag, page, size):
+        let parameters = ["hashtag": hashTag, "page": "\(page)", "size": "\(size)"]
         return .requestParameters(parameters: parameters, encoding: URLEncoding.queryString)
         
       case .joinChallenge, .challengeProveMemberCount:
@@ -130,7 +136,7 @@ extension ChallengeAPI: TargetType {
         let jsonData = data.data(using: .utf8)
         
         return .networkResponse(200, jsonData ?? Data(), "OK", "성공")
-
+        
       case .joinChallenge, .joinPrivateChallenge, .uploadChallengeProof, .updateChallengeGoal, .leaveChallenge:
         let data = """
           {
@@ -150,7 +156,7 @@ extension ChallengeAPI: TargetType {
         let jsonData = data.data(using: .utf8)
         
         return .networkResponse(200, jsonData ?? Data(), "OK", "성공")
- 
+        
       case .challengeDescription:
         let data = ChallengeDescriptionResponseDTO.stubData
         let jsonData = data.data(using: .utf8)
@@ -187,6 +193,12 @@ extension ChallengeAPI: TargetType {
         """
         let jsonData = data.data(using: .utf8)
         
-        return .networkResponse(200, jsonData ?? Data(), "OK", "성공")    }
+        return .networkResponse(200, jsonData ?? Data(), "OK", "성공")
+      case .challengesByHashTag:
+        let data = ChallengesByHashTagResponseDTO.stubData
+        let jsonData = data.data(using: .utf8)
+        
+        return .networkResponse(200, jsonData ?? Data(), "OK", "성공")
+    }
   }
 }

--- a/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeRepositoryImpl.swift
+++ b/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeRepositoryImpl.swift
@@ -56,6 +56,22 @@ public extension ChallengeRepositoryImpl {
     .map { dataMapper.mapToChallengeDetail(dto: $0, id: id) }
   }
   
+  func fetchChallenges(
+    byHashTag hashTag: String,
+    page: Int,
+    size: Int
+  ) async throws -> (challenges: [ChallengeSummary], isLast: Bool) {
+    let api = ChallengeAPI.challengesByHashTag(hashTag, page: page, size: size)
+    
+    let result = try await requestUnAuthorizableAPI(
+      api: api,
+      responseType: ChallengesByHashTagResponseDTO.self
+    ).value
+    
+    let challenges = dataMapper.mapToChallengeSummaryFromChallengeByHashTag(dto: result)
+    return (challenges, result.last)
+  }
+  
   func isProve(challengeId: Int) async throws -> Bool {
     let api = ChallengeAPI.isProve(challengeId: challengeId)
     let result = try await requestAuthorizableAPI(

--- a/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeRepositoryImpl.swift
+++ b/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeRepositoryImpl.swift
@@ -32,6 +32,14 @@ public extension ChallengeRepositoryImpl {
     .map { $0.map { dataMapper.mapToChallengeDetail(dto: $0) } }
   }
   
+  func fetchPopularHashTags() -> Single<[String]> {
+    return requestUnAuthorizableAPI(
+      api: ChallengeAPI.popularHashTags,
+      responseType: [HashTagResponseDTO].self
+    )
+    .map { $0.map { $0.hashtag } }
+  }
+  
   func fetchEndedChallenges(page: Int, size: Int) -> Single<[ChallengeSummary]> {
     return requestAuthorizableAPI(
       api: ChallengeAPI.endedChallenges(page: page, size: size),

--- a/Projects/Domain/Repository/Interfaces/ChallengeRepository.swift
+++ b/Projects/Domain/Repository/Interfaces/ChallengeRepository.swift
@@ -14,15 +14,17 @@ public protocol ChallengeRepository {
   func fetchPopularChallenges() -> Single<[ChallengeDetail]>
   func fetchEndedChallenges(page: Int, size: Int) -> Single<[ChallengeSummary]>
   func fetchChallengeDetail(id: Int) -> Single<ChallengeDetail>
-  func joinPublicChallenge(id: Int) -> Single<Void>
-  func joinPrivateChallnege(id: Int, code: String) -> Single<Void>
-  func uploadChallengeFeedProof(id: Int, image: Data, imageType: String) async throws -> Feed
-  func isProve(challengeId: Int) async throws -> Bool
-  func challengeProveMemberCount(challengeId: Int) async throws -> Int
-  func challengeCount() async throws -> Int
-  func updateChallengeGoal(_ goal: String, challengeId: Int) -> Single<Void>
   func fetchMyChallenges(page: Int, size: Int) -> Single<[ChallengeSummary]>
   func fetchChallengeDescription(challengeId: Int) -> Single<ChallengeDescription>
   func fetchChallengeMembers(challengeId: Int) -> Single<[ChallengeMember]>
+  func fetchPopularHashTags() -> Single<[String]>
+  func isProve(challengeId: Int) async throws -> Bool
+  func challengeProveMemberCount(challengeId: Int) async throws -> Int
+  func challengeCount() async throws -> Int
+  
+  func joinPublicChallenge(id: Int) -> Single<Void>
+  func joinPrivateChallnege(id: Int, code: String) -> Single<Void>
+  func updateChallengeGoal(_ goal: String, challengeId: Int) -> Single<Void>
   func leaveChallenge(id: Int) -> Single<Void>
+  func uploadChallengeFeedProof(id: Int, image: Data, imageType: String) async throws -> Feed
 }

--- a/Projects/Domain/Repository/Interfaces/ChallengeRepository.swift
+++ b/Projects/Domain/Repository/Interfaces/ChallengeRepository.swift
@@ -17,6 +17,11 @@ public protocol ChallengeRepository {
   func fetchMyChallenges(page: Int, size: Int) -> Single<[ChallengeSummary]>
   func fetchChallengeDescription(challengeId: Int) -> Single<ChallengeDescription>
   func fetchChallengeMembers(challengeId: Int) -> Single<[ChallengeMember]>
+  func fetchChallenges(
+    byHashTag hashTag: String,
+    page: Int,
+    size: Int
+  ) async throws -> (challenges: [ChallengeSummary], isLast: Bool)
   func fetchPopularHashTags() -> Single<[String]>
   func isProve(challengeId: Int) async throws -> Bool
   func challengeProveMemberCount(challengeId: Int) async throws -> Int

--- a/Projects/Domain/UseCase/Implementations/SearchUseCaseImpl.swift
+++ b/Projects/Domain/UseCase/Implementations/SearchUseCaseImpl.swift
@@ -49,10 +49,6 @@ public extension SearchUseCaseImpl {
       let myChallenges = try await challengeRepository.fetchMyChallenges(page: 0, size: 20).value
         .map { $0.id }
       
-      guard myChallenges.count < 20 else {
-        throw APIError.challengeFailed(reason: .exceedMaxChallengeCount)
-      }
-      
       return myChallenges.contains(id)
     } catch {
       if let error = error as? APIError, case .authenticationFailed = error {

--- a/Projects/Domain/UseCase/Implementations/SearchUseCaseImpl.swift
+++ b/Projects/Domain/UseCase/Implementations/SearchUseCaseImpl.swift
@@ -28,4 +28,18 @@ public extension SearchUseCaseImpl {
   func popularHashtags() -> Single<[String]> {
     return challengeRepository.fetchPopularHashTags()
   }
+  
+  func challenges(
+    byHashTag hashTag: String,
+    page: Int,
+    size: Int
+  ) async throws -> PageSearchChallenges {
+    let (challenges, isLast) = try await challengeRepository.fetchChallenges(
+      byHashTag: hashTag,
+      page: page,
+      size: size
+    )
+   
+    return isLast ? .lastPage(challenges) : .defaults(challenges)
+  }
 }

--- a/Projects/Domain/UseCase/Implementations/SearchUseCaseImpl.swift
+++ b/Projects/Domain/UseCase/Implementations/SearchUseCaseImpl.swift
@@ -1,0 +1,31 @@
+//
+//  SearchUseCaseImpl.swift
+//  UseCaseImpl
+//
+//  Created by jung on 5/27/25.
+//  Copyright © 2025 com.photi. All rights reserved.
+//
+
+import RxSwift
+import Entity
+import UseCase
+import Repository
+
+public final class SearchUseCaseImpl: SearchUseCase {
+  private let challengeRepository: ChallengeRepository
+  
+  public init(challengeRepository: ChallengeRepository) {
+    self.challengeRepository = challengeRepository
+  }
+}
+
+// MARK: - Fetch Methods
+public extension SearchUseCaseImpl {
+  func popularChallenges() -> Single<[ChallengeDetail]> {
+    return challengeRepository.fetchPopularChallenges()
+  }
+  
+  func popularHashtags() -> Single<[String]> {
+    return challengeRepository.fetchPopularHashTags()
+  }
+}

--- a/Projects/Domain/UseCase/Interfaces/SearchUseCase.swift
+++ b/Projects/Domain/UseCase/Interfaces/SearchUseCase.swift
@@ -28,4 +28,7 @@ public protocol SearchUseCase {
     byHashTag hashTag: String,
     page: Int,
     size: Int
-  ) async throws -> PageSearchChallenges}
+  ) async throws -> PageSearchChallenges
+  func didJoinedChallenge(id: Int) async throws -> Bool
+  func isPossibleToCreateChallenge() async -> Bool
+}

--- a/Projects/Domain/UseCase/Interfaces/SearchUseCase.swift
+++ b/Projects/Domain/UseCase/Interfaces/SearchUseCase.swift
@@ -9,7 +9,23 @@
 import RxSwift
 import Entity
 
+public enum PageSearchChallenges {
+  case `defaults`([ChallengeSummary])
+  case lastPage([ChallengeSummary])
+  
+  public var challenges: [ChallengeSummary] {
+    switch self {
+      case .defaults(let values), .lastPage(let values):
+        return values
+    }
+  }
+}
+
 public protocol SearchUseCase {
   func popularChallenges() -> Single<[ChallengeDetail]>
   func popularHashtags() -> Single<[String]>
-}
+  func challenges(
+    byHashTag hashTag: String,
+    page: Int,
+    size: Int
+  ) async throws -> PageSearchChallenges}

--- a/Projects/Domain/UseCase/Interfaces/SearchUseCase.swift
+++ b/Projects/Domain/UseCase/Interfaces/SearchUseCase.swift
@@ -1,0 +1,15 @@
+//
+//  SearchUseCase.swift
+//  UseCase
+//
+//  Created by jung on 5/27/25.
+//  Copyright © 2025 com.photi. All rights reserved.
+//
+
+import RxSwift
+import Entity
+
+public protocol SearchUseCase {
+  func popularChallenges() -> Single<[ChallengeDetail]>
+  func popularHashtags() -> Single<[String]>
+}

--- a/Projects/Presentation/Challenge/Implementations/NoneMember/NoneMemberChallengeContainer.swift
+++ b/Projects/Presentation/Challenge/Implementations/NoneMember/NoneMemberChallengeContainer.swift
@@ -29,6 +29,7 @@ public final class NoneMemberChallengeContainer:
     let logInGuideContainer = LogInGuideContainer(dependency: self)
     
     let coordinator = NoneMemberChallengeCoordinator(
+      challengeId: challengeId,
       viewControllerable: viewControllerable,
       viewModel: viewModel,
       enterChallengeGoalContainer: enterChallengeGoalContainer,

--- a/Projects/Presentation/Challenge/Implementations/NoneMember/NoneMemberChallengeCoordinator.swift
+++ b/Projects/Presentation/Challenge/Implementations/NoneMember/NoneMemberChallengeCoordinator.swift
@@ -16,7 +16,7 @@ import LogIn
 
 final class NoneMemberChallengeCoordinator: ViewableCoordinator<NoneMemberChallengePresentable> {
   weak var listener: NoneMemberChallengeListener?
-
+  private let challengeId: Int
   private let viewModel: NoneMemberChallengeViewModel
   
   private let enterChallengeGoalContainer: EnterChallengeGoalContainable
@@ -29,12 +29,14 @@ final class NoneMemberChallengeCoordinator: ViewableCoordinator<NoneMemberChalle
   private var logInCoordinator: ViewableCoordinating?
   
   init(
+    challengeId: Int,
     viewControllerable: ViewControllerable,
     viewModel: NoneMemberChallengeViewModel,
     enterChallengeGoalContainer: EnterChallengeGoalContainable,
     logInGuideContainer: LogInGuideContainable,
     logInContainer: LogInContainable
   ) {
+    self.challengeId = challengeId
     self.enterChallengeGoalContainer = enterChallengeGoalContainer
     self.logInGuideContainer = logInGuideContainer
     self.logInContainer = logInContainer
@@ -118,7 +120,7 @@ extension NoneMemberChallengeCoordinator: EnterChallengeGoalListener {
   }
   
   func didFinishEnterChallengeGoal(_ goal: String) {
-    listener?.didJoinChallenge()
+    listener?.didJoinChallenge(id: challengeId)
   }
   
   func authenticatedFailedAtEnterChallengeGoal() {

--- a/Projects/Presentation/Challenge/Interfaces/NoneMemberChallenge.swift
+++ b/Projects/Presentation/Challenge/Interfaces/NoneMemberChallenge.swift
@@ -14,6 +14,6 @@ public protocol NoneMemberChallengeContainable: Containable {
 
 public protocol NoneMemberChallengeListener: AnyObject {
   func didTapBackButtonAtNoneMemberChallenge()
-  func didJoinChallenge()
+  func didJoinChallenge(id: Int)
   func authenticatedFailedAtNoneMemberChallenge()
 }

--- a/Projects/Presentation/SearchChallenge/Implementations/PresentationModel/SearchChallengePresentaionModelMapper.swift
+++ b/Projects/Presentation/SearchChallenge/Implementations/PresentationModel/SearchChallengePresentaionModelMapper.swift
@@ -1,0 +1,22 @@
+//
+//  SearchChallengePresentaionModelMapper.swift
+//  SearchChallengeImpl
+//
+//  Created by jung on 5/27/25.
+//  Copyright © 2025 com.photi. All rights reserved.
+//
+
+import Core
+import Entity
+
+struct SearchChallengePresentaionModelMapper {
+  func mapToChallengeCardPresentationModel(from challenge: ChallengeDetail) -> ChallengeCardPresentationModel {
+    return .init(
+      id: challenge.id,
+      hashTags: challenge.hashTags,
+      title: challenge.name,
+      imageUrl: challenge.imageUrl,
+      deadLine: challenge.endDate.toString("~ yyyy.MM.dd")
+    )
+  }
+}

--- a/Projects/Presentation/SearchChallenge/Implementations/RecommendedChallenges/RecommendedChallengesContainer.swift
+++ b/Projects/Presentation/SearchChallenge/Implementations/RecommendedChallenges/RecommendedChallengesContainer.swift
@@ -7,8 +7,11 @@
 //
 
 import Core
+import UseCase
 
-protocol RecommendedChallengesDependency: Dependency { }
+protocol RecommendedChallengesDependency: Dependency {
+  var searchUseCase: SearchUseCase { get }
+}
 
 protocol RecommendedChallengesContainable: Containable {
   func coordinator(listener: RecommendedChallengesListener) -> ViewableCoordinating
@@ -18,7 +21,7 @@ final class RecommendedChallengesContainer:
   Container<RecommendedChallengesDependency>,
   RecommendedChallengesContainable {
   func coordinator(listener: RecommendedChallengesListener) -> ViewableCoordinating {
-    let viewModel = RecommendedChallengesViewModel()
+    let viewModel = RecommendedChallengesViewModel(useCase: dependency.searchUseCase)
     let viewControllerable = RecommendedChallengesViewController(viewModel: viewModel)
     
     let coordinator = RecommendedChallengesCoordinator(

--- a/Projects/Presentation/SearchChallenge/Implementations/RecommendedChallenges/RecommendedChallengesViewModel.swift
+++ b/Projects/Presentation/SearchChallenge/Implementations/RecommendedChallenges/RecommendedChallengesViewModel.swift
@@ -8,6 +8,7 @@
 
 import RxCocoa
 import RxSwift
+import UseCase
 
 protocol RecommendedChallengesCoordinatable: AnyObject {
   func didTapChallenge(challengeId: Int)
@@ -23,6 +24,7 @@ protocol RecommendedChallengesViewModelType: AnyObject {
 final class RecommendedChallengesViewModel: RecommendedChallengesViewModelType {
   weak var coordinator: RecommendedChallengesCoordinatable?
   
+  private let useCase: SearchUseCase
   private let disposeBag = DisposeBag()
   private var fetchingHashTagChallengeTask: Task<Void, Never>?
   private var isFetching = false
@@ -57,7 +59,9 @@ final class RecommendedChallengesViewModel: RecommendedChallengesViewModelType {
   }
   
   // MARK: - Initializers
-  init() { }
+  init(useCase: SearchUseCase) {
+    self.useCase = useCase
+  }
   
   func transform(input: Input) -> Output {
     input.requestData

--- a/Projects/Presentation/SearchChallenge/Implementations/RecommendedChallenges/RecommendedChallengesViewModel.swift
+++ b/Projects/Presentation/SearchChallenge/Implementations/RecommendedChallenges/RecommendedChallengesViewModel.swift
@@ -25,6 +25,7 @@ final class RecommendedChallengesViewModel: RecommendedChallengesViewModelType {
   weak var coordinator: RecommendedChallengesCoordinatable?
   
   private let useCase: SearchUseCase
+  private let modelMapper: SearchChallengePresentaionModelMapper
   private let disposeBag = DisposeBag()
   private var fetchingHashTagChallengeTask: Task<Void, Never>?
   private var isFetching = false
@@ -41,6 +42,7 @@ final class RecommendedChallengesViewModel: RecommendedChallengesViewModelType {
   private let hashTagsRelay = BehaviorRelay<[String]>(value: [])
   private let hashTagInitialChallenges = BehaviorRelay<[ChallengeCardPresentationModel]>(value: [])
   private let hashTagChallenges = BehaviorRelay<[ChallengeCardPresentationModel]>(value: [])
+  private let networkUnstableRelay = PublishRelay<Void>()
 
   // MARK: - Input
   struct Input {
@@ -56,17 +58,19 @@ final class RecommendedChallengesViewModel: RecommendedChallengesViewModelType {
     let hashTags: Driver<[String]>
     let hashTagInitialChallenges: Driver<[ChallengeCardPresentationModel]>
     let hashTagChallenges: Driver<[ChallengeCardPresentationModel]>
+    let networkUnstable: Signal<Void>
   }
   
   // MARK: - Initializers
   init(useCase: SearchUseCase) {
     self.useCase = useCase
+    self.modelMapper = SearchChallengePresentaionModelMapper()
   }
   
   func transform(input: Input) -> Output {
     input.requestData
       .emit(with: self) { owner, _ in
-        owner.fetchAllData()
+        Task { await owner.fetchAllData() }
       }
       .disposed(by: disposeBag)
     
@@ -92,22 +96,36 @@ final class RecommendedChallengesViewModel: RecommendedChallengesViewModelType {
       popularChallenges: popularChallenges.asDriver(),
       hashTags: hashTagsRelay.asDriver(),
       hashTagInitialChallenges: hashTagInitialChallenges.asDriver(),
-      hashTagChallenges: hashTagChallenges.asDriver()
+      hashTagChallenges: hashTagChallenges.asDriver(),
+      networkUnstable: networkUnstableRelay.asSignal()
     )
   }
 }
 
 // MARK: - API Methods
 private extension RecommendedChallengesViewModel {
-  func fetchAllData() {
-    fetchPopularChallenges()
-    fetchHastags()
-    Task { await fetchHashTagChallenge(hashTag: selectedHashTag) }
+  func fetchAllData() async {
+    do {
+      async let hashtags = fetchHastags()
+      async let challenges = fetchPopularChallenges()
+
+      try await popularChallenges.accept(challenges)
+      try await hashTagsRelay.accept(hashtags)
+    } catch {
+      networkUnstableRelay.accept(())
+    }
   }
   
-  func fetchPopularChallenges() { }
+  func fetchPopularChallenges() async throws -> [ChallengeCardPresentationModel] {
+    let challenges = try await useCase.popularChallenges().value
+    return challenges.map {
+      modelMapper.mapToChallengeCardPresentationModel(from: $0)
+    }
+  }
   
-  func fetchHastags() { }
+  func fetchHastags() async throws -> [String] {
+    return try await useCase.popularHashtags().value
+  }
   
   func fetchHashTagChallenge(hashTag: String) async {
     guard !Task.isCancelled else { return }

--- a/Projects/Presentation/SearchChallenge/Implementations/SearchChallengeContainer.swift
+++ b/Projects/Presentation/SearchChallenge/Implementations/SearchChallengeContainer.swift
@@ -9,9 +9,11 @@
 import Core
 import Challenge
 import SearchChallenge
+import UseCase
 
 public protocol SearchChallengeDependency: Dependency {
   var challengeOrganizeContainable: ChallengeOrganizeContainable { get }
+  var searchUseCase: SearchUseCase { get }
 }
 
 public final class SearchChallengeContainer:
@@ -20,6 +22,8 @@ public final class SearchChallengeContainer:
   RecommendedChallengesDependency,
   RecentChallengesDependency,
   SearchResultDependency {
+  var searchUseCase: SearchUseCase { dependency.searchUseCase }
+  
   public func coordinator(listener: SearchChallengeListener) -> ViewableCoordinating {
     let viewModel = SearchChallengeViewModel()
     let viewControllerable = SearchChallengeViewController(viewModel: viewModel)

--- a/Projects/Presentation/SearchChallenge/Implementations/SearchChallengeContainer.swift
+++ b/Projects/Presentation/SearchChallenge/Implementations/SearchChallengeContainer.swift
@@ -14,6 +14,8 @@ import UseCase
 public protocol SearchChallengeDependency: Dependency {
   var challengeOrganizeContainable: ChallengeOrganizeContainable { get }
   var searchUseCase: SearchUseCase { get }
+  var challengeContainable: ChallengeContainable { get }
+  var noneMemberChallengeContainable: NoneMemberChallengeContainable { get }
 }
 
 public final class SearchChallengeContainer:
@@ -25,7 +27,7 @@ public final class SearchChallengeContainer:
   var searchUseCase: SearchUseCase { dependency.searchUseCase }
   
   public func coordinator(listener: SearchChallengeListener) -> ViewableCoordinating {
-    let viewModel = SearchChallengeViewModel()
+    let viewModel = SearchChallengeViewModel(useCase: searchUseCase)
     let viewControllerable = SearchChallengeViewController(viewModel: viewModel)
     
     let recommendedChallenges = RecommendedChallengesContainer(dependency: self)
@@ -38,7 +40,9 @@ public final class SearchChallengeContainer:
       challengeOrganizeContainable: dependency.challengeOrganizeContainable,
       recommendedChallengesContainable: recommendedChallenges,
       recentChallengesContainable: recentChallenges,
-      searchResultContainable: searchResult
+      searchResultContainable: searchResult,
+      challengeContainable: dependency.challengeContainable,
+      noneMemberChallengeContainable: dependency.noneMemberChallengeContainable
     )
     coordinator.listener = listener
     return coordinator

--- a/Projects/Presentation/SearchChallenge/Implementations/SearchChallengeCoordinator.swift
+++ b/Projects/Presentation/SearchChallenge/Implementations/SearchChallengeCoordinator.swift
@@ -79,7 +79,7 @@ final class SearchChallengeCoordinator: ViewableCoordinator<SearchChallengePrese
 }
 
 // MARK: - ChallengeOrganize
-private extension SearchChallengeCoordinator {
+extension SearchChallengeCoordinator {
   func attachChallengeOrganize() {
     guard organizeCoordinator == nil else { return }
     
@@ -123,12 +123,51 @@ private extension SearchChallengeCoordinator {
   }
 }
 
-// MARK: - SearchChallengeCoordinatable
-extension SearchChallengeCoordinator: SearchChallengeCoordinatable {
-  func didTapChallengeOrganize() {
-    attachChallengeOrganize()
+// MARK: - Challenge
+extension SearchChallengeCoordinator {
+  func attachChallenge(id: Int) {
+    guard challengeCoordinator == nil else { return }
+    let coordinater = challengeContainable.coordinator(
+      listener: self,
+      challengeId: id,
+      presentType: .default
+    )
+    viewControllerable.pushViewController(coordinater.viewControllerable, animated: true)
+    addChild(coordinater)
+    self.challengeCoordinator = coordinater
   }
   
+  func detachChallenge() {
+    guard let coordinater = challengeCoordinator else { return }
+    viewControllerable.popViewController(animated: true)
+    viewControllerable.uiviewController.showTabBar(animted: true)
+    removeChild(coordinater)
+    self.challengeCoordinator = nil
+  }
+}
+
+// MARK: - NoneMemberChallenge
+extension SearchChallengeCoordinator {
+  func attachNonememberChallenge(id: Int) {
+    guard noneMemberchallengeCoordinator == nil else { return }
+    let coordinater = noneMemberChallengeContainable.coordinator(listener: self, challengeId: id)
+    viewControllerable.pushViewController(coordinater.viewControllerable, animated: true)
+    addChild(coordinater)
+    self.noneMemberchallengeCoordinator = coordinater
+  }
+  
+  func detachNonememberChallenge(animted: Bool) {
+    guard let coordinater = noneMemberchallengeCoordinator else { return }
+    viewControllerable.popViewController(animated: animted)
+    
+    if animted { viewControllerable.uiviewController.showTabBar(animted: true) }
+    removeChild(coordinater)
+    self.noneMemberchallengeCoordinator = nil
+  }
+}
+
+// MARK: - SearchChallengeCoordinatable
+extension SearchChallengeCoordinator: SearchChallengeCoordinatable {
   func didStartSearch() {
     attachSearchResult()
   }
@@ -143,7 +182,9 @@ extension SearchChallengeCoordinator: ChallengeOrganizeListener {
 
 // MARK: - RecommendedChallengesListener
 extension SearchChallengeCoordinator: RecommendedChallengesListener {
-  func requestAttachChallengeAtRecommendedChallenges(challengeId: Int) { }
+  func requestAttachChallengeAtRecommendedChallenges(challengeId: Int) {
+    Task { await viewModel.decideRouteForChallenge(id: challengeId) }
+  }
 }
 
 // MARK: - RecentChallengesListener
@@ -155,5 +196,40 @@ extension SearchChallengeCoordinator: RecentChallengesListener {
 extension SearchChallengeCoordinator: SearchResultListener {
   func didTapBackButtonAtSearchResult() {
     detachSearchResult()
+  }
+}
+
+// MARK: - ChallengeListener
+extension SearchChallengeCoordinator: ChallengeListener {
+  func didTapBackButtonAtChallenge() {
+    detachChallenge()
+  }
+  
+  func shouldDismissChallenge() {
+    detachChallenge()
+  }
+  
+  func leaveChallenge(challengeId: Int) {
+    detachChallenge()
+  }
+  
+  func authenticatedFailedAtChallenge() {
+    listener?.authenticatedFailedAtSearchChallenge()
+  }
+}
+
+// MARK: - NoneMemberChallengeListener
+extension SearchChallengeCoordinator: NoneMemberChallengeListener {
+  func didTapBackButtonAtNoneMemberChallenge() {
+    detachNonememberChallenge(animted: true)
+  }
+  
+  func didJoinChallenge(id: Int) {
+    detachNonememberChallenge(animted: false)
+    attachChallenge(id: id)
+  }
+  
+  func authenticatedFailedAtNoneMemberChallenge() {
+    listener?.authenticatedFailedAtSearchChallenge()
   }
 }

--- a/Projects/Presentation/SearchChallenge/Implementations/SearchChallengeCoordinator.swift
+++ b/Projects/Presentation/SearchChallenge/Implementations/SearchChallengeCoordinator.swift
@@ -32,19 +32,29 @@ final class SearchChallengeCoordinator: ViewableCoordinator<SearchChallengePrese
   private let searchResultContainable: SearchResultContainable
   private var searchResultCoordinator: ViewableCoordinating?
   
+  private let challengeContainable: ChallengeContainable
+  private var challengeCoordinator: ViewableCoordinating?
+  
+  private let noneMemberChallengeContainable: NoneMemberChallengeContainable
+  private var noneMemberchallengeCoordinator: ViewableCoordinating?
+  
   init(
     viewControllerable: ViewControllerable,
     viewModel: SearchChallengeViewModel,
     challengeOrganizeContainable: ChallengeOrganizeContainable,
     recommendedChallengesContainable: RecommendedChallengesContainable,
     recentChallengesContainable: RecentChallengesContainable,
-    searchResultContainable: SearchResultContainable
+    searchResultContainable: SearchResultContainable,
+    challengeContainable: ChallengeContainable,
+    noneMemberChallengeContainable: NoneMemberChallengeContainable
   ) {
     self.viewModel = viewModel
     self.organizeContainable = challengeOrganizeContainable
     self.recommendedChallengesContainable = recommendedChallengesContainable
     self.recentChallengesContainable = recentChallengesContainable
     self.searchResultContainable = searchResultContainable
+    self.challengeContainable = challengeContainable
+    self.noneMemberChallengeContainable = noneMemberChallengeContainable
     super.init(viewControllerable)
     viewModel.coordinator = self
   }

--- a/Projects/Presentation/SearchChallenge/Implementations/SearchChallengeViewController.swift
+++ b/Projects/Presentation/SearchChallenge/Implementations/SearchChallengeViewController.swift
@@ -120,10 +120,22 @@ private extension SearchChallengeViewController {
       .disposed(by: disposeBag)
   }
   
-  func bind(output: SearchChallengeViewModel.Output) {}
+  func bind(output: SearchChallengeViewModel.Output) {
+    output.networkUnstable
+      .emit(with: self) { owner, _ in
+        owner.presentNetworkUnstableAlert()
+      }
+      .disposed(by: disposeBag)
+    
+    output.exceedMaxChallengeCount
+      .emit(with: self) { owner, _ in
+        owner.presentExceedMaxChallengeCountToastView()
+      }
+      .disposed(by: disposeBag)
+  }
 }
 
-// MARK: -
+// MARK: - UITextFieldDelegate
 extension SearchChallengeViewController: UITextFieldDelegate {
   func textFieldShouldBeginEditing(_ textField: UITextField) -> Bool {
     return false
@@ -159,5 +171,20 @@ private extension SearchChallengeViewController {
     viewController.view.snp.makeConstraints {
       $0.edges.equalToSuperview()
     }
+  }
+  
+  func presentExceedMaxChallengeCountToastView() {
+    let toastView = ToastView(
+      tipPosition: .none,
+      text: "챌린지는 최대 20개까지 참여할 수 있어요.",
+      icon: .closeRed
+    )
+    
+    toastView.setConstraints {
+      $0.centerX.equalToSuperview()
+      $0.bottom.equalToSuperview().inset(64)
+    }
+    
+    toastView.present(at: self.view)
   }
 }

--- a/Projects/Presentation/SearchChallenge/Interfaces/SearchChallenge.swift
+++ b/Projects/Presentation/SearchChallenge/Interfaces/SearchChallenge.swift
@@ -12,4 +12,6 @@ public protocol SearchChallengeContainable: Containable {
   func coordinator(listener: SearchChallengeListener) -> ViewableCoordinating
 }
 
-public protocol SearchChallengeListener: AnyObject { }
+public protocol SearchChallengeListener: AnyObject {
+  func authenticatedFailedAtSearchChallenge()
+}


### PR DESCRIPTION
## 관련 이슈

- #151 

## 작업 설명
- 인기있는 챌린지 API 연결 
- 해시태그별로 조회하는 API 연결 및 Pagination 구현 
- 챌린지 클릭지 참여 유무에 따른, Challenge이동 
- 챌린지 최대 참여 갯수 초과시 챌린지 생성 제한 기능 
![Simulator Screen Recording - iPhone 16 Pro - 2025-05-27 at 21 07 55](https://github.com/user-attachments/assets/7f16a53f-c027-4769-a71a-194bd733f69d)
![Simulator Screen Recording - iPhone 16 Pro - 2025-05-27 at 21 12 00](https://github.com/user-attachments/assets/be2656d3-35f1-400e-b59a-039f36d7a7d2)



## 특이사항 
- 현재  API 변경으로 인해 챌린지 참여에서 에러가 발생합니다. 추후에 챌린지 API 수정예정입니다.