### PR TITLE
[FEAT]: 딥링크 동작 연결 처리

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
-TUIST = ~/.tuist/versions/3.17.0/tuist
+TUIST = $(shell which tuist)
 
 generate:
 	$(TUIST) fetch
 	TUIST_ROOT_DIR=${PWD} $(TUIST) generate
+	python3 scripts/patch_workspace.py
 
 reset:
 	$(TUIST) clean

--- a/Projects/App/Info.plist
+++ b/Projects/App/Info.plist
@@ -32,6 +32,7 @@
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>photi.app</string>
+				<string>photi</string>
 			</array>
 		</dict>
 		<dict>

--- a/Projects/App/Photi-PROD.entitlements
+++ b/Projects/App/Photi-PROD.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:app.photi.store</string>
+	</array>
+</dict>
+</plist>

--- a/Projects/App/Sources/AppCoordinator.swift
+++ b/Projects/App/Sources/AppCoordinator.swift
@@ -16,6 +16,7 @@ import MyPage
 @MainActor protocol AppPresentable {
   func attachNavigationControllers(_ viewControllerables: NavigationControllerable...)
   func changeNavigationControllerToHome()
+  func changeNavigationControllerToSearchChallenge()
   func presentWelcomeToastView(_ username: String)
   func presentTokenExpiredAlertView(to navigationControllerable: NavigationControllerable)
   func presentTabMyPageWithoutLogInAlertView(to navigationControllerable: NavigationControllerable)
@@ -33,6 +34,7 @@ final class AppCoordinator: ViewableCoordinator<AppPresentable> {
   
   private let searchChallengeContainer: SearchChallengeContainable
   private var searchChallengeCoordinator: ViewableCoordinating?
+  private weak var searchChallengeDeepLinkable: SearchChallengeDeepLinkable?
   
   private let myPageContainer: MyPageContainable
   private var myPageCoordinator: ViewableCoordinating?
@@ -130,11 +132,12 @@ private extension AppCoordinator {
 private extension AppCoordinator {
   @MainActor func attachSearchChallenge() {
     guard searchChallengeCoordinator == nil else { return }
-    
+
     let coordinator = searchChallengeContainer.coordinator(listener: self)
     searchChallengeNavigationControllerable.setViewControllers([coordinator.viewControllerable], animated: true)
     addChild(coordinator)
     self.searchChallengeCoordinator = coordinator
+    self.searchChallengeDeepLinkable = coordinator as? SearchChallengeDeepLinkable
   }
   
   @MainActor func detachSearchChallenge() {
@@ -171,9 +174,16 @@ extension AppCoordinator: AppCoordinatable {
       await presenter.presentTabMyPageWithoutLogInAlertView(to: homeNavigationControllerable)
     }
   }
-  
+
   func attachLogIn() {
     Task { await attachLogIn(at: homeNavigationControllerable) }
+  }
+
+  func handleDeepLink(challengeId: Int) {
+    Task {
+      await presenter.changeNavigationControllerToSearchChallenge()
+      await searchChallengeDeepLinkable?.routeToChallenge(challengeId: challengeId)
+    }
   }
 }
 

--- a/Projects/App/Sources/AppLifeCycle/AppDelegate.swift
+++ b/Projects/App/Sources/AppLifeCycle/AppDelegate.swift
@@ -15,6 +15,8 @@ import KakaoSDKAuth
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
   private var appCoordinator: Coordinating?
+  private weak var appCoordinatable: AppCoordinatable?
+  private var pendingDeepLinkChallengeId: Int?
   private let appContainer = AppContainer(dependency: AppDependency())
   var window: UIWindow?
 
@@ -39,6 +41,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     if AuthApi.isKakaoTalkLoginUrl(url) {
       return AuthController.handleOpenUrl(url: url)
     }
+
+    if url.scheme == "photi", url.host == "challenge",
+       let challengeId = Int(url.lastPathComponent) {
+      if let coordinator = appCoordinatable {
+        coordinator.handleDeepLink(challengeId: challengeId)
+      } else {
+        pendingDeepLinkChallengeId = challengeId
+      }
+      return true
+    }
+
     return false
   }
 }
@@ -59,11 +72,17 @@ private extension AppDelegate {
   func launchMainApp() {
     guard let window else { return }
     let appCoordinator = appContainer.coordinator()
-    
+
     appCoordinator.start()
-    
+
     window.rootViewController = appCoordinator.viewControllerable.uiviewController
     self.appCoordinator = appCoordinator
+    self.appCoordinatable = appCoordinator as? AppCoordinatable
+
+    if let challengeId = pendingDeepLinkChallengeId {
+      pendingDeepLinkChallengeId = nil
+      appCoordinatable?.handleDeepLink(challengeId: challengeId)
+    }
   }
 }
 

--- a/Projects/App/Sources/AppViewController.swift
+++ b/Projects/App/Sources/AppViewController.swift
@@ -120,10 +120,16 @@ extension AppViewController: AppPresentable {
   
   func changeNavigationControllerToHome() {
     guard viewControllers != nil else { return }
-    selectedIndex = 0 // 첫 번째 탭으로 전환
-    
+    selectedIndex = 0
+
     guard let viewController = viewControllers?.first else { return }
     viewController.showTabBar(animted: true)
+  }
+
+  func changeNavigationControllerToSearchChallenge() {
+    guard let viewControllers, viewControllers.count > 1 else { return }
+    selectedIndex = 1
+    viewControllers[1].showTabBar(animted: true)
   }
   
   func presentWelcomeToastView(_ username: String) {

--- a/Projects/App/Sources/AppViewModel.swift
+++ b/Projects/App/Sources/AppViewModel.swift
@@ -13,6 +13,7 @@ import UseCase
 protocol AppCoordinatable: AnyObject {
   func shouldReloadAllPage()
   func attachLogIn()
+  func handleDeepLink(challengeId: Int)
 }
 
 protocol AppViewModelType: AnyObject {

--- a/Projects/Presentation/LogIn/Implementations/LogInViewModel.swift
+++ b/Projects/Presentation/LogIn/Implementations/LogInViewModel.swift
@@ -7,6 +7,7 @@
 //
 
 import Combine
+import Foundation
 import Entity
 import UseCase
 import KakaoSDKAuth

--- a/Projects/Presentation/SearchChallenge/Implementations/SearchChallengeCoordinator.swift
+++ b/Projects/Presentation/SearchChallenge/Implementations/SearchChallengeCoordinator.swift
@@ -243,6 +243,13 @@ extension SearchChallengeCoordinator: ChallengeListener {
   }
 }
 
+// MARK: - SearchChallengeDeepLinkable
+extension SearchChallengeCoordinator: SearchChallengeDeepLinkable {
+  func routeToChallenge(challengeId: Int) {
+    Task { await viewModel.decideRouteForChallenge(id: challengeId) }
+  }
+}
+
 // MARK: - NoneMemberChallengeListener
 extension SearchChallengeCoordinator: NoneMemberChallengeListener {
   func didTapBackButtonAtNoneMemberChallenge() {

--- a/Projects/Presentation/SearchChallenge/Interfaces/SearchChallenge.swift
+++ b/Projects/Presentation/SearchChallenge/Interfaces/SearchChallenge.swift
@@ -17,3 +17,7 @@ public protocol SearchChallengeListener: AnyObject {
   func attachLoginPopup()
   func didLoginAtSearchChallenge()
 }
+
+public protocol SearchChallengeDeepLinkable: AnyObject {
+  @MainActor func routeToChallenge(challengeId: Int)
+}

--- a/scripts/patch_workspace.py
+++ b/scripts/patch_workspace.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+# Tuist generates the workspace without kakao-ios-sdk because its xcodeproj
+# is named KakaoOpenSDK.xcodeproj instead of kakao-ios-sdk.xcodeproj.
+# This script adds it to the workspace after every `tuist generate`.
+
+workspace = 'Photi.xcworkspace/contents.xcworkspacedata'
+
+with open(workspace) as f:
+    content = f.read()
+
+if 'KakaoOpenSDK' in content:
+    print('KakaoSDK already in workspace, skipping.')
+    exit(0)
+
+entry = (
+    '\n               <FileRef\n'
+    '                  location = "group:kakao-ios-sdk/KakaoOpenSDK.xcodeproj">\n'
+    '               </FileRef>'
+)
+
+idx = content.rfind('</FileRef>')
+if idx == -1:
+    print('ERROR: Could not find insertion point in workspace.')
+    exit(1)
+
+idx += len('</FileRef>')
+content = content[:idx] + entry + content[idx:]
+
+with open(workspace, 'w') as f:
+    f.write(content)
+
+print('KakaoSDK added to workspace.')


### PR DESCRIPTION
## 관련 이슈

- #355 

## 작업 설명

Custom URL Scheme(photi://) 기반 딥링크 구현

- Info.plist에 photi URL Scheme 등록
- AppDelegate에서 photi://challenge/{id} URL 파싱 및 처리
- 앱 실행 중: 즉시 해당 챌린지로 이동
- Cold Start(앱 미실행): Splash 완료 후 딥링크 처리되도록 pending 대응
- SearchChallengeDeepLinkable 프로토콜 추가 (Interface 모듈)
- SearchChallengeCoordinator에서 기존 decideRouteForChallenge 재사용하여 멤버/비멤버 분기 자동 처리
- AppCoordinator에서 SearchChallenge 탭 전환 후 챌린지 화면 진입

## 딥링크 진입 흐름

```mermaid
flowchart TD
    A["photi://challenge/{id}"] --> B[AppDelegate]
    B --> C[AppCoordinator.handleDeepLink]
    C --> D[SearchChallenge 탭 전환]
    D --> E[decideRouteForChallenge]
    E --> F[멤버]
    E --> G[비멤버]
    F --> H[ChallengeView]
    G --> I[NoneMemberChallengeView]
```

## PR 특이 사항

- 공유하기 기능 추가 필요
- https://www.photi.store/open?challenge_id={id} 로 메모장에서 링크 진입하면 됩니다.
