### PR TITLE
[FEAT]: 검색 화면에서 최신순 챌린지 조회 API 연결

### DIFF
--- a/Projects/Data/DTO/Challenge/ChallengeByHashTag/SearcgChallengesSummaryResponseDTO.swift
+++ b/Projects/Data/DTO/Challenge/ChallengeByHashTag/SearcgChallengesSummaryResponseDTO.swift
@@ -6,25 +6,15 @@
 //  Copyright © 2025 com.photi. All rights reserved.
 //
 
-import Foundation
-
-public struct ChallengesByHashTagResponseDTO: Decodable {
-  public let content: [ChallengeByHashTag]
+public struct SearcgChallengesSummaryResponseDTO: Decodable {
+  public let content: [SearchChallengeResponseDTO]
   public let page: Int
   public let size: Int
   public let first: Bool
   public let last: Bool
 }
 
-public struct ChallengeByHashTag: Decodable {
-  public let id: Int
-  public let name: String
-  public let imageUrl: String?
-  public let endDate: String
-  public let hashtags: [HashTagResponseDTO]
-}
-
-public extension ChallengesByHashTagResponseDTO {
+public extension SearcgChallengesSummaryResponseDTO {
   static let stubData = """
 {
   "code": "200 OK",

--- a/Projects/Data/DTO/Challenge/ChallengeByHashTag/SearchChallengeResponseDTO.swift
+++ b/Projects/Data/DTO/Challenge/ChallengeByHashTag/SearchChallengeResponseDTO.swift
@@ -1,0 +1,15 @@
+//
+//  SearchChallengeResponseDTO.swift
+//  DTO
+//
+//  Created by jung on 5/27/25.
+//  Copyright © 2025 com.photi. All rights reserved.
+//
+
+public struct SearchChallengeResponseDTO: Decodable {
+  public let id: Int
+  public let name: String
+  public let imageUrl: String?
+  public let endDate: String
+  public let hashtags: [HashTagResponseDTO]
+}

--- a/Projects/Data/DataMapper/ChallengeDataMapper.swift
+++ b/Projects/Data/DataMapper/ChallengeDataMapper.swift
@@ -27,8 +27,11 @@ public protocol ChallengeDataMapper {
 
 public struct ChallengeDataMapperImpl: ChallengeDataMapper {
   public init() {}
-  
-  public func mapToChallengeDetail(dto: PopularChallengeResponseDTO) -> ChallengeDetail {
+}
+
+// MARK: - Challenge Mapping
+public extension ChallengeDataMapperImpl {
+  func mapToChallengeDetail(dto: PopularChallengeResponseDTO) -> ChallengeDetail {
     let endDate = dto.endDate.toDate() ?? Date()
     let hasTags = dto.hashtags.map { $0.hashtag }
     let proveTime = dto.proveTime.toDate("HH:mm") ?? Date()
@@ -47,7 +50,7 @@ public struct ChallengeDataMapperImpl: ChallengeDataMapper {
     )
   }
   
-  public func mapToChallengeDetail(dto: ChallengeDetailResponseDTO, id: Int) -> ChallengeDetail {
+  func mapToChallengeDetail(dto: ChallengeDetailResponseDTO, id: Int) -> ChallengeDetail {
     let endDate = dto.endDate.toDate() ?? Date()
     let hasTags = dto.hashtags.map { $0.hashtag }
     let proveTime = dto.proveTime.toDate("HH:mm") ?? Date()
@@ -69,7 +72,7 @@ public struct ChallengeDataMapperImpl: ChallengeDataMapper {
     )
   }
   
-  public func mapToChallengeSummaryFromEnded(dto: EndedChallengeResponseDTO) -> [ChallengeSummary] {
+  func mapToChallengeSummaryFromEnded(dto: EndedChallengeResponseDTO) -> [ChallengeSummary] {
     return dto.content.map {
       let endDate = $0.endDate.toDate() ?? Date()
       let memberImages = $0.memberImages.map { $0.memberImage }
@@ -86,7 +89,7 @@ public struct ChallengeDataMapperImpl: ChallengeDataMapper {
     }
   }
   
-  public func mapToChallengeSummaryFromMyChallenge(dto: MyChallengesResponseDTO) -> [ChallengeSummary] {
+  func mapToChallengeSummaryFromMyChallenge(dto: MyChallengesResponseDTO) -> [ChallengeSummary] {
     return dto.content.map {
       let endDate = $0.endDate.toDate() ?? Date()
       let hasTags = $0.hashtags.map { $0.hashtag }
@@ -108,7 +111,7 @@ public struct ChallengeDataMapperImpl: ChallengeDataMapper {
     }
   }
   
-  public func mapToChallengeSummaryFromSearchChallengesSummary(dto: SearcgChallengesSummaryResponseDTO) -> [ChallengeSummary] {
+  func mapToChallengeSummaryFromSearchChallengesSummary(dto: SearcgChallengesSummaryResponseDTO) -> [ChallengeSummary] {
     return dto.content.map {
       let endDate = $0.endDate.toDate() ?? Date()
       let hasTags = $0.hashtags.map { $0.hashtag }
@@ -123,8 +126,39 @@ public struct ChallengeDataMapperImpl: ChallengeDataMapper {
       )
     }
   }
+  
+  func mapToChallengeDescription(dto: ChallengeDescriptionResponseDTO, id: Int) -> ChallengeDescription {
+    let proveTime = dto.proveTime.toDate("HH:mm") ?? Date()
+    let startDate = dto.startDate.toDate() ?? Date()
+    let endDate = dto.endDate.toDate() ?? Date()
+    let rules = dto.rules.map { $0.rule }
+    return .init(
+      id: id,
+      rules: rules,
+      proveTime: proveTime,
+      startDate: startDate,
+      goal: dto.goal,
+      endDate: endDate
+    )
+  }
+  
+  func mapToChallengeMembers(dto: [ChallengeMemberResponseDTO]) -> [ChallengeMember] {
+    return dto.map {
+      return .init(
+        id: $0.id,
+        name: $0.username,
+        imageUrl: URL(string: $0.imageUrl ?? ""),
+        isOwner: $0.isCreator,
+        duration: $0.duration,
+        goal: $0.goal ?? ""
+      )
+    }
+  }
+}
 
-  public func mapToFeed(dto: FeedResponseDTO) -> Feed {
+// MARK: - Feed Mapping
+public extension ChallengeDataMapperImpl {
+  func mapToFeed(dto: FeedResponseDTO) -> Feed {
     let updateTime = dto.createdDateTime.toDateFromISO8601() ?? Date()
     let imageUrl = URL(string: dto.imageUrl ?? "") ?? defaultURL()
     return .init(
@@ -136,7 +170,7 @@ public struct ChallengeDataMapperImpl: ChallengeDataMapper {
     )
   }
   
-  public func mapToFeed(dto: FeedDetailResponseDTO, id: Int) -> Feed {
+  func mapToFeed(dto: FeedDetailResponseDTO, id: Int) -> Feed {
     let updateTime = dto.createdDateTime.toDateFromISO8601() ?? Date()
     let imageURL = URL(string: dto.feedImageUrl ?? "") ?? defaultURL()
     let authorImageURL = URL(string: dto.userImageUrl ?? "")
@@ -152,7 +186,7 @@ public struct ChallengeDataMapperImpl: ChallengeDataMapper {
     )
   }
   
-  public func mapToFeedComment(dto: CommentResponseDTO) -> FeedComment {
+  func mapToFeedComment(dto: CommentResponseDTO) -> FeedComment {
     return .init(
       id: dto.id,
       author: dto.username,
@@ -160,35 +194,7 @@ public struct ChallengeDataMapperImpl: ChallengeDataMapper {
     )
   }
   
-  public func mapToChallengeDescription(dto: ChallengeDescriptionResponseDTO, id: Int) -> ChallengeDescription {
-    let proveTime = dto.proveTime.toDate("HH:mm") ?? Date()
-    let startDate = dto.startDate.toDate() ?? Date()
-    let endDate = dto.endDate.toDate() ?? Date()
-    let rules = dto.rules.map { $0.rule }
-    return .init(
-      id: id,
-      rules: rules,
-      proveTime: proveTime,
-      startDate: startDate,
-      goal: dto.goal,
-      endDate: endDate
-    )
-  }
-  
-  public func mapToChallengeMembers(dto: [ChallengeMemberResponseDTO]) -> [ChallengeMember] {
-    return dto.map {
-      return .init(
-        id: $0.id,
-        name: $0.username,
-        imageUrl: URL(string: $0.imageUrl ?? ""),
-        isOwner: $0.isCreator,
-        duration: $0.duration,
-        goal: $0.goal ?? ""
-      )
-    }
-  }
-  
-  public func mapToFeedHistory(dto: FeedHistoryResponseDTO) -> [FeedHistory] {
+  func mapToFeedHistory(dto: FeedHistoryResponseDTO) -> [FeedHistory] {
     return dto.content.map {
       FeedHistory(
         feedId: $0.feedId,

--- a/Projects/Data/DataMapper/ChallengeDataMapper.swift
+++ b/Projects/Data/DataMapper/ChallengeDataMapper.swift
@@ -16,7 +16,7 @@ public protocol ChallengeDataMapper {
   func mapToChallengeDetail(dto: ChallengeDetailResponseDTO, id: Int) -> ChallengeDetail
   func mapToChallengeSummaryFromEnded(dto: EndedChallengeResponseDTO) -> [ChallengeSummary]
   func mapToChallengeSummaryFromMyChallenge(dto: MyChallengesResponseDTO) -> [ChallengeSummary]
-  func mapToChallengeSummaryFromChallengeByHashTag(dto: ChallengesByHashTagResponseDTO) -> [ChallengeSummary]
+  func mapToChallengeSummaryFromSearchChallengesSummary(dto: SearcgChallengesSummaryResponseDTO) -> [ChallengeSummary]
   func mapToFeed(dto: FeedResponseDTO) -> Feed
   func mapToFeed(dto: FeedDetailResponseDTO, id: Int) -> Feed
   func mapToFeedComment(dto: CommentResponseDTO) -> FeedComment
@@ -108,7 +108,7 @@ public struct ChallengeDataMapperImpl: ChallengeDataMapper {
     }
   }
   
-  public func mapToChallengeSummaryFromChallengeByHashTag(dto: ChallengesByHashTagResponseDTO) -> [ChallengeSummary] {
+  public func mapToChallengeSummaryFromSearchChallengesSummary(dto: SearcgChallengesSummaryResponseDTO) -> [ChallengeSummary] {
     return dto.content.map {
       let endDate = $0.endDate.toDate() ?? Date()
       let hasTags = $0.hashtags.map { $0.hashtag }

--- a/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeAPI.swift
+++ b/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeAPI.swift
@@ -17,6 +17,7 @@ public enum ChallengeAPI {
   case challengeDetail(id: Int)
   case endedChallenges(page: Int, size: Int)
   case myChallenges(page: Int, size: Int)
+  case recentChallenges(page: Int, size: Int)
   case challengesByHashTag(_ hashTag: String, page: Int, size: Int)
   case joinChallenge(id: Int)
   case joinPrivateChallenge(id: Int, code: String)
@@ -40,6 +41,7 @@ extension ChallengeAPI: TargetType {
       case .popularChallenges: return "api/challenges/popular"
       case .popularHashTags: return "api/challenges/hashtags"
       case .challengesByHashTag: return "api/challenges/by-hashtags"
+      case .recentChallenges: return "api/challenges"
       case let .challengeDetail(id), let .leaveChallenge(id): return "api/challenges/\(id)"
       case .endedChallenges: return "api/users/ended-challenges"
       case .myChallenges: return "api/users/my-challenges"
@@ -58,7 +60,7 @@ extension ChallengeAPI: TargetType {
   public var method: HTTPMethod {
     switch self {
       case .popularChallenges, .popularHashTags: return .get
-      case .challengeDetail, .challengesByHashTag: return .get
+      case .challengeDetail, .challengesByHashTag, .recentChallenges: return .get
       case .endedChallenges, .myChallenges: return .get
       case .joinChallenge, .joinPrivateChallenge: return .post
       case .uploadChallengeProof: return .post
@@ -75,7 +77,7 @@ extension ChallengeAPI: TargetType {
       case .popularChallenges, .challengeCount, .challengeDetail, .popularHashTags:
         return .requestPlain
         
-      case let .endedChallenges(page, size), let .myChallenges(page, size):
+      case let .endedChallenges(page, size), let .myChallenges(page, size), let .recentChallenges(page, size):
         let parameters = ["page": page, "size": size]
         return .requestParameters(parameters: parameters, encoding: URLEncoding.queryString)
         
@@ -194,8 +196,9 @@ extension ChallengeAPI: TargetType {
         let jsonData = data.data(using: .utf8)
         
         return .networkResponse(200, jsonData ?? Data(), "OK", "성공")
-      case .challengesByHashTag:
-        let data = ChallengesByHashTagResponseDTO.stubData
+        
+      case .challengesByHashTag, .recentChallenges:
+        let data = SearcgChallengesSummaryResponseDTO.stubData
         let jsonData = data.data(using: .utf8)
         
         return .networkResponse(200, jsonData ?? Data(), "OK", "성공")

--- a/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeRepositoryImpl.swift
+++ b/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeRepositoryImpl.swift
@@ -65,10 +65,10 @@ public extension ChallengeRepositoryImpl {
     
     let result = try await requestUnAuthorizableAPI(
       api: api,
-      responseType: ChallengesByHashTagResponseDTO.self
+      responseType: SearcgChallengesSummaryResponseDTO.self
     ).value
     
-    let challenges = dataMapper.mapToChallengeSummaryFromChallengeByHashTag(dto: result)
+    let challenges = dataMapper.mapToChallengeSummaryFromSearchChallengesSummary(dto: result)
     return (challenges, result.last)
   }
   
@@ -106,6 +106,18 @@ public extension ChallengeRepositoryImpl {
       responseType: MyChallengesResponseDTO.self
     )
     .map { dataMapper.mapToChallengeSummaryFromMyChallenge(dto: $0) }
+  }
+  
+  func fetchRecentChallenges(page: Int, size: Int) async throws -> (challenges: [ChallengeSummary], isLast: Bool) {
+    let api = ChallengeAPI.recentChallenges(page: page, size: size)
+    
+    let result = try await requestUnAuthorizableAPI(
+      api: api,
+      responseType: SearcgChallengesSummaryResponseDTO.self
+    ).value
+    
+    let challenges = dataMapper.mapToChallengeSummaryFromSearchChallengesSummary(dto: result)
+    return (challenges, result.last)
   }
   
   func fetchChallengeDescription(challengeId: Int) -> Single<ChallengeDescription> {

--- a/Projects/Domain/Repository/Interfaces/ChallengeRepository.swift
+++ b/Projects/Domain/Repository/Interfaces/ChallengeRepository.swift
@@ -22,6 +22,7 @@ public protocol ChallengeRepository {
     page: Int,
     size: Int
   ) async throws -> (challenges: [ChallengeSummary], isLast: Bool)
+  func fetchRecentChallenges(page: Int, size: Int) async throws -> (challenges: [ChallengeSummary], isLast: Bool)
   func fetchPopularHashTags() -> Single<[String]>
   func isProve(challengeId: Int) async throws -> Bool
   func challengeProveMemberCount(challengeId: Int) async throws -> Int

--- a/Projects/Domain/UseCase/Implementations/SearchUseCaseImpl.swift
+++ b/Projects/Domain/UseCase/Implementations/SearchUseCaseImpl.swift
@@ -44,6 +44,12 @@ public extension SearchUseCaseImpl {
     return isLast ? .lastPage(challenges) : .defaults(challenges)
   }
   
+  func recentChallenges(page: Int, size: Int) async throws -> PageSearchChallenges {
+    let (challenges, isLast) = try await challengeRepository.fetchRecentChallenges(page: page, size: size)
+    
+    return isLast ? .lastPage(challenges) : .defaults(challenges)
+  }
+  
   func didJoinedChallenge(id: Int) async throws -> Bool {
     do {
       let myChallenges = try await challengeRepository.fetchMyChallenges(page: 0, size: 20).value

--- a/Projects/Domain/UseCase/Interfaces/SearchUseCase.swift
+++ b/Projects/Domain/UseCase/Interfaces/SearchUseCase.swift
@@ -31,4 +31,5 @@ public protocol SearchUseCase {
   ) async throws -> PageSearchChallenges
   func didJoinedChallenge(id: Int) async throws -> Bool
   func isPossibleToCreateChallenge() async -> Bool
+  func recentChallenges(page: Int, size: Int) async throws -> PageSearchChallenges
 }

--- a/Projects/Presentation/Home/Implementations/NoneChallengeHome/NoneChallengeHomeCoordinator.swift
+++ b/Projects/Presentation/Home/Implementations/NoneChallengeHome/NoneChallengeHomeCoordinator.swift
@@ -68,7 +68,7 @@ extension NoneChallengeHomeCoordinator: NoneMemberChallengeListener {
     detachNoneMemberChallenge()
   }
   
-  func didJoinChallenge() {
+  func didJoinChallenge(id: Int) {
     listener?.requstConvertInitialHome()
   }
   

--- a/Projects/Presentation/SearchChallenge/Implementations/PresentationModel/SearchChallengePresentaionModelMapper.swift
+++ b/Projects/Presentation/SearchChallenge/Implementations/PresentationModel/SearchChallengePresentaionModelMapper.swift
@@ -19,4 +19,14 @@ struct SearchChallengePresentaionModelMapper {
       deadLine: challenge.endDate.toString("~ yyyy.MM.dd")
     )
   }
+  
+  func mapToPresentationModelChallengeSummary(from challenge: ChallengeSummary) -> ChallengeCardPresentationModel {
+    return .init(
+      id: challenge.id,
+      hashTags: challenge.hashTags,
+      title: challenge.name,
+      imageUrl: challenge.imageUrl,
+      deadLine: challenge.endDate.toString("~ yyyy.MM.dd")
+    )
+  }
 }

--- a/Projects/Presentation/SearchChallenge/Implementations/RecentChallenges/RecentChallengesContainer.swift
+++ b/Projects/Presentation/SearchChallenge/Implementations/RecentChallenges/RecentChallengesContainer.swift
@@ -7,8 +7,11 @@
 //
 
 import Core
+import UseCase
 
-protocol RecentChallengesDependency: Dependency { }
+protocol RecentChallengesDependency: Dependency {
+  var searchUseCase: SearchUseCase { get }
+}
 
 protocol RecentChallengesContainable: Containable {
   func coordinator(listener: RecentChallengesListener) -> ViewableCoordinating
@@ -16,7 +19,7 @@ protocol RecentChallengesContainable: Containable {
 
 final class RecentChallengesContainer: Container<RecentChallengesDependency>, RecentChallengesContainable {
   func coordinator(listener: RecentChallengesListener) -> ViewableCoordinating {
-    let viewModel = RecentChallengesViewModel()
+    let viewModel = RecentChallengesViewModel(useCase: dependency.searchUseCase)
     let viewControllerable = RecentChallengesViewController(viewModel: viewModel)
     
     let coordinator = RecentChallengesCoordinator(

--- a/Projects/Presentation/SearchChallenge/Implementations/RecentChallenges/RecentChallengesViewController.swift
+++ b/Projects/Presentation/SearchChallenge/Implementations/RecentChallenges/RecentChallengesViewController.swift
@@ -117,6 +117,12 @@ private extension RecentChallengesViewController {
         owner.append(models: challengs)
       }
       .disposed(by: disposeBag)
+    
+    output.networkUnstable
+      .emit(with: self) { owner, _ in
+        owner.presentNetworkUnstableAlert()
+      }
+      .disposed(by: disposeBag)
   }
 }
 

--- a/Projects/Presentation/SearchChallenge/Implementations/RecentChallenges/RecentChallengesViewModel.swift
+++ b/Projects/Presentation/SearchChallenge/Implementations/RecentChallenges/RecentChallengesViewModel.swift
@@ -8,6 +8,7 @@
 
 import RxCocoa
 import RxSwift
+import UseCase
 
 protocol RecentChallengesCoordinatable: AnyObject {
   func didTapChallenge(challengeId: Int)
@@ -22,7 +23,7 @@ protocol RecentChallengesViewModelType: AnyObject {
 
 final class RecentChallengesViewModel: RecentChallengesViewModelType {
   weak var coordinator: RecentChallengesCoordinatable?
-
+  private let useCase: SearchUseCase
   private let disposeBag = DisposeBag()
   private var isFetching = false
   private var isLastPage = false
@@ -44,7 +45,10 @@ final class RecentChallengesViewModel: RecentChallengesViewModelType {
   }
   
   // MARK: - Initializers
-  init() { }
+  init(useCase: SearchUseCase) {
+    self.useCase = useCase
+    self.modelMapper = SearchChallengePresentaionModelMapper()
+  }
   
   func transform(input: Input) -> Output {
     input.requestData

--- a/Projects/Presentation/SearchChallenge/Implementations/RecentChallenges/RecentChallengesViewModel.swift
+++ b/Projects/Presentation/SearchChallenge/Implementations/RecentChallenges/RecentChallengesViewModel.swift
@@ -88,7 +88,7 @@ private extension RecentChallengesViewModel {
     }
       
     do {
-      let result = try await useCase.recentChallenges(page: currentPage, size: 3)
+      let result = try await useCase.recentChallenges(page: currentPage, size: 15)
       let models = result.challenges.map {
         modelMapper.mapToPresentationModelChallengeSummary(from: $0)
       }

--- a/Projects/Presentation/SearchChallenge/Implementations/RecommendedChallenges/RecommendedChallengesViewController.swift
+++ b/Projects/Presentation/SearchChallenge/Implementations/RecommendedChallenges/RecommendedChallengesViewController.swift
@@ -213,6 +213,12 @@ private extension RecommendedChallengesViewController {
         owner.append(models: models)
       }
       .disposed(by: disposeBag)
+    
+    output.networkUnstable
+      .emit(with: self) { owner, _ in
+        owner.presentNetworkUnstableAlert()
+      }
+      .disposed(by: disposeBag)
   }
 }
 

--- a/Projects/Presentation/SearchChallenge/Implementations/SearchChallengeCoordinator.swift
+++ b/Projects/Presentation/SearchChallenge/Implementations/SearchChallengeCoordinator.swift
@@ -189,7 +189,9 @@ extension SearchChallengeCoordinator: RecommendedChallengesListener {
 
 // MARK: - RecentChallengesListener
 extension SearchChallengeCoordinator: RecentChallengesListener {
-  func requestAttachChallengeAtRecentChallenges(challengeId: Int) { }
+  func requestAttachChallengeAtRecentChallenges(challengeId: Int) {
+    Task { await viewModel.decideRouteForChallenge(id: challengeId) }
+  }
 }
 
 // MARK: - SearchResultListener

--- a/Projects/Presentation/SearchChallenge/Implementations/SearchResult/ChallengeTitleResult/ChallengeTitleResultViewController.swift
+++ b/Projects/Presentation/SearchChallenge/Implementations/SearchResult/ChallengeTitleResult/ChallengeTitleResultViewController.swift
@@ -71,7 +71,6 @@ final class ChallengeTitleResultViewController: UIViewController, ViewController
     self.datasource = datasource
     challengeCollectionView.dataSource = datasource
     challengeCollectionView.delegate = self
-    initialize(with: Dummy.initialSearchPage)
   }
 }
 


### PR DESCRIPTION
## 관련 이슈

- #255 

## 작업 설명
검색화면에서 "최신순" 세그먼트 부분<br> 
챌린지 조회 API 연결 완료 했습니다.  <br>
- 최신 챌린지 조회 Pagination 구현 

추가로 지난번 리뷰에서 말씀 주신 오류 수정했습니다. 
- `NoneMemberChallengeHome`에서 발생하는 빌드에러 
- `ChallengeTItleResultViewController`에서 `Dummy`라는 샘플 코드로 인한 버그

## 스크린샷
![Simulator Screen Recording - iPhone 16 Pro - 2025-05-29 at 00 00 30](https://github.com/user-attachments/assets/4bd40b6f-072f-4a1e-954f-38e004d45d45)
> Pagination이 되는 것을 보이기 위해 영상 상에서는 size를 3으로 설정했습니다