### PR TITLE
[FEAT]: Google AdMob 배너 광고 컴포넌트 구현 (#402)

### DIFF
--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -35,7 +35,8 @@ let project = Project.make(
         .Project.Data.RepositoryImpl,
         .SPM.KakaoSDKAuth,
         .SPM.KakaoSDKUser,
-        .SPM.KakaoSDKCommon
+        .SPM.KakaoSDKCommon,
+        .SPM.GoogleMobileAds
       ],
       settings: .settings(
         base: [
@@ -72,7 +73,8 @@ let project = Project.make(
         .Project.Data.RepositoryImpl,
         .SPM.KakaoSDKAuth,
         .SPM.KakaoSDKUser,
-        .SPM.KakaoSDKCommon
+        .SPM.KakaoSDKCommon,
+        .SPM.GoogleMobileAds
       ],
       settings: .settings(
         base: [

--- a/Projects/App/Sources/AppLifeCycle/AppDelegate.swift
+++ b/Projects/App/Sources/AppLifeCycle/AppDelegate.swift
@@ -9,6 +9,7 @@
 import UIKit
 import Core
 import Coordinator
+import GoogleMobileAds
 import KakaoSDKCommon
 import KakaoSDKAuth
 
@@ -22,6 +23,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
   ) -> Bool {
+    // GoogleMobileAds 초기화
+    MobileAds.shared.start()
+
     // KakaoSDK 초기화
     KakaoSDK.initSDK(appKey: ServiceConfiguration.shared.kakaoNativeAppKey)
 

--- a/Projects/DesignSystem/Project.swift
+++ b/Projects/DesignSystem/Project.swift
@@ -20,7 +20,8 @@ let project = Project.make(
 			dependencies: [
             .Project.Cores.CoreUI,
 				.SPM.SnapKit,
-				.SPM.Lottie
+				.SPM.Lottie,
+				.SPM.GoogleMobileAds
       ]
 		)
 	],

--- a/Projects/DesignSystem/Sources/BannerAd/BannerAdPlacement.swift
+++ b/Projects/DesignSystem/Sources/BannerAd/BannerAdPlacement.swift
@@ -1,0 +1,25 @@
+//
+//  BannerAdPlacement.swift
+//  DesignSystem
+//
+
+import Foundation
+
+public enum BannerAdPlacement {
+  case homeBottom
+  case challengeTop
+  case myPage
+
+  /// 실제 배포 전 AdMob 콘솔에서 발급받은 광고 단위 ID로 교체하세요.
+  /// 현재는 Google 공식 테스트 ID가 설정되어 있습니다.
+  var adUnitID: String {
+    switch self {
+    case .homeBottom:
+      return "ca-app-pub-3940256099942544/2934735716"   // TODO: 실제 ID로 교체
+    case .challengeTop:
+      return "ca-app-pub-3940256099942544/2934735716"   // TODO: 실제 ID로 교체
+    case .myPage:
+      return "ca-app-pub-3940256099942544/2934735716"   // TODO: 실제 ID로 교체
+    }
+  }
+}

--- a/Projects/DesignSystem/Sources/BannerAd/BannerAdView.swift
+++ b/Projects/DesignSystem/Sources/BannerAd/BannerAdView.swift
@@ -1,0 +1,53 @@
+//
+//  BannerAdView.swift
+//  DesignSystem
+//
+
+import UIKit
+import GoogleMobileAds
+
+public final class BannerAdView: UIView {
+  private let bannerView = BannerView(adSize: GADAdSizeBanner)
+
+  // MARK: - Init
+
+  public init(placement: BannerAdPlacement) {
+    super.init(frame: .zero)
+    bannerView.adUnitID = placement.adUnitID
+    setupUI()
+  }
+
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  // MARK: - Public
+
+  /// ViewController가 화면에 추가된 뒤 호출하세요.
+  /// - Parameter viewController: 광고를 표시할 rootViewController
+  public func load(from viewController: UIViewController) {
+    bannerView.rootViewController = viewController
+    bannerView.load(Request())
+  }
+
+  public override var intrinsicContentSize: CGSize {
+    return CGSize(
+      width: bannerView.adSize.size.width,
+      height: bannerView.adSize.size.height
+    )
+  }
+}
+
+// MARK: - Private
+
+private extension BannerAdView {
+  func setupUI() {
+    addSubview(bannerView)
+    bannerView.translatesAutoresizingMaskIntoConstraints = false
+    NSLayoutConstraint.activate([
+      bannerView.centerXAnchor.constraint(equalTo: centerXAnchor),
+      bannerView.centerYAnchor.constraint(equalTo: centerYAnchor)
+    ])
+  }
+}

--- a/Tuist/Dependencies.swift
+++ b/Tuist/Dependencies.swift
@@ -40,6 +40,10 @@ let dependencies = Dependencies(
         .remote(
           url: "https://github.com/kakao/kakao-ios-sdk.git",
           requirement: .exact("2.23.0")
+        ),
+        .remote(
+          url: "https://github.com/googleads/swift-package-manager-google-mobile-ads.git",
+          requirement: .upToNextMajor(from: "11.0.0")
         )
 		],
 		platforms: [.iOS]

--- a/Tuist/ProjectDescriptionHelpers/TargetDependency+SPM.swift
+++ b/Tuist/ProjectDescriptionHelpers/TargetDependency+SPM.swift
@@ -23,4 +23,5 @@ public extension TargetDependency.SPM {
   static let KakaoSDKAuth = TargetDependency.external(name: "KakaoSDKAuth")
   static let KakaoSDKUser = TargetDependency.external(name: "KakaoSDKUser")
   static let KakaoSDKCommon = TargetDependency.external(name: "KakaoSDKCommon")
+  static let GoogleMobileAds = TargetDependency.external(name: "GoogleMobileAds")
 }


### PR DESCRIPTION
## 관련 이슈

- #402 

## 작업 설명

- GoogleMobileAds SPM 패키지 추가 (Tuist Dependencies, TargetDependency+SPM)
- DesignSystem에 BannerAdPlacement enum 및 BannerAdView 컴포넌트 구현
- BannerAdPlacement로 광고 단위를 추상화하여 Presentation에서는 placement만 전달
- AppDelegate에서 MobileAds.shared.start() 초기화 추가


