### PR TITLE
로그인 이후 홈화면 업데이트 안되는 버그 수정

### DIFF
--- a/Projects/App/Sources/AppCoordinator.swift
+++ b/Projects/App/Sources/AppCoordinator.swift
@@ -207,6 +207,14 @@ extension AppCoordinator: SearchChallengeListener {
       await presenter.presentTabMyPageWithoutLogInAlertView(to: homeNavigationControllerable)
     }
   }
+  
+  func didLoginAtSearchChallenge() {
+    Task {
+      await MainActor.run {
+        homeCoorinator?.start()
+      }
+    }
+  }
 }
 
 // MARK: - MyPageListener

--- a/Projects/Presentation/Challenge/Implementations/NoneMember/NoneMemberChallengeCoordinator.swift
+++ b/Projects/Presentation/Challenge/Implementations/NoneMember/NoneMemberChallengeCoordinator.swift
@@ -155,7 +155,7 @@ extension NoneMemberChallengeCoordinator: LogInListener {
   func didFinishLogIn(userName: String) {
     detachLogIn(animted: false)
     detachLogInGuide(animted: true)
-    
+    listener?.didLoginAtNoneMemberChallenge()
     Task { @MainActor [weak self] in
       guard let self else { return }
       let isJoined = await viewModel.isJoinedChallenge()

--- a/Projects/Presentation/Challenge/Interfaces/NoneMemberChallenge.swift
+++ b/Projects/Presentation/Challenge/Interfaces/NoneMemberChallenge.swift
@@ -18,4 +18,9 @@ public protocol NoneMemberChallengeListener: AnyObject {
   func didJoinChallenge(id: Int)
   func authenticatedFailedAtNoneMemberChallenge()
   func shouldDismissNoneMemberChallenge()
+  func didLoginAtNoneMemberChallenge()
+}
+
+public extension NoneMemberChallengeListener {
+  func didLoginAtNoneMemberChallenge() {}
 }

--- a/Projects/Presentation/Home/Implementations/HomeCoordinator.swift
+++ b/Projects/Presentation/Home/Implementations/HomeCoordinator.swift
@@ -63,7 +63,7 @@ private extension HomeCoordinator {
   }
   
   @MainActor func detachChallengeHome() {
-    guard let coordinator = noneChallengeHomeCoordinator else { return }
+    guard let coordinator = challengeHomeCoordinator else { return }
     
     removeChild(coordinator)
     self.challengeHomeCoordinator = nil

--- a/Projects/Presentation/SearchChallenge/Implementations/SearchChallengeCoordinator.swift
+++ b/Projects/Presentation/SearchChallenge/Implementations/SearchChallengeCoordinator.swift
@@ -216,6 +216,10 @@ extension SearchChallengeCoordinator: SearchResultListener {
   func didTapBackButtonAtSearchResult() {
     detachSearchResult()
   }
+  
+  func didLoginAtSearchResult() {
+    listener?.didLoginAtSearchChallenge()
+  }
 }
 
 // MARK: - ChallengeListener
@@ -271,5 +275,9 @@ extension SearchChallengeCoordinator: NoneMemberChallengeListener {
   
   func authenticatedFailedAtNoneMemberChallenge() {
     listener?.authenticatedFailedAtSearchChallenge()
+  }
+  
+  func didLoginAtNoneMemberChallenge() {
+    listener?.didLoginAtSearchChallenge()
   }
 }

--- a/Projects/Presentation/SearchChallenge/Implementations/SearchResult/SearchResultCoordinator.swift
+++ b/Projects/Presentation/SearchChallenge/Implementations/SearchResult/SearchResultCoordinator.swift
@@ -12,6 +12,7 @@ import Core
 protocol SearchResultListener: AnyObject {
   func didTapBackButtonAtSearchResult()
   func authenticatedFailedAtSearchResult()
+  func didLoginAtSearchResult()
 }
 
 @MainActor protocol SearchResultPresentable {
@@ -198,5 +199,9 @@ extension SearchResultCoordinator: NoneMemberChallengeListener {
   
   func authenticatedFailedAtNoneMemberChallenge() {
     listener?.authenticatedFailedAtSearchResult()
+  }
+  
+  func didLoginAtNoneMemberChallenge() {
+    listener?.didLoginAtSearchResult()
   }
 }

--- a/Projects/Presentation/SearchChallenge/Interfaces/SearchChallenge.swift
+++ b/Projects/Presentation/SearchChallenge/Interfaces/SearchChallenge.swift
@@ -15,4 +15,5 @@ public protocol SearchChallengeContainable: Containable {
 public protocol SearchChallengeListener: AnyObject {
   func authenticatedFailedAtSearchChallenge()
   func attachLoginPopup()
+  func didLoginAtSearchChallenge()
 }


### PR DESCRIPTION
## 관련 이슈

- #358 

## 작업 설명

- 홈화면을 제외한 다른 탭에서 로그인 할 시 홈화면이 업데이트 안되는 현상 
- 로그아웃 직후, "재로그인이 필요해요" 경고창이 뜨는 현상

### 1. 홈화면을 제외한 다른 탭에서 로그인 할 시 홈화면이 업데이트 안되는 현상
|*기존*| *변경 후* |    
| :-----------: | :------------: | 
| ![기존_인식X](https://github.com/user-attachments/assets/12f455c9-4dc2-4dbc-96cb-af02966a8a12)  | ![인tlrㅒ](https://github.com/user-attachments/assets/138e826f-182f-490e-b828-0a6bfb4c7f74) |    

기존에는 "검색"에서 로그인 하고 홈으로 돌아 온 경우, 위와 같이 인식되지 않았습니다. <br>

```swift
// AppCoordinator.swift
func didLoginAtSearchChallenge() {
  Task {
    await MainActor.run {
      homeCoorinator?.start()
    }
  }
}

```
이를 로그인시 이벤트 전달을 추가로 진행하여, 로그인하면 홈화면을 리로드하는 로직을 추가해주었습니다. 

### 로그아웃 직후, "재로그인이 필요해요" 경고창이 뜨는 현상
![로그아웃 될때 토큰 으로 인식되는 버그](https://github.com/user-attachments/assets/6f2d4e70-e619-4dd2-94fc-ddbd40a7ac96)
위와 같이, 로그아웃 이후 토큰만료로 인식이 되는 경우가 있었습니다. 

해당 이유는 `HomeCoordinator`에서 detach시에 코드 오류였습니다. 
// HomeCoordinator.swift
```swift
@MainActor func detachNoneChallengeHome() {
// guard let coordinator = noneChallengeHomeCoordinator else { return } 
  guard let coordinator = challengeHomeCoordinator else { return } // 기존의 잘못된 코드
  
  removeChild(coordinator)
  self.noneChallengeHomeCoordinator = nil
}
```
위와 같이 `noneChallengeHome`을 detach해야 하는데, guard 구문에서는 challengeHome으로 판별하는 로직으로 되어있었습니다. 
<br>이에 따라, 제대로 detach가 되지 못하고, 로그인 여부를 묻는 로직이 한번더 시행되었었습니다. 
 