### PR TITLE
[REFACT]: 홈에서 챌린지 합류 시 이동 플로우 수정

### DIFF
--- a/Projects/Presentation/Home/Implementations/ChallengeHome/ChallengeHomeContainer.swift
+++ b/Projects/Presentation/Home/Implementations/ChallengeHome/ChallengeHomeContainer.swift
@@ -16,12 +16,12 @@ protocol ChallengeHomeDependency: Dependency {
 }
 
 protocol ChallengeHomeContainable: Containable {
-  func coordinator(listener: ChallengeHomeListener) -> ViewableCoordinating
+  func coordinator(listener: ChallengeHomeListener, challengeId: Int?) -> ViewableCoordinating
 }
 
 final class ChallengeHomeContainer: Container<ChallengeHomeDependency>, ChallengeHomeContainable {
-  func coordinator(listener: ChallengeHomeListener) -> ViewableCoordinating {
-    let viewModel = ChallengeHomeViewModel(useCase: dependency.homeUseCase)
+  func coordinator(listener: ChallengeHomeListener, challengeId: Int? = nil) -> ViewableCoordinating {
+    let viewModel = ChallengeHomeViewModel(useCase: dependency.homeUseCase, firstJoinedChallengeId: challengeId)
     let viewControllerable = ChallengeHomeViewController(viewModel: viewModel)
     
     let coordinator = ChallengeHomeCoordinator(

--- a/Projects/Presentation/Home/Implementations/ChallengeHome/ChallengeHomeViewController.swift
+++ b/Projects/Presentation/Home/Implementations/ChallengeHome/ChallengeHomeViewController.swift
@@ -29,6 +29,7 @@ final class ChallengeHomeViewController: UIViewController, CameraRequestable, Vi
   private let disposeBag = DisposeBag()
   private let viewModel: ChallengeHomeViewModel
   
+  private let viewDidAppearRelay = PublishRelay<Void>()
   private let requestData = PublishRelay<Void>()
   private let uploadChallengeFeed = PublishRelay<(Int, UIImageWrapper)>()
   private let didTapFeed = PublishRelay<(challengeId: Int, feedId: Int)>()
@@ -87,6 +88,11 @@ final class ChallengeHomeViewController: UIViewController, CameraRequestable, Vi
     super.viewWillAppear(animated)
     requestData.accept(())
   }
+  
+  override func viewDidAppear(_ animated: Bool) {
+    super.viewDidAppear(animated)
+    viewDidAppearRelay.accept(())
+  }
 }
 
 // MARK: - UI Methods
@@ -143,6 +149,7 @@ private extension ChallengeHomeViewController {
 private extension ChallengeHomeViewController {
   func bind() {
     let input = ChallengeHomeViewModel.Input(
+      viewDidAppear: viewDidAppearRelay.asSignal(),
       requestData: requestData.asSignal(),
       didTapChallenge: bottomView.didTapChallenge,
       uploadChallengeFeed: uploadChallengeFeed.asSignal(),

--- a/Projects/Presentation/Home/Implementations/HomeCoordinator.swift
+++ b/Projects/Presentation/Home/Implementations/HomeCoordinator.swift
@@ -136,7 +136,7 @@ extension HomeCoordinator: NoneChallengeHomeListener {
     listener?.authenticatedFailedAtHome()
   }
 
-  func requstConvertInitialHome() {
+  func requestConvertInitialHome() {
     navigationControllerable.navigationController.showTabBar(animted: true)
     Task {
       await detachNoneChallengeHome()

--- a/Projects/Presentation/Home/Implementations/HomeCoordinator.swift
+++ b/Projects/Presentation/Home/Implementations/HomeCoordinator.swift
@@ -52,10 +52,10 @@ final class HomeCoordinator: Coordinator {
 
 // MARK: - ChallengeHome
 private extension HomeCoordinator {
-  @MainActor func attachChallengeHome(animated: Bool = true) {
+  @MainActor func attachChallengeHome(animated: Bool = true, challengeId: Int? = nil) {
     guard challengeHomeCoordinator == nil else { return }
     
-    let coordinator = challengeHomeContainer.coordinator(listener: self)
+    let coordinator = challengeHomeContainer.coordinator(listener: self, challengeId: challengeId)
     addChild(coordinator)
     navigationControllerable.setViewControllers([coordinator.viewControllerable], animated: animated)
     
@@ -141,6 +141,13 @@ extension HomeCoordinator: NoneChallengeHomeListener {
     Task {
       await detachNoneChallengeHome()
       await attachInitialScreenIfNeeded()
+    }
+  }
+  
+  func didJoinChallenge(challengeId: Int) {
+    Task {
+      await detachNoneChallengeHome()
+      await attachChallengeHome(animated: false, challengeId: challengeId)
     }
   }
 }

--- a/Projects/Presentation/Home/Implementations/HomeCoordinator.swift
+++ b/Projects/Presentation/Home/Implementations/HomeCoordinator.swift
@@ -59,14 +59,14 @@ private extension HomeCoordinator {
     addChild(coordinator)
     navigationControllerable.setViewControllers([coordinator.viewControllerable], animated: animated)
     
-    self.noneChallengeHomeCoordinator = coordinator
+    self.challengeHomeCoordinator = coordinator
   }
   
   @MainActor func detachChallengeHome() {
     guard let coordinator = noneChallengeHomeCoordinator else { return }
     
     removeChild(coordinator)
-    self.noneChallengeHomeCoordinator = nil
+    self.challengeHomeCoordinator = nil
   }
 }
 

--- a/Projects/Presentation/Home/Implementations/NoneChallengeHome/NoneChallengeHomeCoordinator.swift
+++ b/Projects/Presentation/Home/Implementations/NoneChallengeHome/NoneChallengeHomeCoordinator.swift
@@ -12,6 +12,7 @@ import Core
 protocol NoneChallengeHomeListener: AnyObject {
   func authenticatedFailedAtNoneChallengeHome()
   func requestConvertInitialHome()
+  func didJoinChallenge(challengeId: Int)
 }
 
 protocol NoneChallengeHomePresentable {
@@ -73,7 +74,7 @@ extension NoneChallengeHomeCoordinator: NoneMemberChallengeListener {
   }
   
   func didJoinChallenge(id: Int) {
-    listener?.requestConvertInitialHome()
+    listener?.didJoinChallenge(challengeId: id)
   }
   
   func authenticatedFailedAtNoneMemberChallenge() {

--- a/Projects/Presentation/Home/Implementations/NoneChallengeHome/NoneChallengeHomeCoordinator.swift
+++ b/Projects/Presentation/Home/Implementations/NoneChallengeHome/NoneChallengeHomeCoordinator.swift
@@ -11,7 +11,7 @@ import Core
 
 protocol NoneChallengeHomeListener: AnyObject {
   func authenticatedFailedAtNoneChallengeHome()
-  func requstConvertInitialHome()
+  func requestConvertInitialHome()
 }
 
 protocol NoneChallengeHomePresentable {
@@ -69,11 +69,11 @@ extension NoneChallengeHomeCoordinator: NoneMemberChallengeListener {
   }
   
   func alreadyJoinedChallenge(id: Int) {
-    listener?.requstConvertInitialHome()
+    listener?.requestConvertInitialHome()
   }
   
   func didJoinChallenge(id: Int) {
-    listener?.requstConvertInitialHome()
+    listener?.requestConvertInitialHome()
   }
   
   func authenticatedFailedAtNoneMemberChallenge() {


### PR DESCRIPTION
## 관련 이슈

- #300 

## 작업 설명

챌린지 홈에서 최초 챌린지 합류시 합류 후 이동 플로우를 수정 했습니다.

기존: 합류하기 -> 챌린지홈
변경: 합류하기 -> 챌린지홈 (animate: false) -> 챌린지
## 스크린샷

<img src = "https://github.com/user-attachments/assets/0f89bdcd-f7cd-4151-ade4-1778a2cd282a" width=200>

## 특이사항
오탈자 수정이 포함되어있습니다