### PR TITLE
[BUG]: 챌린지 인증 내역 화면 타이틀 잘리는 버그 수정

### DIFF
--- a/Projects/Presentation/MyPage/Implementations/Views/FeedHistory/FeedHistoryCell.swift
+++ b/Projects/Presentation/MyPage/Implementations/Views/FeedHistory/FeedHistoryCell.swift
@@ -60,6 +60,7 @@ private extension FeedHistoryCell {
     challengeTitleChip.snp.makeConstraints {
       $0.top.equalTo(feedImageView.snp.bottom).offset(8)
       $0.leading.bottom.equalToSuperview()
+      $0.height.equalTo(23)
       $0.trailing.lessThanOrEqualTo(shareButton.snp.leading).inset(16)
     }
     


### PR DESCRIPTION
## 관련 이슈

- #312 

## 작업 설명

종료된챌린지 크래시 - 챌린지 id가 중복되어서 죽는 문제발생 - 서버 측 전달
챌린지 인증내역 챌린지 이름 안나오는문제 - UI constraints 수정 (height 23)

## 스크린샷
종료된 챌린지 크래시
<img src="https://github.com/user-attachments/assets/b6dd763f-df92-4449-aaa2-a92f006b90cb" width=400>


