### PR TITLE
[BUG]:release 모드 일때, configuration 파일 누락되는 버그 해결

### DIFF
--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -9,76 +9,78 @@ import ProjectDescription
 import ProjectDescriptionHelpers
 
 let project = Project.make(
-	name: "Photi",
-	targets: [
-		.make(
-			name: "Photi-DEV",
-			product: .app,
-			bundleId: "com.photi.develop",
-			infoPlist: .file(path: .relativeToRoot("Projects/App/Info.plist")),
-			sources: ["Sources/**"],
-			resources: ["Resources/**"],
-			dependencies: [
-				.Project.Presentation.Home,
-				.Project.Presentation.HomeImpl,
-				.Project.Presentation.SearchChallenge,
-				.Project.Presentation.SearchChallengeImpl,
-				.Project.Presentation.MyPage,
-				.Project.Presentation.MyPageImpl,
-				.Project.Presentation.LogIn,
-				.Project.Presentation.LogInImpl,
-				.Project.Presentation.Challenge,
-				.Project.Presentation.ChallengeImpl,
-				.Project.Presentation.Report,
-				.Project.Presentation.ReportImpl,
-				.Project.Domain.UseCaseImpl,
-				.Project.Data.RepositoryImpl
-			],
-			settings: .settings(
-				base: [
-					"ASSETCATALOG_COMPILER_APPICON_NAME": "DevAppIcon",
-					"OTHER_LDFLAGS": "-ObjC"
-				],
-				configurations: [
-					.debug(name: .debug, xcconfig: "./xcconfigs/Photi.debug.xcconfig")
-				]
-			)
-		),
-		.make(
-			name: "Photi-PROD",
-			product: .app,
-			bundleId: "com.photi.product",
-			infoPlist: .file(path: .relativeToRoot("Projects/App/Info.plist")),
-			sources: ["Sources/**"],
-			resources: ["Resources/**"],
-			dependencies: [
-				.Project.Presentation.Home,
-				.Project.Presentation.HomeImpl,
-				.Project.Presentation.SearchChallenge,
-				.Project.Presentation.SearchChallengeImpl,
-				.Project.Presentation.MyPage,
-				.Project.Presentation.MyPageImpl,
-				.Project.Presentation.LogIn,
-				.Project.Presentation.LogInImpl,
-				.Project.Presentation.Challenge,
-				.Project.Presentation.ChallengeImpl,
-				.Project.Presentation.Report,
-				.Project.Presentation.ReportImpl,
-				.Project.Domain.UseCaseImpl,
-				.Project.Data.RepositoryImpl
-			],
-			settings: .settings(
-				base: [
-					"ASSETCATALOG_COMPILER_APPICON_NAME": "ProdAppIcon",
-					"OTHER_LDFLAGS": "-ObjC"
-				],
-				configurations: [
-					.debug(name: .debug, xcconfig: "./xcconfigs/Photi.release.xcconfig")
-				]
-			)
-		)
-	],
-	additionalFiles: [
-		"./xcconfigs/Photi.shared.xcconfig"
-	]
+  name: "Photi",
+  targets: [
+    .make(
+      name: "Photi-DEV",
+      product: .app,
+      bundleId: "com.photi.develop",
+      infoPlist: .file(path: .relativeToRoot("Projects/App/Info.plist")),
+      sources: ["Sources/**"],
+      resources: ["Resources/**"],
+      dependencies: [
+        .Project.Presentation.Home,
+        .Project.Presentation.HomeImpl,
+        .Project.Presentation.SearchChallenge,
+        .Project.Presentation.SearchChallengeImpl,
+        .Project.Presentation.MyPage,
+        .Project.Presentation.MyPageImpl,
+        .Project.Presentation.LogIn,
+        .Project.Presentation.LogInImpl,
+        .Project.Presentation.Challenge,
+        .Project.Presentation.ChallengeImpl,
+        .Project.Presentation.Report,
+        .Project.Presentation.ReportImpl,
+        .Project.Domain.UseCaseImpl,
+        .Project.Data.RepositoryImpl
+      ],
+      settings: .settings(
+        base: [
+          "ASSETCATALOG_COMPILER_APPICON_NAME": "DevAppIcon",
+          "OTHER_LDFLAGS": "-ObjC"
+        ],
+        configurations: [
+          .debug(name: .debug, xcconfig: "./xcconfigs/Photi.debug.xcconfig"),
+          .release(name: .release, xcconfig: "./xcconfigs/Photi.debug.xcconfig")
+        ]
+      )
+    ),
+    .make(
+      name: "Photi-PROD",
+      product: .app,
+      bundleId: "com.photi.product",
+      infoPlist: .file(path: .relativeToRoot("Projects/App/Info.plist")),
+      sources: ["Sources/**"],
+      resources: ["Resources/**"],
+      dependencies: [
+        .Project.Presentation.Home,
+        .Project.Presentation.HomeImpl,
+        .Project.Presentation.SearchChallenge,
+        .Project.Presentation.SearchChallengeImpl,
+        .Project.Presentation.MyPage,
+        .Project.Presentation.MyPageImpl,
+        .Project.Presentation.LogIn,
+        .Project.Presentation.LogInImpl,
+        .Project.Presentation.Challenge,
+        .Project.Presentation.ChallengeImpl,
+        .Project.Presentation.Report,
+        .Project.Presentation.ReportImpl,
+        .Project.Domain.UseCaseImpl,
+        .Project.Data.RepositoryImpl
+      ],
+      settings: .settings(
+        base: [
+          "ASSETCATALOG_COMPILER_APPICON_NAME": "ProdAppIcon",
+          "OTHER_LDFLAGS": "-ObjC"
+        ],
+        configurations: [
+          .debug(name: .debug, xcconfig: "./xcconfigs/Photi.release.xcconfig"),
+          .release(name: .release, xcconfig: "./xcconfigs/Photi.release.xcconfig")
+        ]
+      )
+    )
+  ],
+  additionalFiles: [
+    "./xcconfigs/Photi.shared.xcconfig"
+  ]
 )


### PR DESCRIPTION
## 관련 이슈

- #334

## 작업 설명

prod, debug 스키마에서, 각각 release 모드일시에 configuration 파일이 누락되는 버그 해결했습니다.

## PR 특이사항 
- 전체 파일 수정이 일어난거는 indent 수정으로 인한 것입니다!