### PR TITLE
[FEAT]: 챌린지 참여 관련 API 서버 변경사항 적용

### DIFF
--- a/Projects/Core/Utils/BaseCoordinator/ViewControllerable.swift
+++ b/Projects/Core/Utils/BaseCoordinator/ViewControllerable.swift
@@ -84,15 +84,15 @@ public extension ViewControllerable {
     }
   }
   
-  func setViewControllers(_ viewControllerables: [ViewControllerable]) {
+  func setViewControllers(_ viewControllerables: [ViewControllerable], animated: Bool = true) {
     if let nav = self.uiviewController as? UINavigationController {
-      nav.setViewControllers(viewControllerables.map(\.uiviewController), animated: true)
+      nav.setViewControllers(viewControllerables.map(\.uiviewController), animated: animated)
     } else {
       self.uiviewController
         .navigationController?
         .setViewControllers(
           viewControllerables.map(\.uiviewController),
-          animated: true
+          animated: animated
         )
     }
   }

--- a/Projects/Data/DTO/Challenge/VerifyInvitationCode/VerifyInvitationCodeResponseDTO.swift
+++ b/Projects/Data/DTO/Challenge/VerifyInvitationCode/VerifyInvitationCodeResponseDTO.swift
@@ -1,0 +1,23 @@
+//
+//  VerifyInvitationCodeResponseDTO.swift
+//  DTO
+//
+//  Created by jung on 5/30/25.
+//  Copyright © 2025 com.photi. All rights reserved.
+//
+
+public struct VerifyInvitationCodeResponseDTO: Decodable {
+  public let isMatch: Bool
+}
+
+public extension VerifyInvitationCodeResponseDTO {
+  static let stubData = """
+{
+  "code": "200 OK",
+  "message": "성공",
+  "data": {
+    "isMatch": true
+  }
+}
+"""
+}

--- a/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeRepositoryImpl.swift
+++ b/Projects/Data/Repository/Implementations/ChallengeRepositoryImpl/ChallengeRepositoryImpl.swift
@@ -173,17 +173,18 @@ public extension ChallengeRepositoryImpl {
 
 // MARK: - Upload Methods
 public extension ChallengeRepositoryImpl {
-  func joinPrivateChallnege(id: Int, code: String) -> Single<Void> {
-    return requestAuthorizableAPI(
-      api: ChallengeAPI.joinPrivateChallenge(id: id, code: code),
-      responseType: SuccessResponseDTO.self
-    )
-    .map { _ in () }
+  func verifyInvitationCode(id: Int, code: String) async throws -> Bool {
+    let result = try await requestUnAuthorizableAPI(
+      api: ChallengeAPI.verifyInvitationCode(id: id, code),
+      responseType: VerifyInvitationCodeResponseDTO.self
+    ).value
+    
+    return result.isMatch
   }
   
-  func joinPublicChallenge(id: Int) -> Single<Void> {
+  func joinChallenge(id: Int, goal: String) -> Single<Void> {
     return requestAuthorizableAPI(
-      api: ChallengeAPI.joinChallenge(id: id),
+      api: ChallengeAPI.joinChallenge(id: id, goal: goal),
       responseType: SuccessResponseDTO.self
     )
     .map { _ in () }
@@ -301,9 +302,7 @@ private extension ChallengeRepositoryImpl {
   }
   
   func map400ToAPIError(_ code: String, _ message: String) -> APIError {
-    if code == "CHALLENGE_INVITATION_CODE_INVALID" {
-      return APIError.challengeFailed(reason: .invalidInvitationCode)
-    } else if code == "CHALLENGE_LIMIT_EXCEED" {
+    if code == "CHALLENGE_LIMIT_EXCEED" {
       return APIError.challengeFailed(reason: .challengeLimitExceed)
     } else {
       return APIError.clientError(code: code, message: message)

--- a/Projects/Data/Repository/Implementations/FeedRepositoryImpl/FeedRepositoryImpl.swift
+++ b/Projects/Data/Repository/Implementations/FeedRepositoryImpl/FeedRepositoryImpl.swift
@@ -143,8 +143,6 @@ private extension FeedRepositoryImpl {
           let result = try await provider.request(api, type: responseType.self).value
           if (200..<300).contains(result.statusCode), let data = result.data {
             single(.success(data))
-          } else if result.statusCode == 400 {
-            single(.failure(APIError.challengeFailed(reason: .invalidInvitationCode)))
           } else if result.statusCode == 401 || result.statusCode == 403 {
             single(.failure(APIError.authenticationFailed))
           } else if result.statusCode == 404 {

--- a/Projects/Domain/Entity/APIError.swift
+++ b/Projects/Domain/Entity/APIError.swift
@@ -59,7 +59,6 @@ extension APIError {
     case userNotFound
     case notChallengeMemeber
     case alreadyJoinedChallenge
-    case invalidInvitationCode
     case alreadyUploadFeed
     case fileTooLarge
     case challengeLimitExceed

--- a/Projects/Domain/Repository/Interfaces/ChallengeRepository.swift
+++ b/Projects/Domain/Repository/Interfaces/ChallengeRepository.swift
@@ -38,8 +38,8 @@ public protocol ChallengeRepository {
   func challengeProveMemberCount(challengeId: Int) async throws -> Int
   func challengeCount() async throws -> Int
   
-  func joinPublicChallenge(id: Int) -> Single<Void>
-  func joinPrivateChallnege(id: Int, code: String) -> Single<Void>
+  func verifyInvitationCode(id: Int, code: String) async throws -> Bool
+  func joinChallenge(id: Int, goal: String) -> Single<Void>
   func updateChallengeGoal(_ goal: String, challengeId: Int) -> Single<Void>
   func leaveChallenge(id: Int) -> Single<Void>
   func uploadChallengeFeedProof(id: Int, image: Data, imageType: String) async throws -> Feed

--- a/Projects/Domain/UseCase/Implementations/ChallengeUseCaseImpl.swift
+++ b/Projects/Domain/UseCase/Implementations/ChallengeUseCaseImpl.swift
@@ -61,12 +61,12 @@ public extension ChallengeUseCaseImpl {
 
 // MARK: - Upload & Update Methods
 public extension ChallengeUseCaseImpl {
-  func joinPrivateChallnege(id: Int, code: String) async throws {
-    try await challengeRepository.joinPrivateChallnege(id: id, code: code).value
+  func verifyInvitationCode(id: Int, code: String) async throws -> Bool {
+    return try await challengeRepository.verifyInvitationCode(id: id, code: code)
   }
   
-  func joinPublicChallenge(id: Int) -> Single<Void> {
-    return challengeRepository.joinPublicChallenge(id: id)
+  func joinChallenge(id: Int, goal: String) -> Single<Void> {
+    return challengeRepository.joinChallenge(id: id, goal: goal)
   }
   
   func uploadChallengeFeedProof(id: Int, image: UIImageWrapper) async throws -> Feed {

--- a/Projects/Domain/UseCase/Implementations/ChallengeUseCaseImpl.swift
+++ b/Projects/Domain/UseCase/Implementations/ChallengeUseCaseImpl.swift
@@ -15,6 +15,8 @@ import UseCase
 import Repository
 
 public struct ChallengeUseCaseImpl: ChallengeUseCase {
+  private let maximumChallengeCount = 20
+  
   private let challengeRepository: ChallengeRepository
   private let feedRepository: FeedRepository
   private let authRepository: AuthRepository
@@ -56,6 +58,15 @@ public extension ChallengeUseCaseImpl {
   
   func challengeProveMemberCount(challengeId: Int) async throws -> Int {
     return try await challengeRepository.challengeProveMemberCount(challengeId: challengeId)
+  }
+  
+  func isPossibleToJoinChallenge() async -> Bool {
+    let myChallengeCount = try? await challengeRepository.fetchMyChallenges(page: 0, size: 20).value
+      .count
+    
+    guard let myChallengeCount else { return true }
+    
+    return myChallengeCount < maximumChallengeCount
   }
 }
 

--- a/Projects/Domain/UseCase/Implementations/ChallengeUseCaseImpl.swift
+++ b/Projects/Domain/UseCase/Implementations/ChallengeUseCaseImpl.swift
@@ -68,6 +68,13 @@ public extension ChallengeUseCaseImpl {
     
     return myChallengeCount < maximumChallengeCount
   }
+  
+  func isJoinedChallenge(id: Int) async -> Bool {
+    let myChallenges = try? await challengeRepository.fetchMyChallenges(page: 0, size: 20).value
+      .map { $0.id }
+    guard let myChallenges else { return false }
+    return myChallenges.contains(id)
+  }
 }
 
 // MARK: - Upload & Update Methods

--- a/Projects/Domain/UseCase/Interfaces/ChallengeUseCase.swift
+++ b/Projects/Domain/UseCase/Interfaces/ChallengeUseCase.swift
@@ -24,6 +24,7 @@ public protocol ChallengeUseCase {
   func fetchChallengeMembers(challengeId: Int) -> Single<[ChallengeMember]>
   func challengeProveMemberCount(challengeId: Int) async throws -> Int
 
+  func isPossibleToJoinChallenge() async -> Bool
   func isProve(challengeId: Int) async throws -> Bool
   func uploadChallengeFeedProof(id: Int, image: UIImageWrapper) async throws -> Feed
   func updateLikeState(challengeId: Int, feedId: Int, isLike: Bool) async throws

--- a/Projects/Domain/UseCase/Interfaces/ChallengeUseCase.swift
+++ b/Projects/Domain/UseCase/Interfaces/ChallengeUseCase.swift
@@ -26,6 +26,7 @@ public protocol ChallengeUseCase {
 
   func isPossibleToJoinChallenge() async -> Bool
   func isProve(challengeId: Int) async throws -> Bool
+  func isJoinedChallenge(id: Int) async -> Bool
   func uploadChallengeFeedProof(id: Int, image: UIImageWrapper) async throws -> Feed
   func updateLikeState(challengeId: Int, feedId: Int, isLike: Bool) async throws
   func fetchFeeds(

--- a/Projects/Domain/UseCase/Interfaces/ChallengeUseCase.swift
+++ b/Projects/Domain/UseCase/Interfaces/ChallengeUseCase.swift
@@ -20,8 +20,10 @@ public enum PageFeeds {
 public protocol ChallengeUseCase {
   func isLogIn() async throws -> Bool
   func fetchChallengeDetail(id: Int) -> Single<ChallengeDetail>
-  func joinPrivateChallnege(id: Int, code: String) async throws
-  func joinPublicChallenge(id: Int) -> Single<Void>
+  func fetchChallengeDescription(id: Int) -> Single<ChallengeDescription>
+  func fetchChallengeMembers(challengeId: Int) -> Single<[ChallengeMember]>
+  func challengeProveMemberCount(challengeId: Int) async throws -> Int
+
   func isProve(challengeId: Int) async throws -> Bool
   func uploadChallengeFeedProof(id: Int, image: UIImageWrapper) async throws -> Feed
   func updateLikeState(challengeId: Int, feedId: Int, isLike: Bool) async throws
@@ -31,9 +33,8 @@ public protocol ChallengeUseCase {
     size: Int,
     orderType: ChallengeFeedsOrderType
   ) async throws -> PageFeeds
+  func verifyInvitationCode(id: Int, code: String) async throws -> Bool
+  func joinChallenge(id: Int, goal: String) -> Single<Void>
   func updateChallengeGoal(_ goal: String, challengeId: Int) -> Single<Void>
-  func fetchChallengeDescription(id: Int) -> Single<ChallengeDescription>
-  func fetchChallengeMembers(challengeId: Int) -> Single<[ChallengeMember]>
   func leaveChallenge(id: Int) -> Single<Void>
-  func challengeProveMemberCount(challengeId: Int) async throws -> Int
 }

--- a/Projects/Presentation/Challenge/Implementations/EnterChallengeGoal/EnterChallengeGoalContainer.swift
+++ b/Projects/Presentation/Challenge/Implementations/EnterChallengeGoal/EnterChallengeGoalContainer.swift
@@ -11,7 +11,7 @@ import UseCase
 
 enum ChallengeGoalMode {
   case edit(goal: String)
-  case add
+  case join
 }
 
 protocol EnterChallengeGoalDependency: Dependency {
@@ -34,7 +34,11 @@ final class EnterChallengeGoalContainer: Container<EnterChallengeGoalDependency>
     challengeName: String,
     listener: EnterChallengeGoalListener
   ) -> ViewableCoordinating {
-    let viewModel = EnterChallengeGoalViewModel(challengeID: challengeID, useCase: dependency.challengeUseCase)
+    let viewModel = EnterChallengeGoalViewModel(
+      mode: mode,
+      challengeID: challengeID,
+      useCase: dependency.challengeUseCase
+    )
     let viewControllerable = EnterChallengeGoalViewController(
       mode: mode,
       challengeName: challengeName,

--- a/Projects/Presentation/Challenge/Implementations/EnterChallengeGoal/EnterChallengeGoalCoordinator.swift
+++ b/Projects/Presentation/Challenge/Implementations/EnterChallengeGoal/EnterChallengeGoalCoordinator.swift
@@ -10,7 +10,7 @@ import Core
 
 protocol EnterChallengeGoalListener: AnyObject {
   func didTapBackButtonAtEnterChallengeGoal()
-  func didFinishEnterChallengeGoal(_ goal: String)
+  func didFinishEnteringGoal(_ goal: String)
   func authenticatedFailedAtEnterChallengeGoal()
 }
 
@@ -37,12 +37,8 @@ extension EnterChallengeGoalCoordinator: EnterChallengeGoalCoordinatable {
     listener?.didTapBackButtonAtEnterChallengeGoal()
   }
   
-  func didChangeChallengeGoal(goal: String) {
-    listener?.didFinishEnterChallengeGoal(goal)
-  }
-  
-  func didSkipEnterChallengeGoal() {
-    listener?.didFinishEnterChallengeGoal("")
+  func didFinishEnteringGoal(_ goal: String) {
+    listener?.didFinishEnteringGoal(goal)
   }
   
   func authenticatedFailed() {

--- a/Projects/Presentation/Challenge/Implementations/EnterChallengeGoal/EnterChallengeGoalViewController.swift
+++ b/Projects/Presentation/Challenge/Implementations/EnterChallengeGoal/EnterChallengeGoalViewController.swift
@@ -170,7 +170,7 @@ private extension EnterChallengeGoalViewController {
   }
   
   func viewBind() {
-    if case .add = mode {
+    if case .join = mode {
       addGoalModeViewBind()
     }
   }
@@ -201,8 +201,22 @@ private extension EnterChallengeGoalViewController {
         owner.presentNetworkUnstableAlert()
       }
       .disposed(by: disposeBag)
+    
+    output.alreadyJoined
+      .emit(with: self) { owner, _ in
+        owner.displayAlreadyJoinPopUp()
+      }
+      .disposed(by: disposeBag)
   }
 }
 
 // MARK: - EditChallengeGoalPresentable
 extension EnterChallengeGoalViewController: EnterChallengeGoalPresentable { }
+
+// MARK: - Private Methods
+private extension EnterChallengeGoalViewController {
+  func displayAlreadyJoinPopUp() {
+    let popUp = AlertViewController(alertType: .confirm, title: "이미 참여한 챌린지예요")
+    popUp.present(to: self, animted: false)
+  }
+}

--- a/Projects/Presentation/Challenge/Implementations/Member/ChallengeViewController.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/ChallengeViewController.swift
@@ -85,6 +85,7 @@ final class ChallengeViewController: UIViewController, ViewControllerable {
 // MARK: - UI Methods
 private extension ChallengeViewController {
   func setupUI() {
+    view.backgroundColor = .white
     setViewHierarhcy()
     setConstraints()
   }

--- a/Projects/Presentation/Challenge/Implementations/Member/Participant/ParticipantCoordinator.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/Participant/ParticipantCoordinator.swift
@@ -90,8 +90,8 @@ extension ParticipantCoordinator: EnterChallengeGoalListener {
   func didTapBackButtonAtEnterChallengeGoal() {
     detachEditChallengeGoal()
   }
-
-  func didFinishEnterChallengeGoal(_ goal: String) {
+  
+  func didFinishEnteringGoal(_ goal: String) {
     detachEditChallengeGoal { [weak self] in
       self?.presenter.didUpdateGoal(goal)
     }

--- a/Projects/Presentation/Challenge/Implementations/NoneMember/NoneMemberChallengeCoordinator.swift
+++ b/Projects/Presentation/Challenge/Implementations/NoneMember/NoneMemberChallengeCoordinator.swift
@@ -118,6 +118,10 @@ extension NoneMemberChallengeCoordinator: NoneMemberChallengeCoordinatable {
   func didTapBackButton() {
     listener?.didTapBackButtonAtNoneMemberChallenge()
   }
+  
+  func requestDetach() {
+    listener?.shouldDismissNoneMemberChallenge()
+  }
 }
 
 // MARK: - EnterChallengeGoalListener

--- a/Projects/Presentation/Challenge/Implementations/NoneMember/NoneMemberChallengeCoordinator.swift
+++ b/Projects/Presentation/Challenge/Implementations/NoneMember/NoneMemberChallengeCoordinator.swift
@@ -156,12 +156,24 @@ extension NoneMemberChallengeCoordinator: LogInListener {
     detachLogIn(animted: false)
     detachLogInGuide(animted: true)
     
-    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
-      self?.presenter.presentWelcomeToastView(userName)
+    Task { @MainActor [weak self] in
+      guard let self else { return }
+      let isJoined = await viewModel.isJoinedChallenge()
+      
+      isJoined ? listener?.alreadyJoinedChallenge(id: challengeId) : presentWelcomeToastView(userName)
     }
   }
   
   func didTapBackButtonAtLogIn() {
     detachLogIn(animted: true)
+  }
+}
+
+// MARK: - Private Methods
+private extension NoneMemberChallengeCoordinator {
+  func presentWelcomeToastView(_ userName: String) {
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
+      self?.presenter.presentWelcomeToastView(userName)
+    }
   }
 }

--- a/Projects/Presentation/Challenge/Implementations/NoneMember/NoneMemberChallengeCoordinator.swift
+++ b/Projects/Presentation/Challenge/Implementations/NoneMember/NoneMemberChallengeCoordinator.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2025 com.photi. All rights reserved.
 //
 
+import Foundation
 import Challenge
 import Core
 import LogIn
@@ -46,14 +47,41 @@ final class NoneMemberChallengeCoordinator: ViewableCoordinator<NoneMemberChalle
   }
 }
 
-// MARK: - Detach
-private extension NoneMemberChallengeCoordinator {
+// MARK: - ChallengeGoal
+extension NoneMemberChallengeCoordinator {
+  func attachEnterChallengeGoal(challengeName: String, challengeID: Int) {
+    guard enterChallengeGoalCoordinator == nil else { return }
+    
+    let coordinator = enterChallengeGoalContainer.coordinator(
+      mode: .join,
+      challengeID: challengeID,
+      challengeName: challengeName,
+      listener: self
+    )
+    
+    addChild(coordinator)
+    self.enterChallengeGoalCoordinator = coordinator
+    viewControllerable.pushViewController(coordinator.viewControllerable, animated: true)
+  }
+  
   func detachEnterChallengeGoal() {
     guard let coordinator = enterChallengeGoalCoordinator else { return }
     
     removeChild(coordinator)
     self.enterChallengeGoalCoordinator = nil
     viewControllerable.popViewController(animated: true)
+  }
+}
+
+// MARK: - LogInGuide
+extension NoneMemberChallengeCoordinator {
+  func attachLogInGuide() {
+    guard logInGuideCoordinator == nil else { return }
+    
+    let coordinator = logInGuideContainer.coordinator(listener: self)
+    addChild(coordinator)
+    self.logInGuideCoordinator = coordinator
+    viewControllerable.pushViewController(coordinator.viewControllerable, animated: true)
   }
   
   func detachLogInGuide(animted: Bool) {
@@ -62,6 +90,18 @@ private extension NoneMemberChallengeCoordinator {
     removeChild(coordinator)
     self.logInGuideCoordinator = nil
     viewControllerable.popViewController(animated: animted)
+  }
+}
+
+// MARK: - LogIn
+extension NoneMemberChallengeCoordinator {
+  func attachLogIn() {
+    guard logInCoordinator == nil else { return }
+    
+    let coordinator = logInContainer.coordinator(listener: self)
+    addChild(coordinator)
+    self.logInCoordinator = coordinator
+    viewControllerable.pushViewController(coordinator.viewControllerable, animated: true)
   }
   
   func detachLogIn(animted: Bool) {
@@ -78,49 +118,16 @@ extension NoneMemberChallengeCoordinator: NoneMemberChallengeCoordinatable {
   func didTapBackButton() {
     listener?.didTapBackButtonAtNoneMemberChallenge()
   }
-  
-  func attachEnterChallengeGoal(challengeName: String, challengeID: Int) {
-    guard enterChallengeGoalCoordinator == nil else { return }
-    
-    let coordinator = enterChallengeGoalContainer.coordinator(
-      mode: .add,
-      challengeID: challengeID,
-      challengeName: challengeName,
-      listener: self
-    )
-    
-    addChild(coordinator)
-    self.enterChallengeGoalCoordinator = coordinator
-    viewControllerable.pushViewController(coordinator.viewControllerable, animated: true)
-  }
-  
-  func attachLogInGuide() {
-    guard logInGuideCoordinator == nil else { return }
-    
-    let coordinator = logInGuideContainer.coordinator(listener: self)
-    addChild(coordinator)
-    self.logInGuideCoordinator = coordinator
-    viewControllerable.pushViewController(coordinator.viewControllerable, animated: true)
-  }
-  
-  func attachLogIn() {
-    guard logInCoordinator == nil else { return }
-    
-    let coordinator = logInContainer.coordinator(listener: self)
-    addChild(coordinator)
-    self.logInCoordinator = coordinator
-    viewControllerable.pushViewController(coordinator.viewControllerable, animated: true)
-  }
 }
 
 // MARK: - EnterChallengeGoalListener
 extension NoneMemberChallengeCoordinator: EnterChallengeGoalListener {
-  func didTapBackButtonAtEnterChallengeGoal() {
-    detachEnterChallengeGoal()
+  func didFinishEnteringGoal(_ goal: String) {
+    listener?.didJoinChallenge(id: challengeId)
   }
   
-  func didFinishEnterChallengeGoal(_ goal: String) {
-    listener?.didJoinChallenge(id: challengeId)
+  func didTapBackButtonAtEnterChallengeGoal() {
+    detachEnterChallengeGoal()
   }
   
   func authenticatedFailedAtEnterChallengeGoal() {
@@ -144,7 +151,10 @@ extension NoneMemberChallengeCoordinator: LogInListener {
   func didFinishLogIn(userName: String) {
     detachLogIn(animted: false)
     detachLogInGuide(animted: true)
-    Task { await presenter.presentWelcomeToastView(userName) }
+    
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
+      self?.presenter.presentWelcomeToastView(userName)
+    }
   }
   
   func didTapBackButtonAtLogIn() {

--- a/Projects/Presentation/Challenge/Implementations/NoneMember/NoneMemberChallengeViewController.swift
+++ b/Projects/Presentation/Challenge/Implementations/NoneMember/NoneMemberChallengeViewController.swift
@@ -284,6 +284,12 @@ private extension NoneMemberChallengeViewController {
         owner.presentChallengeNotFoundAlert()
       }
       .disposed(by: disposeBag)
+    
+    output.exceededJoinableChallengeLimit
+      .emit(with: self) { owner, _ in
+        owner.presentExceededJoinableChallengeLimitToastView()
+      }
+      .disposed(by: disposeBag)
   }
 }
 
@@ -359,5 +365,20 @@ private extension NoneMemberChallengeViewController {
   
   func presentChallengeNotFoundAlert() {
     challengeNotFoundAlert.present(to: self, animted: true)
+  }
+  
+  func presentExceededJoinableChallengeLimitToastView() {
+    let toastView = ToastView(
+      tipPosition: .none,
+      text: "챌린지는 최대 20개까지 참여할 수 있어요.",
+      icon: .closeRed
+    )
+    
+    toastView.setConstraints {
+      $0.centerX.equalToSuperview()
+      $0.bottom.equalToSuperview().inset(64)
+    }
+    
+    toastView.present(at: self.view)
   }
 }

--- a/Projects/Presentation/Challenge/Implementations/NoneMember/NoneMemberChallengeViewController.swift
+++ b/Projects/Presentation/Challenge/Implementations/NoneMember/NoneMemberChallengeViewController.swift
@@ -264,17 +264,13 @@ private extension NoneMemberChallengeViewController {
   }
   
   func bindFailedView(for output: NoneMemberChallengeViewModel.Output) {
-    output.requestFailed
+    output.networkUnstable
       .emit(with: self) { owner, _ in
         owner.presentNetworkUnstableAlert()
       }
       .disposed(by: disposeBag)
     
-    output.alreadyJoined
-      .emit(with: self) { owner, _ in
-        owner.displayAlreadyJoinPopUp()
-      }
-      .disposed(by: disposeBag)
+    // TODO: - 없는 챌린지 인경우, alert 띄우고, 뒤로 가기!
   }
 }
 
@@ -346,10 +342,5 @@ private extension NoneMemberChallengeViewController {
     self.invitationCodeViewController = viewController
     viewController.delegate = self
     present(viewController, animated: false)
-  }
-  
-  func displayAlreadyJoinPopUp() {
-    let popUp = AlertViewController(alertType: .confirm, title: "이미 참여한 챌린지예요")
-    popUp.present(to: self, animted: false)
   }
 }

--- a/Projects/Presentation/Challenge/Implementations/NoneMember/NoneMemberChallengeViewModel.swift
+++ b/Projects/Presentation/Challenge/Implementations/NoneMember/NoneMemberChallengeViewModel.swift
@@ -37,9 +37,8 @@ final class NoneMemberChallengeViewModel: NoneMemberChallengeViewModelType, @unc
   
   private let displayUnlockViewRelay = PublishRelay<Void>()
   private let verifyCodeResultRelay = PublishRelay<Bool>()
-  private let requestFailedRelay = PublishRelay<Void>()
+  private let networkUnstableRelay = PublishRelay<Void>()
   private let challengeNotFoundRelay = PublishRelay<Void>()
-  private let alreadyJoinedRelay = PublishRelay<Void>()
   
   private let challengeRelay = BehaviorRelay<ChallengeDetail?>(value: nil)
   private let challengeObservable: Observable<ChallengeDetail>
@@ -68,8 +67,7 @@ final class NoneMemberChallengeViewModel: NoneMemberChallengeViewModelType, @unc
     let deadLine: Driver<String>
     let memberThumbnailURLs: Driver<[URL]>
     let challengeNotFound: Signal<Void>
-    let requestFailed: Signal<Void>
-    let alreadyJoined: Signal<Void>
+    let networkUnstable: Signal<Void>
   }
 
   // MARK: - Initializers
@@ -82,7 +80,7 @@ final class NoneMemberChallengeViewModel: NoneMemberChallengeViewModelType, @unc
   func transform(input: Input) -> Output {
     input.viewDidLoad
       .emit(with: self) { owner, _ in
-        owner.fetchChallenge()
+        Task { await owner.fetchChallenge() }
       }
       .disposed(by: disposeBag)
     
@@ -94,7 +92,7 @@ final class NoneMemberChallengeViewModel: NoneMemberChallengeViewModelType, @unc
     
     input.didTapJoinButton
       .bind(with: self) { owner, _ in
-        owner.didTapJoinButton()
+        Task { await owner.attemptToJoinChallenge() }
       }
       .disposed(by: disposeBag)
     
@@ -106,7 +104,7 @@ final class NoneMemberChallengeViewModel: NoneMemberChallengeViewModelType, @unc
     
     input.requestVerifyInvitationCode
       .emit(with: self) { owner, code in
-        Task { await owner.requestJoinPrivateChallenge(code: code) }
+        Task { await owner.verifyInvitationCode(code) }
       }
       .disposed(by: disposeBag)
     
@@ -127,107 +125,65 @@ final class NoneMemberChallengeViewModel: NoneMemberChallengeViewModelType, @unc
       deadLine: deadLineObservable.asDriver(onErrorJustReturn: ""),
       memberThumbnailURLs: challengeObservable.map(\.memberImages).asDriver(onErrorJustReturn: []),
       challengeNotFound: challengeNotFoundRelay.asSignal(),
-      requestFailed: requestFailedRelay.asSignal(),
-      alreadyJoined: alreadyJoinedRelay.asSignal()
+      networkUnstable: networkUnstableRelay.asSignal()
     )
   }
 }
 
 // MARK: - Private Methods
 private extension NoneMemberChallengeViewModel {
-  func didTapJoinButton() {
-    Task {
-      do {
-        let isLogin = try await useCase.isLogIn()
-        
-        DispatchQueue.main.async { [weak self] in
-          if isLogin {
-            self?.joinChallenge()
-          } else {
-            self?.coordinator?.attachLogInGuide()
-          }
-        }
-      } catch {
-        requestFailedRelay.accept(())
-      }
+  @MainActor func attemptToJoinChallenge() async {
+    do {
+      let isLogin = try await useCase.isLogIn()
+       
+      decideJoinFlowBasedOnLogIn(isLogin: isLogin)
+    } catch {
+      networkUnstableRelay.accept(())
     }
   }
   
-  func joinChallenge() {
-    if isPrivateChallenge {
-      displayUnlockViewRelay.accept(())
-    } else {
-      Task { await requestJoinPublicChallenge() }
-    }
+  func decideJoinFlowBasedOnLogIn(isLogin: Bool) {
+    isLogin ? routeBasedOnChallengePrivacy() : coordinator?.attachLogInGuide()
+  }
+  
+  func routeBasedOnChallengePrivacy() {
+    isPrivateChallenge ?
+    displayUnlockViewRelay.accept(()) :
+    coordinator?.attachEnterChallengeGoal(challengeName: challengeName, challengeID: challengeId)
   }
 }
 
 // MARK: - API Methods
 private extension NoneMemberChallengeViewModel {
-  func fetchChallenge() {
-    useCase.fetchChallengeDetail(id: challengeId)
-      .observe(on: MainScheduler.instance)
-      .subscribe(
-        with: self,
-        onSuccess: { owner, challenge in
-          owner.challengeName = challenge.name
-          owner.isPrivateChallenge = !(challenge.isPublic ?? false)
-          owner.challengeRelay.accept(challenge)
-        },
-        onFailure: { owner, error in
-          owner.fetchChallengeFailed(with: error)
-        }
-      )
-      .disposed(by: disposeBag)
+  @MainActor func fetchChallenge() async {
+    do {
+      let challenge = try await useCase.fetchChallengeDetail(id: challengeId).value
+      challengeName = challenge.name
+      isPrivateChallenge = !(challenge.isPublic ?? false)
+      challengeRelay.accept(challenge)
+    } catch {
+      requestFailed(with: error)
+    }
   }
   
-  func fetchChallengeFailed(with error: Error) {
-    guard let error = error as? APIError else { return }
-    
+  func verifyInvitationCode(_ code: String) async {
+    do {
+      let isMatch = try await useCase.verifyInvitationCode(id: challengeId, code: code)
+      verifyCodeResultRelay.accept(isMatch)
+    } catch {
+      requestFailed(with: error)
+    }
+  }
+  
+  func requestFailed(with error: Error) {
+    guard let error = error as? APIError else { return networkUnstableRelay.accept(()) }
     switch error {
       case let .challengeFailed(reason) where reason == .challengeNotFound:
         challengeNotFoundRelay.accept(())
-      default:
-        requestFailedRelay.accept(())
-    }
-  }
-  
-  func requestJoinChallengeFailed(with error: Error) {
-    guard let error = error as? APIError else { return requestFailedRelay.accept(()) }
-    print(error)
-    switch error {
-      case let .challengeFailed(reason) where reason == .invalidInvitationCode:
-        verifyCodeResultRelay.accept(false)
-      case let .challengeFailed(reason) where reason == .alreadyJoinedChallenge:
-        alreadyJoinedRelay.accept(())
       case .authenticationFailed:
         coordinator?.attachLogInGuide()
       default:
-        requestFailedRelay.accept(())
-    }
-  }
-}
-
-// MARK: - Internal Methods
-extension NoneMemberChallengeViewModel {
-  func requestJoinPublicChallenge() async {
-    do {
-      try await useCase.joinPublicChallenge(id: challengeId).value
-      DispatchQueue.main.async { [weak self] in
-        guard let self else { return }
-        coordinator?.attachEnterChallengeGoal(challengeName: challengeName, challengeID: challengeId)
-      }
-    } catch {
-      requestJoinChallengeFailed(with: error)
-    }
-  }
-  
-  func requestJoinPrivateChallenge(code: String) async {
-    do {
-      try await useCase.joinPrivateChallnege(id: challengeId, code: code)
-      verifyCodeResultRelay.accept(true)
-    } catch {
-      requestJoinChallengeFailed(with: error)
+        networkUnstableRelay.accept(())
     }
   }
 }

--- a/Projects/Presentation/Challenge/Implementations/NoneMember/NoneMemberChallengeViewModel.swift
+++ b/Projects/Presentation/Challenge/Implementations/NoneMember/NoneMemberChallengeViewModel.swift
@@ -16,6 +16,7 @@ protocol NoneMemberChallengeCoordinatable: AnyObject {
   func attachEnterChallengeGoal(challengeName: String, challengeID: Int)
   func didTapBackButton()
   func attachLogInGuide()
+  func requestDetach()
 }
 
 protocol NoneMemberChallengeViewModelType: AnyObject {
@@ -50,6 +51,7 @@ final class NoneMemberChallengeViewModel: NoneMemberChallengeViewModelType, @unc
     let didTapJoinButton: ControlEvent<Void>
     let requestVerifyInvitationCode: Signal<String>
     let didFinishVerify: Signal<Void>
+    let didTapConfirmButtonAtChallengeNotFound: Signal<Void>
   }
   
   // MARK: - Output
@@ -105,6 +107,12 @@ final class NoneMemberChallengeViewModel: NoneMemberChallengeViewModelType, @unc
     input.requestVerifyInvitationCode
       .emit(with: self) { owner, code in
         Task { await owner.verifyInvitationCode(code) }
+      }
+      .disposed(by: disposeBag)
+    
+    input.didTapConfirmButtonAtChallengeNotFound
+      .emit(with: self) { owner, _ in
+        owner.coordinator?.requestDetach()
       }
       .disposed(by: disposeBag)
     

--- a/Projects/Presentation/Challenge/Implementations/NoneMember/NoneMemberChallengeViewModel.swift
+++ b/Projects/Presentation/Challenge/Implementations/NoneMember/NoneMemberChallengeViewModel.swift
@@ -141,6 +141,13 @@ final class NoneMemberChallengeViewModel: NoneMemberChallengeViewModelType, @unc
   }
 }
 
+// MARK: - Internal Methods
+extension NoneMemberChallengeViewModel {
+  @MainActor func isJoinedChallenge() async -> Bool {
+    return await useCase.isJoinedChallenge(id: challengeId)
+  }
+}
+
 // MARK: - Private Methods
 private extension NoneMemberChallengeViewModel {
   @MainActor func attemptToJoinChallenge() async {

--- a/Projects/Presentation/Challenge/Interfaces/NoneMemberChallenge.swift
+++ b/Projects/Presentation/Challenge/Interfaces/NoneMemberChallenge.swift
@@ -14,6 +14,7 @@ public protocol NoneMemberChallengeContainable: Containable {
 
 public protocol NoneMemberChallengeListener: AnyObject {
   func didTapBackButtonAtNoneMemberChallenge()
+  func alreadyJoinedChallenge(id: Int)
   func didJoinChallenge(id: Int)
   func authenticatedFailedAtNoneMemberChallenge()
   func shouldDismissNoneMemberChallenge()

--- a/Projects/Presentation/Challenge/Interfaces/NoneMemberChallenge.swift
+++ b/Projects/Presentation/Challenge/Interfaces/NoneMemberChallenge.swift
@@ -16,4 +16,5 @@ public protocol NoneMemberChallengeListener: AnyObject {
   func didTapBackButtonAtNoneMemberChallenge()
   func didJoinChallenge(id: Int)
   func authenticatedFailedAtNoneMemberChallenge()
+  func shouldDismissNoneMemberChallenge()
 }

--- a/Projects/Presentation/Home/Implementations/NoneChallengeHome/NoneChallengeHomeCoordinator.swift
+++ b/Projects/Presentation/Home/Implementations/NoneChallengeHome/NoneChallengeHomeCoordinator.swift
@@ -75,4 +75,8 @@ extension NoneChallengeHomeCoordinator: NoneMemberChallengeListener {
   func authenticatedFailedAtNoneMemberChallenge() {
     listener?.authenticatedFailedAtNoneChallengeHome()
   }
+  
+  func shouldDismissNoneMemberChallenge() {
+    detachNoneMemberChallenge()
+  }
 }

--- a/Projects/Presentation/Home/Implementations/NoneChallengeHome/NoneChallengeHomeCoordinator.swift
+++ b/Projects/Presentation/Home/Implementations/NoneChallengeHome/NoneChallengeHomeCoordinator.swift
@@ -68,6 +68,10 @@ extension NoneChallengeHomeCoordinator: NoneMemberChallengeListener {
     detachNoneMemberChallenge()
   }
   
+  func alreadyJoinedChallenge(id: Int) {
+    listener?.requstConvertInitialHome()
+  }
+  
   func didJoinChallenge(id: Int) {
     listener?.requstConvertInitialHome()
   }

--- a/Projects/Presentation/SearchChallenge/Implementations/SearchChallengeCoordinator.swift
+++ b/Projects/Presentation/SearchChallenge/Implementations/SearchChallengeCoordinator.swift
@@ -248,6 +248,17 @@ extension SearchChallengeCoordinator: NoneMemberChallengeListener {
     attachChallenge(id: id)
   }
   
+  func alreadyJoinedChallenge(id: Int) {
+    detachNonememberChallenge(willRemoveView: false)
+    guard
+       let navigationController = viewControllerable.uiviewController.navigationController,
+       let baseVC = navigationController.viewControllers.first as? ViewControllerable
+     else { return }
+    
+    viewControllerable.setViewControllers([baseVC], animated: false)
+    attachChallenge(id: id)
+  }
+  
   func authenticatedFailedAtNoneMemberChallenge() {
     listener?.authenticatedFailedAtSearchChallenge()
   }

--- a/Projects/Presentation/SearchChallenge/Implementations/SearchChallengeCoordinator.swift
+++ b/Projects/Presentation/SearchChallenge/Implementations/SearchChallengeCoordinator.swift
@@ -156,11 +156,14 @@ extension SearchChallengeCoordinator {
     self.noneMemberchallengeCoordinator = coordinater
   }
   
-  func detachNonememberChallenge(animted: Bool) {
+  func detachNonememberChallenge(willRemoveView: Bool) {
     guard let coordinater = noneMemberchallengeCoordinator else { return }
-    viewControllerable.popViewController(animated: animted)
     
-    if animted { viewControllerable.uiviewController.showTabBar(animted: true) }
+    if willRemoveView {
+      viewControllerable.popViewController(animated: true)
+      viewControllerable.uiviewController.showTabBar(animted: true)
+    }
+
     removeChild(coordinater)
     self.noneMemberchallengeCoordinator = nil
   }
@@ -227,11 +230,17 @@ extension SearchChallengeCoordinator: ChallengeListener {
 // MARK: - NoneMemberChallengeListener
 extension SearchChallengeCoordinator: NoneMemberChallengeListener {
   func didTapBackButtonAtNoneMemberChallenge() {
-    detachNonememberChallenge(animted: true)
+    detachNonememberChallenge(willRemoveView: true)
   }
   
   func didJoinChallenge(id: Int) {
-    detachNonememberChallenge(animted: false)
+    detachNonememberChallenge(willRemoveView: false)
+    guard
+       let navigationController = viewControllerable.uiviewController.navigationController,
+       let baseVC = navigationController.viewControllers.first as? ViewControllerable // A
+     else { return }
+    
+    viewControllerable.setViewControllers([baseVC], animated: false)
     attachChallenge(id: id)
   }
   

--- a/Projects/Presentation/SearchChallenge/Implementations/SearchChallengeCoordinator.swift
+++ b/Projects/Presentation/SearchChallenge/Implementations/SearchChallengeCoordinator.swift
@@ -233,6 +233,10 @@ extension SearchChallengeCoordinator: NoneMemberChallengeListener {
     detachNonememberChallenge(willRemoveView: true)
   }
   
+  func shouldDismissNoneMemberChallenge() {
+    detachNonememberChallenge(willRemoveView: true)
+  }
+  
   func didJoinChallenge(id: Int) {
     detachNonememberChallenge(willRemoveView: false)
     guard

--- a/Projects/Presentation/SearchChallenge/Implementations/SearchChallengeCoordinator.swift
+++ b/Projects/Presentation/SearchChallenge/Implementations/SearchChallengeCoordinator.swift
@@ -237,7 +237,7 @@ extension SearchChallengeCoordinator: NoneMemberChallengeListener {
     detachNonememberChallenge(willRemoveView: false)
     guard
        let navigationController = viewControllerable.uiviewController.navigationController,
-       let baseVC = navigationController.viewControllers.first as? ViewControllerable // A
+       let baseVC = navigationController.viewControllers.first as? ViewControllerable
      else { return }
     
     viewControllerable.setViewControllers([baseVC], animated: false)

--- a/Projects/Presentation/SearchChallenge/Implementations/SearchResult/SearchResultCoordinator.swift
+++ b/Projects/Presentation/SearchChallenge/Implementations/SearchResult/SearchResultCoordinator.swift
@@ -109,9 +109,14 @@ extension SearchResultCoordinator {
     self.noneMemberchallengeCoordinator = coordinater
   }
   
-  func detachNonememberChallenge(animted: Bool) {
+  func detachNonememberChallenge(willRemoveView: Bool) {
     guard let coordinater = noneMemberchallengeCoordinator else { return }
-    viewControllerable.popViewController(animated: animted)
+    
+    if willRemoveView {
+      viewControllerable.popViewController(animated: true)
+      viewControllerable.uiviewController.showTabBar(animted: true)
+    }
+
     removeChild(coordinater)
     self.noneMemberchallengeCoordinator = nil
   }
@@ -160,11 +165,21 @@ extension SearchResultCoordinator: ChallengeListener {
 // MARK: - NoneMemberChallengeListener
 extension SearchResultCoordinator: NoneMemberChallengeListener {
   func didTapBackButtonAtNoneMemberChallenge() {
-    detachNonememberChallenge(animted: true)
+    detachNonememberChallenge(willRemoveView: true)
+  }
+  
+  func shouldDismissNoneMemberChallenge() {
+    detachNonememberChallenge(willRemoveView: true)
   }
   
   func didJoinChallenge(id: Int) {
-    detachNonememberChallenge(animted: false)
+    detachNonememberChallenge(willRemoveView: false)
+    guard
+       let navigationController = viewControllerable.uiviewController.navigationController,
+       let baseVC = navigationController.viewControllers.first as? ViewControllerable
+     else { return }
+    
+    viewControllerable.setViewControllers([baseVC], animated: false)
     attachChallenge(id: id)
   }
   


### PR DESCRIPTION
## 관련 이슈

- #253 

## 작업 설명
챌린지 참여 관련 API 서버 변경사항 적용완료했습니다. 

## 스크린샷
### 선택한 챌린지가 로그인 이후 이미 참여했던 챌린지인 경우 
![이미 참여한 챌린지 로그인 후](https://github.com/user-attachments/assets/723167b7-1620-4fbf-9ba8-397c64bbf38e)

### 챌린지 참여 후, 멤버 화면으로 전환되는 경우
![챌린지 참여](https://github.com/user-attachments/assets/dd841634-c9f7-478d-ad8a-930ac03c9a76)


### 참여한 챌린지와 참여하지 않는 챌린지를 구분하는 모습
![챌린지 참여 완료](https://github.com/user-attachments/assets/ca699166-6fcc-4cae-9694-3449f84af8ba)


