### PR TITLE
[FEAT]: 마이페이지 비밀번호 초기화 시 로직 수정

### DIFF
--- a/Projects/App/Sources/AppContainer.swift
+++ b/Projects/App/Sources/AppContainer.swift
@@ -110,6 +110,7 @@ final class AppContainer:
   lazy var profileEditUseCase: ProfileEditUseCase = {
     return ProfileEditUseCaseImpl(
       authRepository: authRepository,
+      loginRepository: logInRepository,
       myPageRepository: myPageRepository
     )
   }()

--- a/Projects/Domain/UseCase/Implementations/ProfileEidtUseCaseImpl.swift
+++ b/Projects/Domain/UseCase/Implementations/ProfileEidtUseCaseImpl.swift
@@ -14,10 +14,16 @@ import Repository
 
 public final class ProfileEditUseCaseImpl: ProfileEditUseCase {
   private let authRepository: AuthRepository
+  private let loginRepository: LogInRepository
   private let myPageRepository: MyPageRepository
   
-  public init(authRepository: AuthRepository, myPageRepository: MyPageRepository) {
+  public init(
+    authRepository: AuthRepository,
+    loginRepository: LogInRepository,
+    myPageRepository: MyPageRepository
+  ) {
     self.authRepository = authRepository
+    self.loginRepository = loginRepository
     self.myPageRepository = myPageRepository
   }
 }
@@ -42,6 +48,10 @@ public extension ProfileEditUseCaseImpl {
   
   func changePassword(from password: String, to newPassword: String) async throws {
     try await myPageRepository.updatePassword(from: password, to: newPassword)
+  }
+  
+  func sendTemporaryPassword(to email: String, userName: String) async throws {
+    try await loginRepository.requestTemporaryPassword(email: email, userName: userName).value
   }
 }
 

--- a/Projects/Domain/UseCase/Interfaces/ProfileEditUseCase.swift
+++ b/Projects/Domain/UseCase/Interfaces/ProfileEditUseCase.swift
@@ -15,4 +15,5 @@ public protocol ProfileEditUseCase {
   func updateProfileImage(_ image: UIImageWrapper) async throws -> URL?
   func withdraw(with password: String) async throws
   func changePassword(from password: String, to newPassword: String) async throws
+  func sendTemporaryPassword(to email: String, userName: String) async throws
 }

--- a/Projects/Presentation/MyPage/Implementations/Setting/ProfileEdit/ChangePassword/ChangePasswordContainer.swift
+++ b/Projects/Presentation/MyPage/Implementations/Setting/ProfileEdit/ChangePassword/ChangePasswordContainer.swift
@@ -31,12 +31,10 @@ final class ChangePasswordContainer:
     userEmail: String,
     listener: ChangePasswordListener
   ) -> ViewableCoordinating {
-    let viewModel = ChangePasswordViewModel(useCase: dependency.profileEditUseCase)
+    let viewModel = ChangePasswordViewModel(email: userEmail, name: userName, useCase: dependency.profileEditUseCase)
     let viewControllerable = ChangePasswordViewController(viewModel: viewModel)
     
     let coordinator = ChangePasswordCoordinator(
-      userName: userName,
-      userEmail: userEmail,
       viewControllerable: viewControllerable,
       viewModel: viewModel,
       resetPasswordContainable: dependency.resetPasswordContainable

--- a/Projects/Presentation/MyPage/Implementations/Setting/ProfileEdit/ChangePassword/ChangePasswordCoordinator.swift
+++ b/Projects/Presentation/MyPage/Implementations/Setting/ProfileEdit/ChangePassword/ChangePasswordCoordinator.swift
@@ -20,22 +20,16 @@ protocol ChangePasswordPresentable { }
 final class ChangePasswordCoordinator: ViewableCoordinator<ChangePasswordPresentable> {
   weak var listener: ChangePasswordListener?
 
-  private let userName: String
-  private let userEmail: String
   private let viewModel: ChangePasswordViewModel
   
   private let resetPasswordContainable: ResetPasswordContainable
   private var resetPasswordCoordinator: Coordinating?
   
   init(
-    userName: String,
-    userEmail: String,
     viewControllerable: ViewControllerable,
     viewModel: ChangePasswordViewModel,
     resetPasswordContainable: ResetPasswordContainable
   ) {
-    self.userName = userName
-    self.userEmail = userEmail
     self.viewModel = viewModel
     self.resetPasswordContainable = resetPasswordContainable
     super.init(viewControllerable)
@@ -52,13 +46,13 @@ extension ChangePasswordCoordinator: ChangePasswordCoordinatable {
   func didChangedPassword() {
     listener?.didChangedPassword()
   }
-  
-  func attachResetPassword() {
+
+  func attachResetPassword(email: String, name: String) {
     guard resetPasswordCoordinator == nil else { return }
     
     let coordinator = resetPasswordContainable.coordinator(
-      userEmail: userEmail,
-      userName: userName,
+      userEmail: email,
+      userName: name,
       navigation: viewControllerable,
       listener: self
     )


### PR DESCRIPTION
## 관련 이슈

- #326

## 작업 설명

"비밀번호 분실"의 경우, 임시 비밀번호 페이지로 넘어가게 됩니다. 
기존의 경우, 임시 비밀번호 재전송 전까지 전송이 안되었으나, <br>
미리 전송되도록 수정했습니다. 