### PR TITLE
[REFACT]: 기기 사이즈별 UI 대응

### DIFF
--- a/Projects/App/Sources/AppContainer.swift
+++ b/Projects/App/Sources/AppContainer.swift
@@ -133,7 +133,8 @@ final class AppContainer:
   lazy var searchUseCase: SearchUseCase = {
     return SearchUseCaseImpl(
       challengeRepository: challengeRepository,
-      searchHistoryRepository: searchHistoryRepository
+      searchHistoryRepository: searchHistoryRepository,
+      authRepository: authRepository
     )
   }()
   

--- a/Projects/App/Sources/AppCoordinator.swift
+++ b/Projects/App/Sources/AppCoordinator.swift
@@ -199,6 +199,14 @@ extension AppCoordinator: SearchChallengeListener {
       await presenter.presentTokenExpiredAlertView(to: homeNavigationControllerable)
     }
   }
+  
+  func attachLoginPopup() {
+    Task {
+      await reloadAllTab()
+      await presenter.changeNavigationControllerToHome()
+      await presenter.presentTabMyPageWithoutLogInAlertView(to: homeNavigationControllerable)
+    }
+  }
 }
 
 // MARK: - MyPageListener

--- a/Projects/Domain/UseCase/Implementations/SearchUseCaseImpl.swift
+++ b/Projects/Domain/UseCase/Implementations/SearchUseCaseImpl.swift
@@ -14,14 +14,21 @@ import Repository
 public final class SearchUseCaseImpl: SearchUseCase {
   private let challengeRepository: ChallengeRepository
   private let searchHistoryRepository: SearchHistoryRepository
+  private let authRepository: AuthRepository
   private let maximumChallengeCount = 20
   
   public init(
     challengeRepository: ChallengeRepository,
-    searchHistoryRepository: SearchHistoryRepository
+    searchHistoryRepository: SearchHistoryRepository,
+    authRepository: AuthRepository
   ) {
     self.challengeRepository = challengeRepository
     self.searchHistoryRepository = searchHistoryRepository
+    self.authRepository = authRepository
+  }
+  
+  public func isLogin() async -> Bool {
+    return (try? await authRepository.isLogIn()) ?? false
   }
 }
 

--- a/Projects/Domain/UseCase/Interfaces/SearchUseCase.swift
+++ b/Projects/Domain/UseCase/Interfaces/SearchUseCase.swift
@@ -26,4 +26,5 @@ public protocol SearchUseCase {
   @discardableResult func saveSearchKeyword(_ keyword: String) -> [String]
   @discardableResult func deleteSearchKeyword(_ keyword: String) -> [String]
   func clearSearchHistory()
+  func isLogin() async -> Bool
 }

--- a/Projects/Presentation/Challenge/Implementations/ChallengeOrganize/ChallengeCover/ChallengeCoverViewController.swift
+++ b/Projects/Presentation/Challenge/Implementations/ChallengeOrganize/ChallengeCover/ChallengeCoverViewController.swift
@@ -52,6 +52,7 @@ final class ChallengeCoverViewController: UIViewController, ViewControllerable, 
     imageView.image = .challengeOrganizeLuckyday
     imageView.layer.cornerRadius = 16
     imageView.layer.masksToBounds = true
+    imageView.contentMode = .scaleAspectFill
     return imageView
   }()
   
@@ -173,11 +174,10 @@ private extension ChallengeCoverViewController {
     }
     
     mainImageView.snp.makeConstraints {
-      $0.centerX.equalToSuperview()
       $0.height.lessThanOrEqualTo(UIScreen.main.bounds.width - 48)
       $0.top.equalTo(titleLabel.snp.bottom).offset(24)
       $0.bottom.lessThanOrEqualTo(imageCollectionView.snp.top).offset(-24)
-      $0.width.equalTo(mainImageView.snp.height)
+      $0.leading.trailing.equalToSuperview().inset(24)
     }
   }
 }

--- a/Projects/Presentation/Challenge/Implementations/ChallengeOrganize/ChallengeCover/ChallengeCoverViewController.swift
+++ b/Projects/Presentation/Challenge/Implementations/ChallengeOrganize/ChallengeCover/ChallengeCoverViewController.swift
@@ -127,9 +127,9 @@ private extension ChallengeCoverViewController {
       navigationBar,
       progressBar,
       titleLabel,
-      mainImageView,
+      nextButton,
       imageCollectionView,
-      nextButton
+      mainImageView
     )
   }
   
@@ -144,35 +144,40 @@ private extension ChallengeCoverViewController {
       titleLabel.snp.makeConstraints {
         $0.top.equalTo(navigationBar.snp.bottom).offset(36)
         $0.leading.equalToSuperview().offset(24)
+        $0.height.equalTo(20)
       }
     } else {
       progressBar.snp.makeConstraints {
         $0.top.equalTo(navigationBar.snp.bottom).offset(8)
         $0.leading.trailing.equalToSuperview().inset(24)
+        $0.height.equalTo(6)
       }
       
       titleLabel.snp.makeConstraints {
-        $0.top.equalTo(progressBar.snp.bottom).offset(48)
+        $0.top.equalTo(progressBar.snp.bottom).offset(36)
         $0.leading.equalToSuperview().offset(24)
+        $0.height.equalTo(20)
       }
-    }
-    
-    mainImageView.snp.makeConstraints {
-      $0.leading.equalToSuperview().offset(24)
-      $0.trailing.equalToSuperview().inset(24)
-      $0.top.equalTo(titleLabel.snp.bottom).offset(24)
-      $0.height.equalTo(UIScreen.main.bounds.width - 48)
-    }
-    
-    imageCollectionView.snp.makeConstraints {
-      $0.leading.trailing.equalToSuperview()
-      $0.top.equalTo(mainImageView.snp.bottom).offset(28)
-      $0.height.equalTo(96)
     }
     
     nextButton.snp.makeConstraints {
       $0.centerX.equalToSuperview()
-      $0.bottom.equalToSuperview().offset(-56)
+      $0.bottom.equalTo(view.safeAreaLayoutGuide).offset(-24)
+      $0.height.equalTo(56)
+    }
+    
+    imageCollectionView.snp.makeConstraints {
+      $0.leading.trailing.equalToSuperview()
+      $0.bottom.equalTo(nextButton.snp.top).offset(-24)
+      $0.height.equalTo(96)
+    }
+    
+    mainImageView.snp.makeConstraints {
+      $0.centerX.equalToSuperview()
+      $0.height.lessThanOrEqualTo(UIScreen.main.bounds.width - 48)
+      $0.top.equalTo(titleLabel.snp.bottom).offset(24)
+      $0.bottom.lessThanOrEqualTo(imageCollectionView.snp.top).offset(-24)
+      $0.width.equalTo(mainImageView.snp.height)
     }
   }
 }

--- a/Projects/Presentation/Challenge/Implementations/ChallengeOrganize/ChallengeGoal/ChallengeGoalViewController.swift
+++ b/Projects/Presentation/Challenge/Implementations/ChallengeOrganize/ChallengeGoal/ChallengeGoalViewController.swift
@@ -191,7 +191,7 @@ private extension ChallengeGoalViewController {
       }
       
       titleLabel.snp.makeConstraints {
-        $0.top.equalTo(progressBar.snp.bottom).offset(48)
+        $0.top.equalTo(progressBar.snp.bottom).offset(36)
         $0.leading.equalToSuperview().offset(24)
       }
     }
@@ -203,7 +203,7 @@ private extension ChallengeGoalViewController {
     }
     
     setProveTimeLabel.snp.makeConstraints {
-      $0.top.equalTo(challengeGoalTextView.snp.bottom).offset(51)
+      $0.top.equalTo(challengeGoalTextView.snp.bottom).offset(24)
       $0.leading.equalTo(challengeGoalTextView)
     }
     

--- a/Projects/Presentation/Challenge/Implementations/ChallengeOrganize/ChallengeRule/ChallengeRuleViewController.swift
+++ b/Projects/Presentation/Challenge/Implementations/ChallengeOrganize/ChallengeRule/ChallengeRuleViewController.swift
@@ -65,7 +65,8 @@ final class ChallengeRuleViewController: UIViewController, ViewControllerable {
     layout.scrollDirection = .vertical
     layout.minimumLineSpacing = 8
     layout.minimumInteritemSpacing = 8
-    layout.itemSize = .init(width: 160, height: 57)
+    let cellWidth = (UIScreen.main.bounds.width - 8 - 24 * 2) / 2
+    layout.itemSize = .init(width: cellWidth, height: 57)
     layout.sectionInset = .init(top: 16, left: 0, bottom: 16, right: 0)
     
     let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)

--- a/Projects/Presentation/Challenge/Implementations/ChallengeOrganize/ChallengeStart/ChallengeStartViewController.swift
+++ b/Projects/Presentation/Challenge/Implementations/ChallengeOrganize/ChallengeStart/ChallengeStartViewController.swift
@@ -123,7 +123,7 @@ private extension ChallengeStartViewController {
     }
   
     startImageView.snp.makeConstraints {
-      $0.top.equalTo(announceLabel.snp.bottom).offset(84)
+      $0.centerY.equalToSuperview()
       $0.leading.equalToSuperview().offset(24)
       $0.trailing.equalToSuperview().inset(24)
       $0.height.equalTo(250)

--- a/Projects/Presentation/SearchChallenge/Implementations/SearchChallengeCoordinator.swift
+++ b/Projects/Presentation/SearchChallenge/Implementations/SearchChallengeCoordinator.swift
@@ -12,6 +12,7 @@ import SearchChallenge
 
 protocol SearchChallengePresentable {
   func attachViewControllerables(_ viewControllerables: ViewControllerable...)
+  func presentLogInAlertView(to navigationControllerable: NavigationControllerable)
 }
 
 final class SearchChallengeCoordinator: ViewableCoordinator<SearchChallengePresentable> {
@@ -173,6 +174,10 @@ extension SearchChallengeCoordinator {
 extension SearchChallengeCoordinator: SearchChallengeCoordinatable {
   func didStartSearch() {
     attachSearchResult()
+  }
+  
+  func attachLogin() {
+    listener?.attachLoginPopup()
   }
 }
 

--- a/Projects/Presentation/SearchChallenge/Interfaces/SearchChallenge.swift
+++ b/Projects/Presentation/SearchChallenge/Interfaces/SearchChallenge.swift
@@ -14,4 +14,5 @@ public protocol SearchChallengeContainable: Containable {
 
 public protocol SearchChallengeListener: AnyObject {
   func authenticatedFailedAtSearchChallenge()
+  func attachLoginPopup()
 }


### PR DESCRIPTION
## 관련 이슈

- #298 

## 작업 설명

개최하기 Scene에서 기기 사이즈에 따른 UI 제약이 없도록 변경
개최 시작화면, 목표, 커버이미지, 룰 화면 수정 했습니다.

## 스크린샷
<img src = "https://github.com/user-attachments/assets/4f2435d2-8917-45c9-9c8c-30924fcd373b" width=200>
<img src = "https://github.com/user-attachments/assets/93355926-d2a2-4fc4-9239-ec79ff61093b" width=200>

<img src = "https://github.com/user-attachments/assets/e4e1135e-d786-4bed-a324-c4cdfe33d695" width=200>
<img src = "https://github.com/user-attachments/assets/75a0865a-79f5-454f-9f7f-ff50d5f5465e" width=200>
