### PR TITLE
[FEAT]: 마이페이지 메인 화면 API 연결

### DIFF
--- a/Projects/App/Sources/AppContainer.swift
+++ b/Projects/App/Sources/AppContainer.swift
@@ -43,19 +43,23 @@ final class AppContainer:
   NoneMemberChallengeDependency,
   ChallengeOrganizeDependency {
   func coordinator() -> ViewableCoordinating {
-    let viewControllerable = AppViewController()
+    let viewModel = AppViewModel(useCase: AppUseCaseImpl(repository: authRepository))
+    let viewControllerable = AppViewController(viewModel: viewModel)
     
     let home = HomeContainer(dependency: self)
     let searchChallenge = SearchChallengeContainer(dependency: self)
     let myPage = MyPageContainer(dependency: self)
     
-    return AppCoordinator(
+    let coordinator = AppCoordinator(
       viewControllerable: viewControllerable,
       homeContainable: home,
       searchChallengeContainable: searchChallenge,
       myPageContainable: myPage,
       loginContainable: loginContainable
     )
+    viewModel.coordinator = coordinator
+
+    return coordinator
   }
   
   // MARK: - Containable

--- a/Projects/App/Sources/AppCoordinator.swift
+++ b/Projects/App/Sources/AppCoordinator.swift
@@ -16,8 +16,8 @@ import MyPage
   func attachNavigationControllers(_ viewControllerables: NavigationControllerable...)
   func changeNavigationControllerToHome()
   func presentWelcomeToastView(_ username: String)
-  func presentTokenExpiredAlertView()
-  func presentTabMyPageWithoutLogInAlertView()
+  func presentTokenExpiredAlertView(to navigationControllerable: NavigationControllerable)
+  func presentTabMyPageWithoutLogInAlertView(to navigationControllerable: NavigationControllerable)
 }
 
 final class AppCoordinator: ViewableCoordinator<AppPresentable> {
@@ -165,8 +165,12 @@ extension AppCoordinator: AppCoordinatable {
     Task {
       await reloadAllTab()
       await presenter.changeNavigationControllerToHome()
-      await presenter.presentTabMyPageWithoutLogInAlertView()
+      await presenter.presentTabMyPageWithoutLogInAlertView(to: homeNavigationControllerable)
     }
+  }
+  
+  func attachLogIn() {
+    Task { await attachLogIn(at: homeNavigationControllerable) }
   }
 }
 
@@ -179,7 +183,7 @@ extension AppCoordinator: HomeListener {
   func authenticatedFailedAtHome() {
     Task {
       await reloadAllTab()
-      await presenter.presentTokenExpiredAlertView()
+      await presenter.presentTokenExpiredAlertView(to: homeNavigationControllerable)
     }
   }
 }
@@ -190,7 +194,7 @@ extension AppCoordinator: SearchChallengeListener {
     Task {
       await reloadAllTab()
       await presenter.changeNavigationControllerToHome()
-      await presenter.presentTokenExpiredAlertView()
+      await presenter.presentTokenExpiredAlertView(to: homeNavigationControllerable)
     }
   }
 }
@@ -205,7 +209,7 @@ extension AppCoordinator: MyPageListener {
     Task {
       await reloadAllTab()
       await presenter.changeNavigationControllerToHome()
-      await presenter.presentTokenExpiredAlertView()
+      await presenter.presentTokenExpiredAlertView(to: homeNavigationControllerable)
     }
   }
 }
@@ -226,5 +230,3 @@ extension AppCoordinator: LogInListener {
     Task { await detachLogIn(willPopViewConroller: true) }
   }
 }
-
-// TODO: presentTokenExpiredAlertView At 띄우기

--- a/Projects/App/Sources/AppViewModel.swift
+++ b/Projects/App/Sources/AppViewModel.swift
@@ -12,6 +12,7 @@ import UseCase
 
 protocol AppCoordinatable: AnyObject {
   func shouldReloadAllPage()
+  func attachLogIn()
 }
 
 protocol AppViewModelType: AnyObject {
@@ -31,6 +32,7 @@ final class AppViewModel: AppViewModelType {
   // MARK: - Input
   struct Input {
     let didTapMyPageTabBarItem: Signal<Void>
+    let didTapLogInButton: Signal<Void>
   }
   
   // MARK: - Output
@@ -47,6 +49,12 @@ final class AppViewModel: AppViewModelType {
     input.didTapMyPageTabBarItem
       .emit(with: self) { owner, _ in
         owner.handleMyPageTabSelection()
+      }
+      .disposed(by: disposeBag)
+    
+    input.didTapLogInButton
+      .emit(with: self) { owner, _ in
+        owner.coordinator?.attachLogIn()
       }
       .disposed(by: disposeBag)
     

--- a/Projects/App/Sources/AppViewModel.swift
+++ b/Projects/App/Sources/AppViewModel.swift
@@ -1,0 +1,66 @@
+//
+//  AppViewModel.swift
+//  DTO
+//
+//  Created by jung on 6/1/25.
+//  Copyright © 2025 com.photi. All rights reserved.
+//
+
+import RxCocoa
+import RxSwift
+import UseCase
+
+protocol AppCoordinatable: AnyObject {
+  func shouldReloadAllPage()
+}
+
+protocol AppViewModelType: AnyObject {
+  associatedtype Input
+  associatedtype Output
+  
+  var coordinator: AppCoordinatable? { get set }
+}
+
+final class AppViewModel: AppViewModelType {
+  weak var coordinator: AppCoordinatable?
+  private let useCase: AppUseCase
+  private let disposeBag = DisposeBag()
+
+  private let allowMoveToMyPage = PublishRelay<Void>()
+  
+  // MARK: - Input
+  struct Input {
+    let didTapMyPageTabBarItem: Signal<Void>
+  }
+  
+  // MARK: - Output
+  struct Output {
+    let allowMoveToMyPage: Signal<Void>
+  }
+  
+  // MARK: - Initializers
+  init(useCase: AppUseCase) {
+    self.useCase = useCase
+  }
+  
+  func transform(input: Input) -> Output {
+    input.didTapMyPageTabBarItem
+      .emit(with: self) { owner, _ in
+        owner.handleMyPageTabSelection()
+      }
+      .disposed(by: disposeBag)
+    
+    return Output(allowMoveToMyPage: allowMoveToMyPage.asSignal())
+  }
+}
+
+// MARK: - Private Methods
+private extension AppViewModel {
+  func handleMyPageTabSelection() {
+    Task {
+      let isLogin = await useCase.isLogIn()
+
+      isLogin ? allowMoveToMyPage.accept(()) : coordinator?.shouldReloadAllPage()
+    }
+  }
+}

--- a/Projects/Data/DTO/MyPage/UserChallengeHistoryResponseDTO.swift
+++ b/Projects/Data/DTO/MyPage/UserChallengeHistoryResponseDTO.swift
@@ -9,20 +9,14 @@
 import Foundation
 
 public struct UserChallengeHistoryResponseDTO: Decodable {
-  public let userName: String
-  public let imageUrl: URL?
+  public let username: String
+  public let imageUrl: String?
   public let feedCnt: Int
   public let endedChallengeCnt: Int
-  
-  public init(userName: String, imageUrl: URL?, feedCnt: Int, endedChallengeCnt: Int) {
-    self.userName = userName
-    self.imageUrl = imageUrl
-    self.feedCnt = feedCnt
-    self.endedChallengeCnt = endedChallengeCnt
-  }
+  public let registerDate: String
 }
 
-public extension UserChallengeHistoryResponseDTO  {
+public extension UserChallengeHistoryResponseDTO {
   static let stubData = """
 {
   "code": "200 OK",
@@ -31,7 +25,8 @@ public extension UserChallengeHistoryResponseDTO  {
     "username": "photi",
     "imageUrl": "https://url.kr/5MhHhD",
     "feedCnt": 99,
-    "endedChallengeCnt": 2
+    "endedChallengeCnt": 2,
+    "registerDate": "2025-06-01"
   }
 }
 """

--- a/Projects/Data/DTO/MyPage/VerifiedChallengeDatesResponseDTO.swift
+++ b/Projects/Data/DTO/MyPage/VerifiedChallengeDatesResponseDTO.swift
@@ -1,0 +1,25 @@
+//
+//  VerifiedChallengeDates.swift
+//  DTO
+//
+//  Created by jung on 6/1/25.
+//  Copyright © 2025 com.photi. All rights reserved.
+//
+
+public struct VerifiedChallengeDatesResponseDTO: Decodable {
+  public let list: [String]
+}
+
+public extension VerifiedChallengeDatesResponseDTO {
+  static let stubData = """
+{
+  "code": "200 OK",
+  "message": "성공",
+  "data": {
+    "list": [
+      "string"
+    ]
+  }
+}  
+"""
+}

--- a/Projects/Data/DataMapper/MyPageDataMapper.swift
+++ b/Projects/Data/DataMapper/MyPageDataMapper.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import Core
 import DTO
 import Entity
 
@@ -22,7 +23,8 @@ public struct MyPageDataMapperImpl: MyPageDataMapper {
       userName: dto.username,
       imageUrl: imageURL(from: dto.imageUrl),
       feedCnt: dto.feedCnt,
-      endedChallengeCnt: dto.endedChallengeCnt
+      endedChallengeCnt: dto.endedChallengeCnt,
+      registerDate: dto.registerDate.toDate("yyyy-MM-dd") ?? Date()
     )
   }
 // MARK: - Private Methods

--- a/Projects/Data/DataMapper/MyPageDataMapper.swift
+++ b/Projects/Data/DataMapper/MyPageDataMapper.swift
@@ -6,22 +6,29 @@
 //  Copyright © 2024 com.photi. All rights reserved.
 //
 
+import Foundation
 import DTO
 import Entity
 
 public protocol MyPageDataMapper {
-  func mapToUserChallengeHistory(responseDTO: UserChallengeHistoryResponseDTO) -> UserChallengeHistory
+  func mapToMyPageSummary(from dto: UserChallengeHistoryResponseDTO) -> MyPageSummary
 }
 
 public struct MyPageDataMapperImpl: MyPageDataMapper {
-  public init() {}
+  public init() { }
   
-  public func mapToUserChallengeHistory(responseDTO: UserChallengeHistoryResponseDTO) -> UserChallengeHistory {
-    return UserChallengeHistory(
-      userName: responseDTO.userName,
-      imageUrl: responseDTO.imageUrl,
-      feedCnt: responseDTO.feedCnt,
-      endedChallengeCnt: responseDTO.endedChallengeCnt
+  public func mapToMyPageSummary(from dto: UserChallengeHistoryResponseDTO) -> MyPageSummary {
+    return MyPageSummary(
+      userName: dto.username,
+      imageUrl: imageURL(from: dto.imageUrl),
+      feedCnt: dto.feedCnt,
+      endedChallengeCnt: dto.endedChallengeCnt
     )
+  }
+// MARK: - Private Methods
+private extension MyPageDataMapperImpl {
+  func imageURL(from strURL: String?) -> URL? {
+    guard let strURL else { return nil }
+    return URL(string: strURL)
   }
 }

--- a/Projects/Data/DataMapper/MyPageDataMapper.swift
+++ b/Projects/Data/DataMapper/MyPageDataMapper.swift
@@ -13,6 +13,7 @@ import Entity
 
 public protocol MyPageDataMapper {
   func mapToMyPageSummary(from dto: UserChallengeHistoryResponseDTO) -> MyPageSummary
+  func mapToDate(from dto: VerifiedChallengeDatesResponseDTO) -> [Date]
 }
 
 public struct MyPageDataMapperImpl: MyPageDataMapper {
@@ -27,6 +28,12 @@ public struct MyPageDataMapperImpl: MyPageDataMapper {
       registerDate: dto.registerDate.toDate("yyyy-MM-dd") ?? Date()
     )
   }
+  
+  public func mapToDate(from dto: VerifiedChallengeDatesResponseDTO) -> [Date] {
+    return dto.list.compactMap { $0.toDate("yyyy-MM-dd") }
+  }
+}
+
 // MARK: - Private Methods
 private extension MyPageDataMapperImpl {
   func imageURL(from strURL: String?) -> URL? {

--- a/Projects/Data/Repository/Implementations/ChangePasswordRepositoryImpl/ChangePasswordRepositoryImpl.swift
+++ b/Projects/Data/Repository/Implementations/ChangePasswordRepositoryImpl/ChangePasswordRepositoryImpl.swift
@@ -38,11 +38,9 @@ public struct ChangePasswordRepositoryImpl: ChangePasswordRepository {
           if result.statusCode == 200 {
             single(.success(()))
           } else if result.statusCode == 400 {
-            single(.failure(APIError.passwordMatchInvalid))
-          } else if result.statusCode == 401 {
-            single(.failure(APIError.loginUnauthenticated))
-          } else if result.statusCode == 403 {
-            single(.failure(APIError.tokenUnauthorized))
+            single(.failure(APIError.myPageFailed(reason: .passwordMatchInvalid)))
+          } else if result.statusCode == 401 || result.statusCode == 403 {
+            single(.failure(APIError.authenticationFailed))
           }
         } catch {
           single(.failure(error))

--- a/Projects/Data/Repository/Implementations/InquiryRepositoryImpl/InquiryRepositoryImpl.swift
+++ b/Projects/Data/Repository/Implementations/InquiryRepositoryImpl/InquiryRepositoryImpl.swift
@@ -33,10 +33,8 @@ public struct InquiryRepositoryImpl: InquiryRepository {
           
           if result.statusCode == 201 {
             single(.success(()))
-          } else if result.statusCode == 401 {
-            single(.failure(APIError.tokenUnauthenticated))
-          } else if result.statusCode == 403 {
-            single(.failure(APIError.tokenUnauthorized))
+          } else if result.statusCode == 401 || result.statusCode == 403 {
+            single(.failure(APIError.authenticationFailed))
           } else if result.statusCode == 404 {
             single(.failure(APIError.userNotFound))
           }

--- a/Projects/Data/Repository/Implementations/MyPageRepositoryImpl/MyPageAPI.swift
+++ b/Projects/Data/Repository/Implementations/MyPageRepositoryImpl/MyPageAPI.swift
@@ -17,8 +17,7 @@ public enum MyPageAPI {
 
 extension MyPageAPI: TargetType {
   public var baseURL: URL {
-    return URL(string: "http://localhost:8080")!
-    //    return URL(string: ServiceConfiguration.baseUrl)!
+    return ServiceConfiguration.shared.baseUrl
   }
   
   public var path: String {
@@ -28,7 +27,7 @@ extension MyPageAPI: TargetType {
     }
   }
   
-  public var method: PhotiNetwork.HTTPMethod {
+  public var method: HTTPMethod {
     switch self {
     case .userChallegeHistory:
       return .get

--- a/Projects/Data/Repository/Implementations/MyPageRepositoryImpl/MyPageAPI.swift
+++ b/Projects/Data/Repository/Implementations/MyPageRepositoryImpl/MyPageAPI.swift
@@ -13,6 +13,7 @@ import PhotiNetwork
 
 public enum MyPageAPI {
   case userChallegeHistory
+  case verifiedChallengeDates
 }
 
 extension MyPageAPI: TargetType {
@@ -22,32 +23,40 @@ extension MyPageAPI: TargetType {
   
   public var path: String {
     switch self {
-    case .userChallegeHistory:
-      return "api/users/challenge-history"
+      case .userChallegeHistory:
+        return "api/users/challenge-history"
+      case .verifiedChallengeDates:
+        return "api/users/feeds"
     }
   }
   
   public var method: HTTPMethod {
     switch self {
-    case .userChallegeHistory:
-      return .get
+      case .userChallegeHistory, .verifiedChallengeDates:
+        return .get
     }
   }
   
   public var task: PhotiNetwork.TaskType {
     switch self {
-    case .userChallegeHistory:
-      return .requestPlain
+      case .userChallegeHistory, .verifiedChallengeDates:
+        return .requestPlain
     }
   }
   
   public var sampleResponse: EndpointSampleResponse {
     switch self {
-    case .userChallegeHistory:
-      let data = UserChallengeHistoryResponseDTO.stubData
-      let jsonData = data.data(using: .utf8)
-      
-      return .networkResponse(200, jsonData ?? Data(), "OK", "성공")
+      case .userChallegeHistory:
+        let data = UserChallengeHistoryResponseDTO.stubData
+        let jsonData = data.data(using: .utf8)
+        
+        return .networkResponse(200, jsonData ?? Data(), "OK", "성공")
+        
+      case .verifiedChallengeDates:
+        let data = VerifiedChallengeDatesResponseDTO.stubData
+        let jsonData = data.data(using: .utf8)
+        
+        return .networkResponse(200, jsonData ?? Data(), "OK", "성공")
     }
   }
 }

--- a/Projects/Data/Repository/Implementations/MyPageRepositoryImpl/MyPageRepositoyImpl.swift
+++ b/Projects/Data/Repository/Implementations/MyPageRepositoryImpl/MyPageRepositoyImpl.swift
@@ -31,6 +31,16 @@ public extension MyPageRepositoyImpl {
     )
     .map { dataMapper.mapToMyPageSummary(from: $0) }
   }
+  
+  func fetchVerifiedChallengeDates() -> Single<[Date]> {
+    return requestAuthorizableAPI(
+      api: MyPageAPI.verifiedChallengeDates,
+      responseType: VerifiedChallengeDatesResponseDTO.self
+    )
+    .map { dataMapper.mapToDate(from: $0) }
+  }
+}
+
 // MARK: - Private Methods
 private extension MyPageRepositoyImpl {
   func requestAuthorizableAPI<T: Decodable>(

--- a/Projects/Data/Repository/Implementations/MyPageRepositoryImpl/MyPageRepositoyImpl.swift
+++ b/Projects/Data/Repository/Implementations/MyPageRepositoryImpl/MyPageRepositoyImpl.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2024 com.photi. All rights reserved.
 //
 
+import Foundation
 import RxSwift
 import DataMapper
 import DTO
@@ -19,35 +20,59 @@ public struct MyPageRepositoyImpl: MyPageRepository {
   public init(dataMapper: MyPageDataMapper) {
     self.dataMapper = dataMapper
   }
-  
-  public func userChallengeHistory() -> Single<UserChallengeHistory> {
+}
+
+// MARK: - Fetch Methods
+public extension MyPageRepositoyImpl {
+  func fetchMyPageSummary() -> Single<MyPageSummary> {
+    return requestAuthorizableAPI(
+      api: MyPageAPI.userChallegeHistory,
+      responseType: UserChallengeHistoryResponseDTO.self
+    )
+    .map { dataMapper.mapToMyPageSummary(from: $0) }
+  }
+// MARK: - Private Methods
+private extension MyPageRepositoyImpl {
+  func requestAuthorizableAPI<T: Decodable>(
+    api: MyPageAPI,
+    responseType: T.Type,
+    behavior: StubBehavior = .never
+  ) -> Single<T> {
     return Single.create { single in
       Task {
         do {
-          let result = try await Provider(
-            stubBehavior: .immediate,
-            session:.init(interceptor: AuthenticationInterceptor())
-          ).request(
-              MyPageAPI.userChallegeHistory,
-              type: UserChallengeHistoryResponseDTO.self
-            ).value
+          let provider = Provider<MyPageAPI>(
+            stubBehavior: behavior,
+            session: .init(interceptor: AuthenticationInterceptor())
+          )
           
-          if result.statusCode == 200, let responseDTO = result.data {
-            single(.success(dataMapper.mapToUserChallengeHistory(responseDTO: responseDTO)))
-          } else if result.statusCode == 401 {
-            single(.failure(APIError.tokenUnauthenticated))
-          } else if result.statusCode == 403 {
-            single(.failure(APIError.tokenUnauthorized))
+          let result = try await provider.request(api, type: responseType.self).value
+          if (200..<300).contains(result.statusCode), let data = result.data {
+            single(.success(data))
+          } else if result.statusCode == 401 || result.statusCode == 403 {
+            single(.failure(APIError.authenticationFailed))
           } else if result.statusCode == 404 {
-            single(.failure(APIError.userNotFound))
+            single(.failure(map404ToAPIError(result.code, result.message)))
           } else {
             single(.failure(APIError.serverError))
           }
         } catch {
-          single(.failure(APIError.serverError))
+          if case NetworkError.networkFailed(reason: .interceptorMapping) = error {
+            single(.failure(APIError.authenticationFailed))
+          } else {
+            single(.failure(error))
+          }
         }
       }
       return Disposables.create()
+    }
+  }
+  
+  func map404ToAPIError(_ code: String, _ message: String) -> APIError {
+    if code == "USER_NOT_FOUND" {
+      return APIError.challengeFailed(reason: .userNotFound)
+    } else {
+      return APIError.clientError(code: code, message: message)
     }
   }
 }

--- a/Projects/Data/Repository/Implementations/ProfileEditRepositoryImpl/ProfileEditRepositoryImpl.swift
+++ b/Projects/Data/Repository/Implementations/ProfileEditRepositoryImpl/ProfileEditRepositoryImpl.swift
@@ -32,10 +32,8 @@ public struct ProfileEditRepositoryImpl: ProfileEditRepository {
           
           if result.statusCode == 200, let responseDTO = result.data {
             single(.success(dataMapper.mapToProfileEditInfo(responseDTO: responseDTO)))
-          } else if result.statusCode == 401 {
-            single(.failure(APIError.tokenUnauthenticated))
-          } else if result.statusCode == 403 {
-            single(.failure(APIError.tokenUnauthorized))
+          } else if result.statusCode == 401 || result.statusCode == 403 {
+            single(.failure(APIError.authenticationFailed))
           } else if result.statusCode == 404 {
             single(.failure(APIError.userNotFound))
           } else {

--- a/Projects/Data/Repository/Implementations/ReportRepositoryImpl/ReportRepositoryImpl.swift
+++ b/Projects/Data/Repository/Implementations/ReportRepositoryImpl/ReportRepositoryImpl.swift
@@ -39,10 +39,8 @@ public struct ReportRepositoryImpl: ReportRepository {
           
           if result.statusCode == 201 {
             single(.success(()))
-          } else if result.statusCode == 401 {
-            single(.failure(APIError.tokenUnauthenticated))
-          } else if result.statusCode == 403 {
-            single(.failure(APIError.tokenUnauthorized))
+          } else if result.statusCode == 401 || result.statusCode == 403 {
+            single(.failure(APIError.authenticationFailed))
           } else if result.statusCode == 404 {
             single(.failure(APIError.userNotFound))
           }

--- a/Projects/Data/Repository/Implementations/ResignRepositoryImpl/ResignRepositoryImpl.swift
+++ b/Projects/Data/Repository/Implementations/ResignRepositoryImpl/ResignRepositoryImpl.swift
@@ -32,11 +32,9 @@ public struct ResignRepositoryImpl: ResignRepository {
           if result.statusCode == 200 {
             single(.success(()))
           } else if result.statusCode == 400 {
-            single(.failure(APIError.passwordMatchInvalid))
-          } else if result.statusCode == 401 {
-            single(.failure(APIError.loginUnauthenticated))
-          } else if result.statusCode == 403 {
-            single(.failure(APIError.tokenUnauthorized))
+            single(.failure(APIError.myPageFailed(reason: .passwordMatchInvalid)))
+          } else if result.statusCode == 401 || result.statusCode == 403 {
+            single(.failure(APIError.authenticationFailed))
           }
         } catch {
           single(.failure(error))

--- a/Projects/DesignSystem/Sources/CalendarView/CalendarView.swift
+++ b/Projects/DesignSystem/Sources/CalendarView/CalendarView.swift
@@ -90,9 +90,7 @@ public final class CalendarView: UIView {
   }
   
   private var dataSource = [[CalendarDate]]() {
-    didSet {
-      calendarCollectionView.reloadData()
-    }
+    didSet { calendarCollectionView.reloadData() }
   }
   
   private weak var selectedCell: CalendarCell?
@@ -186,15 +184,17 @@ private extension CalendarView {
       $0.top.leading.trailing.equalToSuperview()
       $0.height.equalTo(64)
     }
+
     weekView.snp.makeConstraints {
       $0.top.equalTo(headerView.snp.bottom)
       $0.leading.equalTo(calendarCollectionView).offset(itemHeight/2 - 7)
+      $0.height.equalTo(42)
     }
-    
+
     calendarCollectionView.snp.makeConstraints {
-      $0.centerX.equalToSuperview()
-      $0.size.equalTo(calendarSize)
       $0.top.equalTo(weekView.snp.bottom)
+      $0.size.bottom.equalTo(calendarSize)
+      $0.centerX.equalToSuperview()
     }
   }
 }

--- a/Projects/DesignSystem/Sources/Popup/Alert/AlertViewController.swift
+++ b/Projects/DesignSystem/Sources/Popup/Alert/AlertViewController.swift
@@ -52,7 +52,13 @@ final public class AlertViewController: UIViewController {
     return view
   }()
   
-  private let mainTitleLabel = UILabel()
+  private let mainTitleLabel: UILabel = {
+    let label = UILabel()
+    label.numberOfLines = 0
+    label.textAlignment = .center
+    return label
+  }()
+  
   private lazy var subTitleLabel: UILabel = {
     let label = UILabel()
     label.numberOfLines = 0

--- a/Projects/DesignSystem/Sources/Popup/Alert/AlertViewController.swift
+++ b/Projects/DesignSystem/Sources/Popup/Alert/AlertViewController.swift
@@ -13,6 +13,8 @@ import SnapKit
 import Core
 
 final public class AlertViewController: UIViewController {
+  public private(set) var isPresenting: Bool = false
+  
   // MARK: - AlertType
   /// Alert의 버튼 갯수를 정의합니다.
   public enum AlertType {
@@ -105,6 +107,17 @@ final public class AlertViewController: UIViewController {
   @available(*, unavailable)
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
+  }
+  
+  // MARK: - Life Cycles
+  public override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+    isPresenting = true
+  }
+  
+  public override func viewDidDisappear(_ animated: Bool) {
+    super.viewDidDisappear(animated)
+    isPresenting = false
   }
 }
 

--- a/Projects/Domain/Entity/APIError.swift
+++ b/Projects/Domain/Entity/APIError.swift
@@ -13,20 +13,16 @@ public enum APIError: Error {
   case loginFailed(reason: LogInFailedReason)
   case signUpFailed(reason: SignUpFailedReason)
   case challengeFailed(reason: ChallengeFailedReason)
+  case myPageFailed(reason: MyPageFailedReason)
   case organazieFailed(reason: OrganizedFailedReason)
-  case tokenUnauthenticated
-  /// 권한이 없는 요청입니다. 로그인 후에 다시 시도 해주세요.
-  case tokenUnauthorized
-  
+
   // MARK: - Profile Edit
   case userNotFound
   
   // MARK: - 비밀번호 변경
   
   /// 비밀번호와 비밀번호 재입력이 동일하지 않습니다.
-  case passwordMatchInvalid
-  /// 아이디 또는 비밀번호가 틀렸습니다.
-  case loginUnauthenticated
+  
 }
 
 extension APIError {
@@ -63,6 +59,14 @@ extension APIError {
     case fileTooLarge
     case challengeLimitExceed
     case invalidFileFormat
+  }
+}
+
+// MARK: - MyPage
+extension APIError {
+  public enum MyPageFailedReason {
+    case userNotFound
+    case passwordMatchInvalid
   }
 }
 

--- a/Projects/Domain/Entity/MyPageSummary.swift
+++ b/Projects/Domain/Entity/MyPageSummary.swift
@@ -1,5 +1,5 @@
 //
-//  UserChallengeHistory.swift
+//  MyPageSummary.swift
 //  Domain
 //
 //  Created by 임우섭 on 10/28/24.
@@ -8,11 +8,11 @@
 
 import Foundation
 
-public struct UserChallengeHistory {
+public struct MyPageSummary {
   public let userName: String
   public let imageUrl: URL?
-  public let feedCnt: Int
-  public let endedChallengeCnt: Int
+  public let feedCount: Int
+  public let endedChallengeCount: Int
   
   public init(
     userName: String,
@@ -22,7 +22,7 @@ public struct UserChallengeHistory {
   ) {
     self.userName = userName
     self.imageUrl = imageUrl
-    self.feedCnt = feedCnt
-    self.endedChallengeCnt = endedChallengeCnt
+    self.feedCount = feedCnt
+    self.endedChallengeCount = endedChallengeCnt
   }
 }

--- a/Projects/Domain/Entity/MyPageSummary.swift
+++ b/Projects/Domain/Entity/MyPageSummary.swift
@@ -13,16 +13,19 @@ public struct MyPageSummary {
   public let imageUrl: URL?
   public let feedCount: Int
   public let endedChallengeCount: Int
+  public let registerDate: Date
   
   public init(
     userName: String,
     imageUrl: URL?,
     feedCnt: Int,
-    endedChallengeCnt: Int
+    endedChallengeCnt: Int,
+    registerDate: Date
   ) {
     self.userName = userName
     self.imageUrl = imageUrl
     self.feedCount = feedCnt
     self.endedChallengeCount = endedChallengeCnt
+    self.registerDate = registerDate
   }
 }

--- a/Projects/Domain/Repository/Interfaces/MyPageRepository.swift
+++ b/Projects/Domain/Repository/Interfaces/MyPageRepository.swift
@@ -6,12 +6,11 @@
 //  Copyright © 2024 com.photi. All rights reserved.
 //
 
+import Foundation
 import RxSwift
-import DataMapper
 import Entity
 
 public protocol MyPageRepository {
-  init (dataMapper: MyPageDataMapper)
+  func fetchMyPageSummary() -> Single<MyPageSummary>
   
-  func userChallengeHistory() -> Single<UserChallengeHistory>
 }

--- a/Projects/Domain/Repository/Interfaces/MyPageRepository.swift
+++ b/Projects/Domain/Repository/Interfaces/MyPageRepository.swift
@@ -12,5 +12,5 @@ import Entity
 
 public protocol MyPageRepository {
   func fetchMyPageSummary() -> Single<MyPageSummary>
-  
+  func fetchVerifiedChallengeDates() -> Single<[Date]>
 }

--- a/Projects/Domain/UseCase/Implementations/AppUseCaseImpl.swift
+++ b/Projects/Domain/UseCase/Implementations/AppUseCaseImpl.swift
@@ -1,0 +1,22 @@
+//
+//  AppUseCaseImpl.swift
+//  UseCase
+//
+//  Created by jung on 6/1/25.
+//  Copyright © 2025 com.photi. All rights reserved.
+//
+
+import UseCase
+import Repository
+
+public final class AppUseCaseImpl: AppUseCase {
+  private let repository: AuthRepository
+  
+  public init(repository: AuthRepository) {
+    self.repository = repository
+  }
+  
+  public func isLogIn() async -> Bool {
+    return (try? await repository.isLogIn()) ?? false
+  }
+}

--- a/Projects/Domain/UseCase/Implementations/MyPageUseCaseImpl.swift
+++ b/Projects/Domain/UseCase/Implementations/MyPageUseCaseImpl.swift
@@ -6,19 +6,23 @@
 //  Copyright © 2024 com.photi. All rights reserved.
 //
 
+import Foundation
 import RxSwift
 import Entity
 import UseCase
 import Repository
 
-public struct MyPageUseCaseImpl: MyPageUseCase {
+public class MyPageUseCaseImpl: MyPageUseCase {
   private let repository: MyPageRepository
   
   public init(repository: MyPageRepository) {
     self.repository = repository
   }
   
-  public func userChallengeHistory() -> Single<UserChallengeHistory> {
-    return repository.userChallengeHistory()
+
+// MARK: - Fetch Methods
+public extension MyPageUseCaseImpl {
+  func loadMyPageSummry() -> Single<MyPageSummary> {
+    return repository.fetchMyPageSummary()
   }
 }

--- a/Projects/Domain/UseCase/Implementations/MyPageUseCaseImpl.swift
+++ b/Projects/Domain/UseCase/Implementations/MyPageUseCaseImpl.swift
@@ -18,11 +18,15 @@ public class MyPageUseCaseImpl: MyPageUseCase {
   public init(repository: MyPageRepository) {
     self.repository = repository
   }
-  
+}
 
 // MARK: - Fetch Methods
 public extension MyPageUseCaseImpl {
   func loadMyPageSummry() -> Single<MyPageSummary> {
     return repository.fetchMyPageSummary()
+  }
+  
+  func loadVerifiedChallengeDates() -> Single<[Date]> {
+    return repository.fetchVerifiedChallengeDates()
   }
 }

--- a/Projects/Domain/UseCase/Interfaces/AppUseCase.swift
+++ b/Projects/Domain/UseCase/Interfaces/AppUseCase.swift
@@ -1,0 +1,11 @@
+//
+//  AppUseCase.swift
+//  UseCase
+//
+//  Created by jung on 6/1/25.
+//  Copyright © 2025 com.photi. All rights reserved.
+//
+
+public protocol AppUseCase {
+  func isLogIn() async -> Bool
+}

--- a/Projects/Domain/UseCase/Interfaces/MyPageUseCase.swift
+++ b/Projects/Domain/UseCase/Interfaces/MyPageUseCase.swift
@@ -12,5 +12,5 @@ import Entity
 
 public protocol MyPageUseCase {
   func loadMyPageSummry() -> Single<MyPageSummary>
-  
+  func loadVerifiedChallengeDates() -> Single<[Date]>
 }

--- a/Projects/Domain/UseCase/Interfaces/MyPageUseCase.swift
+++ b/Projects/Domain/UseCase/Interfaces/MyPageUseCase.swift
@@ -6,12 +6,11 @@
 //  Copyright © 2024 com.photi. All rights reserved.
 //
 
+import Foundation
 import RxSwift
 import Entity
-import Repository
 
 public protocol MyPageUseCase {
-  init(repository: MyPageRepository)
+  func loadMyPageSummry() -> Single<MyPageSummary>
   
-  func userChallengeHistory() -> Single<UserChallengeHistory>
 }

--- a/Projects/Presentation/Home/Implementations/HomeCoordinator.swift
+++ b/Projects/Presentation/Home/Implementations/HomeCoordinator.swift
@@ -45,19 +45,19 @@ final class HomeCoordinator: Coordinator {
   override func start() {
     Task {
       await detachAll()
-      await attachInitialScreenIfNeeded()
+      await attachInitialScreenIfNeeded(animated: false)
     }
   }
 }
 
 // MARK: - ChallengeHome
 private extension HomeCoordinator {
-  @MainActor func attachChallengeHome() {
+  @MainActor func attachChallengeHome(animated: Bool = true) {
     guard challengeHomeCoordinator == nil else { return }
     
     let coordinator = challengeHomeContainer.coordinator(listener: self)
     addChild(coordinator)
-    navigationControllerable.setViewControllers([coordinator.viewControllerable])
+    navigationControllerable.setViewControllers([coordinator.viewControllerable], animated: animated)
     
     self.noneChallengeHomeCoordinator = coordinator
   }
@@ -72,12 +72,12 @@ private extension HomeCoordinator {
 
 // MARK: - NoneChallengeHome
 private extension HomeCoordinator {
-  @MainActor func attachNoneChallengeHome() {
+  @MainActor func attachNoneChallengeHome(animated: Bool = true) {
     guard noneChallengeHomeCoordinator == nil else { return }
     
     let coordinator = noneChallengeHomeContainer.coordinator(listener: self)
     addChild(coordinator)
-    navigationControllerable.setViewControllers([coordinator.viewControllerable])
+    navigationControllerable.setViewControllers([coordinator.viewControllerable], animated: animated)
     
     self.noneChallengeHomeCoordinator = coordinator
   }
@@ -92,12 +92,12 @@ private extension HomeCoordinator {
 
 // MARK: - NoneMemberHome
 private extension HomeCoordinator {
-  @MainActor func attachNoneMemberHome() {
+  @MainActor func attachNoneMemberHome(animated: Bool = true) {
     guard noneMemberHomeCoordinator == nil else { return }
     let coordinator = noneMemberHomeContainer.coordinator(listener: self)
     addChild(coordinator)
     
-    navigationControllerable.setViewControllers([coordinator.viewControllerable])
+    navigationControllerable.setViewControllers([coordinator.viewControllerable], animated: animated)
     self.noneMemberHomeCoordinator = coordinator
   }
   
@@ -147,14 +147,14 @@ extension HomeCoordinator: NoneChallengeHomeListener {
 
 // MARK: - Private Methods
 private extension HomeCoordinator {
-  func attachInitialScreenIfNeeded() async {
+  func attachInitialScreenIfNeeded(animated: Bool = true) async {
     do {
       let count = try await useCase.challengeCount()
       
-      count == 0 ? await attachNoneChallengeHome() : await attachChallengeHome()
+      count == 0 ? await attachNoneChallengeHome(animated: animated) : await attachChallengeHome(animated: animated)
     } catch {
       if let error = error as? APIError, case .authenticationFailed = error {
-        await attachNoneMemberHome()
+        await attachNoneMemberHome(animated: animated)
       } else {
         await presentNetworkUnstableAlert()
       }

--- a/Projects/Presentation/MyPage/Implementations/ChangePassword/ChangePasswordViewModel.swift
+++ b/Projects/Presentation/MyPage/Implementations/ChangePassword/ChangePasswordViewModel.swift
@@ -163,9 +163,9 @@ private extension ChangePasswordViewModel {
   func requestFailed(with error: Error) {
     if let error = error as? APIError {
       switch error {
-        case .tokenUnauthorized:
+        case .authenticationFailed:
           tokenUnauthorizedRelay.accept(())
-        case .loginUnauthenticated:
+        case let .myPageFailed(reason) where reason == .passwordMatchInvalid:
           unMatchedCurrentPasswordRelay.accept(())
         default:
           break

--- a/Projects/Presentation/MyPage/Implementations/MyPageContainer.swift
+++ b/Projects/Presentation/MyPage/Implementations/MyPageContainer.swift
@@ -43,14 +43,14 @@ public final class MyPageContainer:
     
     let settingContainable = SettingContainer(dependency: self)
     let endedChallengeContainable = EndedChallengeContainer(dependency: self)
-    let FeedHistoryContainable = FeedHistoryContainer(dependency: self)
+    let feedHistoryContainable = FeedHistoryContainer(dependency: self)
     
     let coordinator = MyPageCoordinator(
       viewControllerable: viewControllerable,
       viewModel: viewModel,
       settingContainable: settingContainable,
       endedChallengeContainable: endedChallengeContainable,
-      FeedHistoryContainable: FeedHistoryContainable
+      feedHistoryContainable: feedHistoryContainable
     )
     
     coordinator.listener = listener

--- a/Projects/Presentation/MyPage/Implementations/MyPageCoordinator.swift
+++ b/Projects/Presentation/MyPage/Implementations/MyPageCoordinator.swift
@@ -43,7 +43,8 @@ final class MyPageCoordinator: ViewableCoordinator<MyPagePresentable> {
   }
 }
 
-extension MyPageCoordinator: MyPageCoordinatable {
+// MARK: - Setting
+extension MyPageCoordinator {
   func attachSetting() {
     guard settingCoordinator == nil else { return }
     
@@ -61,7 +62,8 @@ extension MyPageCoordinator: MyPageCoordinatable {
     viewControllerable.popToRoot(animated: true)
     self.settingCoordinator = nil
   }
-  
+}
+
 // MARK: - FeedHistory
 extension MyPageCoordinator {
   func attachFeedHistory(count: Int) {
@@ -102,6 +104,12 @@ extension MyPageCoordinator {
     removeChild(coordinator)
     viewControllerable.popViewController(animated: true)
     self.endedChallengeCoordinator = nil
+  }
+}
+
+extension MyPageCoordinator: MyPageCoordinatable {
+  func authenticatedFailed() {
+    listener?.authenticatedFailedAtMyPage()
   }
 }
 

--- a/Projects/Presentation/MyPage/Implementations/MyPageCoordinator.swift
+++ b/Projects/Presentation/MyPage/Implementations/MyPageCoordinator.swift
@@ -22,21 +22,21 @@ final class MyPageCoordinator: ViewableCoordinator<MyPagePresentable> {
   private let endedChallengeContainable: EndedChallengeContainable
   private var endedChallengeCoordinator: ViewableCoordinating?
   
-  private let FeedHistoryContainable: FeedHistoryContainable
-  private var FeedHistoryCoordinator: ViewableCoordinating?
+  private let feedHistoryContainable: FeedHistoryContainable
+  private var feedHistoryCoordinator: ViewableCoordinating?
   
   init(
     viewControllerable: ViewControllerable,
     viewModel: MyPageViewModel,
     settingContainable: SettingContainable,
     endedChallengeContainable: EndedChallengeContainable,
-    FeedHistoryContainable: FeedHistoryContainable
+    feedHistoryContainable: FeedHistoryContainable
   ) {
     self.viewModel = viewModel
     
     self.settingContainable = settingContainable
     self.endedChallengeContainable = endedChallengeContainable
-    self.FeedHistoryContainable = FeedHistoryContainable
+    self.feedHistoryContainable = feedHistoryContainable
     
     super.init(viewControllerable)
     viewModel.coordinator = self
@@ -62,26 +62,31 @@ extension MyPageCoordinator: MyPageCoordinatable {
     self.settingCoordinator = nil
   }
   
+// MARK: - FeedHistory
+extension MyPageCoordinator {
   func attachFeedHistory(count: Int) {
-    guard FeedHistoryCoordinator == nil else { return }
+    guard feedHistoryCoordinator == nil else { return }
     
-    let coordinator = FeedHistoryContainable.coordinator(listener: self, feedCount: count)
+    let coordinator = feedHistoryContainable.coordinator(listener: self, feedCount: count)
     addChild(coordinator)
     
     viewControllerable.pushViewController(coordinator.viewControllerable, animated: true)
 
-    self.FeedHistoryCoordinator = coordinator
+    self.feedHistoryCoordinator = coordinator
   }
   
   func detachFeedHistory() {
-    guard let coordinator = FeedHistoryCoordinator else { return }
+    guard let coordinator = feedHistoryCoordinator else { return }
     
     removeChild(coordinator)
     
     viewControllerable.popViewController(animated: true)
-    self.FeedHistoryCoordinator = nil
+    self.feedHistoryCoordinator = nil
   }
-  
+}
+
+// MARK: - EndedChallenge
+extension MyPageCoordinator {
   func attachEndedChallenge() {
     guard endedChallengeCoordinator == nil else { return }
     

--- a/Projects/Presentation/MyPage/Implementations/MyPageViewController.swift
+++ b/Projects/Presentation/MyPage/Implementations/MyPageViewController.swift
@@ -18,92 +18,70 @@ final class MyPageViewController: UIViewController, ViewControllerable {
   private let viewModel: MyPageViewModel
   
   private let disposeBag = DisposeBag()
-  // MARK: - UIComponents
-  private let scrollView = {
+  
+  // MARK: - UI Components
+  private let scrollView: UIScrollView = {
     let scrollView = UIScrollView()
-    scrollView.translatesAutoresizingMaskIntoConstraints = false
     scrollView.showsVerticalScrollIndicator = false
     scrollView.bounces = false
+    scrollView.backgroundColor = .blue500
     
     return scrollView
   }()
   
-  private let containerView = {
+  private let containerView = UIView()
+
+  /// navigationBar
+  private let navigationBar: UIView = {
     let view = UIView()
-    view.backgroundColor = .clear
-    view.translatesAutoresizingMaskIntoConstraints = false
-    
-    return view
-  }()
-  // 사용자 정보 part
-  private let userInfoView = {
-    let view = UIView()
-    view.backgroundColor = .clear
-    
     return view
   }()
   
-  /// 하단 톱니모양뷰
-  private let userInfoBottomImageView = {
-    let pinkingView = UIImageView()
-    pinkingView.image = .pinkingBlueDown
+  private let settingButton: UIButton = {
+    let button = UIButton()
+    button.setImage(.settingsWhite, for: .normal)
+    return button
+  }()
+  
+  /// 상단 유저 정보
+  private let userInfoView = UIView()
+  private let profileImageView = AvatarImageView(size: .large)
+  private let userNameLabel = UILabel()
+  private let countBoxStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .horizontal
+    stackView.spacing = 7
+    stackView.alignment = .fill
+    stackView.distribution = .fillEqually
+    
+    return stackView
+  }()
+  private let feedsCountBox = ChallengeCountBox(title: "인증 횟수")
+  private let endedChallengeCountBox = ChallengeCountBox(title: "종료된 챌린지")
+
+  private let seperatorView: UIImageView = {
+    let pinkingView = UIImageView(image: .pinkingBlueDown)
     pinkingView.contentMode = .topLeft
     
     return pinkingView
   }()
   
-  private let userImageView = {
-    let imageView = UIImageView()
-    imageView.layer.cornerRadius = 48
-    imageView.backgroundColor = .gray400
-    imageView.clipsToBounds = true
-    imageView.image = .personLight
-    imageView.contentMode = .scaleAspectFill
-    
-    return imageView
-  }()
-  
-  private let settingButton = {
-    let button = UIButton()
-    button.setImage(.settingsWhite.resize(CGSize(width: 24, height: 24)), for: .normal)
-    return button
-  }()
-  
-  private let feedInfoView = {
+  /// 하단
+  private let feedsInfoView: UIView = {
     let view = UIView()
     view.backgroundColor = .white
     
     return view
   }()
-  
-  private let userNameLabel = {
-    let label = UILabel()
-    label.textColor = .white
-    label.textAlignment = .center
-    label.attributedText = "유저 아이디".attributedString(
-      font: .heading1,
-      color: .white,
-      alignment: .center
-    )
-    
-    return label
-  }()
-  
-  private let authCountBox = ChallengeCountBox(title: "인증 횟수", count: 0)
-  
-  private let endedChallengeCountBox = ChallengeCountBox(title: "종료된 챌린지", count: 0)
-  
-  // 피드
   private let myFeedLabel = {
     let label = UILabel()
-    label.textColor = .white
     label.attributedText = "내 피드".attributedString(font: .heading3, color: .gray900)
     
     return label
   }()
   
-  private let calendarView = {
-    let calendarView = CalendarView(selectionMode: .multiple, startDate: Date())
+  private let calendarView: CalendarView = {
+    let calendarView = CalendarView(selectionMode: .multiple, startDate: Date(), endDate: Date())
     calendarView.isCloseButtonHidden = true
     
     return calendarView
@@ -121,7 +99,7 @@ final class MyPageViewController: UIViewController, ViewControllerable {
     fatalError("init(coder:) has not been implemented")
   }
   
-  // MARK: - View LifeCycle
+  // MARK: - LifeCycles
   override func viewDidLoad() {
     super.viewDidLoad()
     calendarView.delegate = self
@@ -139,101 +117,96 @@ final class MyPageViewController: UIViewController, ViewControllerable {
 // MARK: - Private methods
 private extension MyPageViewController {
   func setupUI() {
-    self.view.backgroundColor = .blue500
+    view.backgroundColor = .white
     setViewHierarchy()
     setConstraints()
   }
   
   func setViewHierarchy() {
-    self.view.addSubview(scrollView)
+    view.addSubview(scrollView)
     scrollView.addSubview(containerView)
-    containerView.addSubviews(userInfoView, feedInfoView)
-    userInfoView.addSubviews(
-      userImageView,
-      settingButton,
-      userNameLabel,
-      authCountBox,
-      endedChallengeCountBox
-    )
-    feedInfoView.addSubviews(userInfoBottomImageView, myFeedLabel, calendarView)
+    containerView.addSubviews(navigationBar, userInfoView, feedsInfoView, seperatorView)
+    navigationBar.addSubview(settingButton)
+    userInfoView.addSubviews(profileImageView, userNameLabel, countBoxStackView)
+    countBoxStackView.addArrangedSubviews(feedsCountBox, endedChallengeCountBox)
+    feedsInfoView.addSubviews(myFeedLabel, calendarView)
   }
   
   func setConstraints() {
+    let tabBarMinY = tabBarController?.tabBar.frame.minY ?? 0
+    let tabBarHeight = view.frame.height - tabBarMinY
     scrollView.snp.makeConstraints {
-      $0.edges.equalToSuperview()
+      $0.leading.top.trailing.equalToSuperview()
+      $0.bottom.equalToSuperview().inset(tabBarHeight)
     }
     
     containerView.snp.makeConstraints {
       $0.edges.width.equalToSuperview()
     }
+
+    navigationBar.snp.makeConstraints {
+      $0.top.leading.trailing.equalToSuperview()
+      $0.height.equalTo(44)
+    }
     
     userInfoView.snp.makeConstraints {
-      $0.leading.top.trailing.equalToSuperview()
-      $0.height.equalTo(344)
+      $0.top.equalTo(navigationBar.snp.bottom)
+      $0.leading.trailing.equalToSuperview()
     }
-    
-    feedInfoView.snp.makeConstraints {
+
+    seperatorView.snp.makeConstraints {
       $0.top.equalTo(userInfoView.snp.bottom)
       $0.leading.trailing.equalToSuperview()
-      $0.bottom.equalToSuperview()
-      $0.height.equalTo(471)
-    }
-    setConstraintsOfUserInfoView()
-    setConstraintsOfFeedInfoView()
-  }
-  
-  func setConstraintsOfUserInfoView() {
-    userInfoBottomImageView.snp.makeConstraints {
-      $0.top.leading.trailing.equalToSuperview()
       $0.height.equalTo(12)
     }
     
+    feedsInfoView.snp.makeConstraints {
+      $0.top.equalTo(userInfoView.snp.bottom)
+      $0.leading.trailing.bottom.equalToSuperview()
+    }
+    
+    setNavigationBarConstraints()
+    setUserInfoViewConstraints()
+    setFeedsInforViewConstraints()
+  }
+  
+  func setNavigationBarConstraints() {
     settingButton.snp.makeConstraints {
-      $0.top.equalToSuperview().offset(12)
-      $0.trailing.equalToSuperview().offset(-19)
-      $0.width.height.equalTo(32)
-    }
-    
-    userImageView.snp.makeConstraints {
-      $0.top.equalTo(settingButton.snp.bottom).offset(16)
-      $0.centerX.equalToSuperview()
-      $0.width.height.equalTo(96)
-    }
-    
-    userNameLabel.snp.makeConstraints {
-      $0.top.equalTo(userImageView.snp.bottom).offset(16)
-      $0.leading.equalToSuperview().offset(24)
-      $0.trailing.equalToSuperview().offset(-24)
-      $0.height.equalTo(21)
-    }
-    
-    authCountBox.snp.makeConstraints {
-      $0.leading.equalToSuperview().offset(24)
-      $0.top.equalTo(userNameLabel.snp.bottom).offset(28)
-      $0.trailing.equalTo(userNameLabel.snp.centerX).offset(-3.5)
-      $0.bottom.equalToSuperview().offset(-31)
-    }
-    
-    endedChallengeCountBox.snp.makeConstraints {
-      $0.trailing.equalToSuperview().offset(-24)
-      $0.top.equalTo(authCountBox)
-      $0.leading.equalTo(userNameLabel.snp.centerX).offset(3.5)
-      $0.bottom.equalTo(authCountBox)
+      $0.width.height.equalTo(24)
+      $0.trailing.equalToSuperview().inset(19)
+      $0.centerY.equalToSuperview()
     }
   }
   
-  func setConstraintsOfFeedInfoView() {
+  func setUserInfoViewConstraints() {
+    profileImageView.snp.makeConstraints {
+      $0.top.equalTo(navigationBar.snp.bottom).offset(16)
+      $0.centerX.equalToSuperview()
+    }
+    
+    userNameLabel.snp.makeConstraints {
+      $0.top.equalTo(profileImageView.snp.bottom).offset(16)
+      $0.leading.trailing.equalToSuperview().inset(24)
+    }
+    
+    countBoxStackView.snp.makeConstraints {
+      $0.top.equalTo(userNameLabel.snp.bottom).offset(22)
+      $0.leading.trailing.equalToSuperview().inset(24)
+      $0.bottom.equalToSuperview().inset(30)
+      $0.height.equalTo(88)
+    }
+  }
+  
+  func setFeedsInforViewConstraints() {
     myFeedLabel.snp.makeConstraints {
+      $0.top.equalTo(seperatorView).offset(40)
       $0.leading.equalToSuperview().offset(24)
-      $0.trailing.equalToSuperview().offset(-24)
-      $0.top.equalTo(userInfoBottomImageView).offset(48)
-      $0.height.equalTo(21)
     }
     
     calendarView.snp.makeConstraints {
-      $0.top.equalTo(myFeedLabel.snp.bottom).offset(20)
+      $0.top.equalTo(myFeedLabel.snp.bottom).offset(22)
       $0.leading.trailing.equalToSuperview()
-      $0.bottom.equalToSuperview().offset(-40)
+      $0.bottom.equalToSuperview().inset(40)
     }
   }
 }
@@ -241,18 +214,11 @@ private extension MyPageViewController {
 // MARK: - Bind Methods
 private extension MyPageViewController {
   func bind() {
-    self.rx.isVisible
-      .bind(with: self) { owner, isVisible in
-        if isVisible {
-          owner.navigationController?.showTabBar(animted: true)
-        }
-      }.disposed(by: disposeBag)
-    
     let input = MyPageViewModel.Input(
       didTapSettingButton: settingButton.rx.tap,
-      didTapAuthCountBox: authCountBox.rx.didTapBox,
+      didTapAuthCountBox: feedsCountBox.rx.didTapBox,
       didTapEndedChallengeBox: endedChallengeCountBox.rx.didTapBox,
-      isVisible: self.rx.isVisible
+      didBecomeVisible: rx.isVisible.filter { $0 }.map { _ in () }.asSignal(onErrorJustReturn: ())
     )
     
     let output = viewModel.transform(input: input)
@@ -260,15 +226,23 @@ private extension MyPageViewController {
   }
   
   func bind(output: MyPageViewModel.Output) {
-    output.userChallengeHistory
-      .emit(with: self) { onwer, userChallengeHistory in
-        // TODO: -  캐싱 적용 후 수정     self?.profileImageView.load(url: userInfo.imageUrl)
-        if let url = userChallengeHistory.imageUrl {
-          onwer.userImageView.kf.setImage(with: url)
-        }
-        onwer.userNameLabel.text = userChallengeHistory.userName
-        onwer.authCountBox.count = userChallengeHistory.feedCnt
-        onwer.endedChallengeCountBox.count = userChallengeHistory.endedChallengeCnt
+    output.username
+      .map { $0.attributedString(font: .heading1, color: .white, alignment: .center) }
+      .drive(userNameLabel.rx.attributedText)
+      .disposed(by: disposeBag)
+    
+    output.feedsCount
+      .drive(feedsCountBox.rx.count)
+      .disposed(by: disposeBag)
+    
+    output.endedChallengeCount
+      .drive(endedChallengeCountBox.rx.count)
+      .disposed(by: disposeBag)
+    
+    output.profileImageURL
+      .filter { $0 != nil }
+      .drive(with: self) { owner, url in
+        owner.profileImageView.kf.setImage(with: url)
       }
       .disposed(by: disposeBag)
   }
@@ -277,9 +251,12 @@ private extension MyPageViewController {
 // MARK: - MyPagePresentable
 extension MyPageViewController: MyPagePresentable { }
 
-// MARK: - CalendarView Delegate
+// MARK: - CalendarViewDelegate
 extension MyPageViewController: CalendarViewDelegate {
   func didSelect(_ date: Date) { }
   
   func didTapCloseButton() { }
 }
+
+// MARK: - Private Methods
+private extension MyPageViewController { }

--- a/Projects/Presentation/MyPage/Implementations/MyPageViewController.swift
+++ b/Projects/Presentation/MyPage/Implementations/MyPageViewController.swift
@@ -81,7 +81,12 @@ final class MyPageViewController: UIViewController, ViewControllerable {
   }()
   
   private let calendarView: CalendarView = {
-    let calendarView = CalendarView(selectionMode: .multiple, startDate: Date(), endDate: Date())
+    let calendarView = CalendarView(
+      selectionMode: .multiple,
+      startDate: Date(),
+      currentDate: Date(),
+      endDate: Date()
+    )
     calendarView.isCloseButtonHidden = true
     
     return calendarView
@@ -244,6 +249,14 @@ private extension MyPageViewController {
       .drive(with: self) { owner, url in
         owner.profileImageView.kf.setImage(with: url)
       }
+      .disposed(by: disposeBag)
+    
+    output.calendarStartDate
+      .drive(calendarView.rx.startDate)
+      .disposed(by: disposeBag)
+    
+    output.verifiedChallengeDates
+      .drive(calendarView.rx.defaultSelectedDates)
       .disposed(by: disposeBag)
   }
 }

--- a/Projects/Presentation/MyPage/Implementations/Views/ChallengeCountBox.swift
+++ b/Projects/Presentation/MyPage/Implementations/Views/ChallengeCountBox.swift
@@ -29,7 +29,7 @@ final class ChallengeCountBox: UIView {
   private let countLabel = UILabel()
   
   // MARK: - Initializers
-  init(title: String = "", count: Int = 0) {
+  init(title: String, count: Int = 0) {
     self.title = title
     self.count = count
     super.init(frame: .zero)
@@ -66,7 +66,7 @@ private extension ChallengeCountBox {
     countLabel.snp.makeConstraints {
       $0.centerX.equalToSuperview()
       $0.top.equalTo(titleLabel.snp.bottom).offset(12)
-      $0.bottom.equalToSuperview().offset(-21)
+      $0.bottom.equalToSuperview().inset(21)
     }
   }
 }

--- a/Projects/Presentation/MyPage/Interfaces/MyPage.swift
+++ b/Projects/Presentation/MyPage/Interfaces/MyPage.swift
@@ -14,4 +14,5 @@ public protocol MyPageContainable: Containable {
 
 public protocol MyPageListener: AnyObject {
   func isUserResigned()
+  func authenticatedFailedAtMyPage()
 }


### PR DESCRIPTION
## 관련 이슈

- #260 
## 작업 설명
- 마이페이지 API 연결 
   - 유저 정보 및 인증한 챌린지 날짜 달력에 연동. 
- APIError 수정 (불필요한 버그 제거) 
- 네이밍 버그 수정 
- 토큰 만료시 로직 구현 
- 로그 아웃 상태에서 "마이페이지"누르는 경우 구현 

### 마이 페이지 
![마이페이지](https://github.com/user-attachments/assets/e3dbb187-710c-4dca-a602-2aa269a476df)

### 로그아웃 상태에서 마이 페이지 누르는 경우 
![로그아웃에서 마이페이지 터시](https://github.com/user-attachments/assets/024f0f9f-fcd6-4408-bb34-2cb70bd9b078)

### 토큰 만료시 
![토근 만료시](https://github.com/user-attachments/assets/4cb18f14-b667-49b6-859c-69b649d4c3ec)