### PR TITLE
[BUG]: Refresh Token 갱신 안되는 버그 수정

### DIFF
--- a/Projects/Data/PhotiNetwork/HTTP/HTTPHeader.swift
+++ b/Projects/Data/PhotiNetwork/HTTP/HTTPHeader.swift
@@ -42,7 +42,7 @@ public extension HTTPHeader {
   
   /// `Refresh-Token`헤더를 리턴합니다.
   static func refreshToken(_ token: String) -> HTTPHeader {
-    HTTPHeader(name: "Refresh-Token", value: "Bearer \(token)")
+    HTTPHeader(name: "Refresh-Token", value: "\(token)")
   }
 }
 


### PR DESCRIPTION
## 관련 이슈

- #341

## 작업 설명

API 문서대로 동작하지 않아, 서버에 문의해보니 Refresh Token은 Bearer가 없는게 맞다고 합니다.

