### PR TITLE
[FEAT]: 회원가입 페이지 이용약관 및 개인정보 처리 방침 띄우는 기능 구현

### DIFF
--- a/Projects/DesignSystem/Sources/BottomSheet/ListBottomSheet/ListBottomSheetViewController.swift
+++ b/Projects/DesignSystem/Sources/BottomSheet/ListBottomSheet/ListBottomSheetViewController.swift
@@ -13,7 +13,7 @@ import SnapKit
 import Core
 
 public protocol ListBottomSheetDelegate: AnyObject {
-  func didTapIcon(at index: Int)
+  func didTapIcon(_ bottomSheet: ListBottomSheetViewController, at index: Int)
   func didTapButton(_ bottomSheet: ListBottomSheetViewController)
 }
 
@@ -177,7 +177,7 @@ extension ListBottomSheetViewController: UITableViewDataSource {
     
     cell.rx.didTapIcon
       .bind(with: self) { owner, _ in
-        owner.delegate?.didTapIcon(at: indexPath.section)
+        owner.delegate?.didTapIcon(owner, at: indexPath.section)
       }
       .disposed(by: disposeBag)
     

--- a/Projects/Presentation/LogIn/Implementations/SignUp/EnterPassword/EnterPasswordViewController.swift
+++ b/Projects/Presentation/LogIn/Implementations/SignUp/EnterPassword/EnterPasswordViewController.swift
@@ -275,7 +275,17 @@ private extension EnterPasswordViewController {
 }
 
 extension EnterPasswordViewController: ListBottomSheetDelegate {
-  func didTapIcon(at index: Int) {  }
+  func didTapIcon(_ bottomSheet: ListBottomSheetViewController, at index: Int) {
+    let url = index == 0 ? ServiceConfiguration.shared.termsUrl : ServiceConfiguration.shared.privacyUrl
+    let webviewController = WebViewController(url: url)
+    webviewController.modalPresentationStyle = .pageSheet
+    
+    if let sheet = webviewController.sheetPresentationController {
+      sheet.prefersGrabberVisible = true
+  }
+
+    bottomSheet.present(webviewController, animated: true)
+  }
   
   func didTapButton(_ bottomSheet: ListBottomSheetViewController) {
     bottomSheet.dismissBottomSheet()


### PR DESCRIPTION
## 관련 이슈

- #324
## 작업 설명

회원가입에서 이용약관 띄우기 완료했습니다.
![Simulator Screen Recording - iPhone 16 Pro - 2025-07-24 at 15 57 56](https://github.com/user-attachments/assets/71aa03fc-4e72-456e-8f15-825845ffd169)
