### PR TITLE
Feature/#393+394

### DIFF
--- a/Projects/App/Info.plist
+++ b/Projects/App/Info.plist
@@ -10,6 +10,10 @@
 	<string>$(BASE_URL)</string>
 	<key>KakaoNativeAppKey</key>
 	<string>$(KAKAO_NATIVE_APP_KEY)</string>
+	<key>GoogleClientID</key>
+	<string>$(GOOGLE_CLIENT_ID)</string>
+	<key>GoogleServerClientID</key>
+	<string>$(GOOGLE_SERVER_CLIENT_ID)</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -43,6 +47,16 @@
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>kakao$(KAKAO_NATIVE_APP_KEY)</string>
+			</array>
+		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>google</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>$(GOOGLE_REVERSED_CLIENT_ID)</string>
 			</array>
 		</dict>
 	</array>

--- a/Projects/App/Photi-PROD.entitlements
+++ b/Projects/App/Photi-PROD.entitlements
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:app.photi.store</string>

--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -35,13 +35,19 @@ let project = Project.make(
         .Project.Data.RepositoryImpl,
         .SPM.KakaoSDKAuth,
         .SPM.KakaoSDKUser,
-        .SPM.KakaoSDKCommon
+        .SPM.KakaoSDKCommon,
+        .SPM.GoogleSignIn,
+        .SPM.GTMSessionFetcherCore
       ],
       settings: .settings(
         base: [
           "ASSETCATALOG_COMPILER_APPICON_NAME": "DevAppIcon",
           "CODE_SIGN_ENTITLEMENTS": "$(SRCROOT)/Photi-PROD.entitlements",
-          "OTHER_LDFLAGS": "-ObjC"
+          "OTHER_LDFLAGS": "-ObjC",
+          "HEADER_SEARCH_PATHS": [
+            "$(inherited)",
+            "$(SRCROOT)/../../Tuist/Dependencies/SwiftPackageManager/.build/checkouts/gtm-session-fetcher/Sources/Core/Public"
+          ]
         ],
         configurations: [
           .debug(name: .debug, xcconfig: "./xcconfigs/Photi.debug.xcconfig"),
@@ -74,12 +80,18 @@ let project = Project.make(
         .Project.Data.RepositoryImpl,
         .SPM.KakaoSDKAuth,
         .SPM.KakaoSDKUser,
-        .SPM.KakaoSDKCommon
+        .SPM.KakaoSDKCommon,
+        .SPM.GoogleSignIn,
+        .SPM.GTMSessionFetcherCore
       ],
       settings: .settings(
         base: [
           "ASSETCATALOG_COMPILER_APPICON_NAME": "ProdAppIcon",
-          "OTHER_LDFLAGS": "-ObjC"
+          "OTHER_LDFLAGS": "-ObjC",
+          "HEADER_SEARCH_PATHS": [
+            "$(inherited)",
+            "$(SRCROOT)/../../Tuist/Dependencies/SwiftPackageManager/.build/checkouts/gtm-session-fetcher/Sources/Core/Public"
+          ]
         ],
         configurations: [
           .debug(name: .debug, xcconfig: "./xcconfigs/Photi.release.xcconfig"),

--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -40,6 +40,7 @@ let project = Project.make(
       settings: .settings(
         base: [
           "ASSETCATALOG_COMPILER_APPICON_NAME": "DevAppIcon",
+          "CODE_SIGN_ENTITLEMENTS": "$(SRCROOT)/Photi-PROD.entitlements",
           "OTHER_LDFLAGS": "-ObjC"
         ],
         configurations: [
@@ -53,6 +54,7 @@ let project = Project.make(
       product: .app,
       bundleId: "com.photi.product",
       infoPlist: .file(path: .relativeToRoot("Projects/App/Info.plist")),
+      entitlements: .relativeToRoot("Projects/App/Photi-PROD.entitlements"),
       sources: ["Sources/**"],
       resources: ["Resources/**"],
       dependencies: [

--- a/Projects/App/Sources/AppLifeCycle/AppDelegate.swift
+++ b/Projects/App/Sources/AppLifeCycle/AppDelegate.swift
@@ -11,6 +11,7 @@ import Core
 import Coordinator
 import KakaoSDKCommon
 import KakaoSDKAuth
+import GoogleSignIn
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -38,6 +39,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     open url: URL,
     options: [UIApplication.OpenURLOptionsKey: Any] = [:]
   ) -> Bool {
+    if GIDSignIn.sharedInstance.handle(url) {
+      return true
+    }
+
     if AuthApi.isKakaoTalkLoginUrl(url) {
       return AuthController.handleOpenUrl(url: url)
     }

--- a/Projects/App/Sources/AppViewController.swift
+++ b/Projects/App/Sources/AppViewController.swift
@@ -9,17 +9,14 @@
 import UIKit
 import Combine
 import Coordinator
-import RxCocoa
-import RxSwift
 import SnapKit
 import DesignSystem
 
 final class AppViewController: UITabBarController, ViewControllerable {
-  private let disposeBag = DisposeBag()
   private var cancellables: Set<AnyCancellable> = []
   private let viewModel: AppViewModel
-  private let didTapMyPageTabBarItem = PublishRelay<Void>()
-  private let didTapLogInButton = PublishRelay<Void>()
+  private let didTapMyPageTabBarItem = PassthroughSubject<Void, Never>()
+  private let didTapLogInButton = PassthroughSubject<Void, Never>()
   private var homeNavigationController: UIViewController?
   
   private let tapMyPageWithoutLogInAlertView: AlertViewController = {
@@ -80,26 +77,25 @@ final class AppViewController: UITabBarController, ViewControllerable {
 private extension AppViewController {
   func bind() {
     let input = AppViewModel.Input(
-      didTapMyPageTabBarItem: didTapMyPageTabBarItem.asSignal(),
-      didTapLogInButton: didTapLogInButton.asSignal()
+      didTapMyPageTabBarItem: didTapMyPageTabBarItem.eraseToAnyPublisher(),
+      didTapLogInButton: didTapLogInButton.eraseToAnyPublisher()
     )
     
     let output = viewModel.transform(input: input)
     
     output.allowMoveToMyPage
-      .emit(with: self) { owner, _ in
+      .sinkOnMain(with: self) { owner, _ in
         owner.selectedIndex = 2
-      }
-      .disposed(by: disposeBag)
+      }.store(in: &cancellables)
     
     tapMyPageWithoutLogInAlertView.didTapConfirmButton
       .sinkOnMain(with: self) { owner, _ in
-        owner.didTapLogInButton.accept(())
+        owner.didTapLogInButton.send(())
       }.store(in: &cancellables)
     
     tokenExpiredAlertView.didTapConfirmButton
       .sinkOnMain(with: self) { owner, _ in
-        owner.didTapLogInButton.accept(())
+        owner.didTapLogInButton.send(())
       }.store(in: &cancellables)
   }
 }
@@ -198,7 +194,7 @@ extension AppViewController: UITabBarControllerDelegate {
   func tabBarController(_ tabBarController: UITabBarController, shouldSelect viewController: UIViewController) -> Bool {
     guard let viewControllers = tabBarController.viewControllers else { return false }
     guard let selectedIndex = viewControllers.firstIndex(of: viewController) else { return false }
-    if selectedIndex == 2 && self.selectedIndex != 2 { didTapMyPageTabBarItem.accept(()) }
+    if selectedIndex == 2 && self.selectedIndex != 2 { didTapMyPageTabBarItem.send(()) }
     return selectedIndex != 2
   }
 }

--- a/Projects/App/Sources/AppViewModel.swift
+++ b/Projects/App/Sources/AppViewModel.swift
@@ -6,8 +6,7 @@
 //  Copyright © 2025 com.photi. All rights reserved.
 //
 
-import RxCocoa
-import RxSwift
+import Combine
 import UseCase
 
 protocol AppCoordinatable: AnyObject {
@@ -26,19 +25,19 @@ protocol AppViewModelType: AnyObject {
 final class AppViewModel: AppViewModelType {
   weak var coordinator: AppCoordinatable?
   private let useCase: AppUseCase
-  private let disposeBag = DisposeBag()
+  private var cancellables = Set<AnyCancellable>()
 
-  private let allowMoveToMyPage = PublishRelay<Void>()
+  private let allowMoveToMyPage = PassthroughSubject<Void, Never>()
   
   // MARK: - Input
   struct Input {
-    let didTapMyPageTabBarItem: Signal<Void>
-    let didTapLogInButton: Signal<Void>
+    let didTapMyPageTabBarItem: AnyPublisher<Void, Never>
+    let didTapLogInButton: AnyPublisher<Void, Never>
   }
   
   // MARK: - Output
   struct Output {
-    let allowMoveToMyPage: Signal<Void>
+    let allowMoveToMyPage: AnyPublisher<Void, Never>
   }
   
   // MARK: - Initializers
@@ -48,18 +47,16 @@ final class AppViewModel: AppViewModelType {
   
   func transform(input: Input) -> Output {
     input.didTapMyPageTabBarItem
-      .emit(with: self) { owner, _ in
+      .sink(with: self) { owner, _ in
         owner.handleMyPageTabSelection()
-      }
-      .disposed(by: disposeBag)
+      }.store(in: &cancellables)
     
     input.didTapLogInButton
-      .emit(with: self) { owner, _ in
+      .sink(with: self) { owner, _ in
         owner.coordinator?.attachLogIn()
-      }
-      .disposed(by: disposeBag)
+      }.store(in: &cancellables)
     
-    return Output(allowMoveToMyPage: allowMoveToMyPage.asSignal())
+    return Output(allowMoveToMyPage: allowMoveToMyPage.eraseToAnyPublisher())
   }
 }
 
@@ -69,7 +66,7 @@ private extension AppViewModel {
     Task {
       let isLogin = await useCase.isLogIn()
 
-      isLogin ? allowMoveToMyPage.accept(()) : coordinator?.shouldReloadAllPage()
+      isLogin ? allowMoveToMyPage.send(()) : coordinator?.shouldReloadAllPage()
     }
   }
 }

--- a/Projects/App/Sources/Splash/SplashViewController.swift
+++ b/Projects/App/Sources/Splash/SplashViewController.swift
@@ -7,13 +7,11 @@
 //
 
 import UIKit
-import RxSwift
 import Combine
 import SnapKit
 import DesignSystem
 
 final class SplashViewController: UIViewController {
-  private let disposeBag = DisposeBag()
   private var cancellables: Set<AnyCancellable> = []
   private let viewModel: SplashViewModel
   private let logoImageView = UIImageView(image: .logo)
@@ -69,10 +67,9 @@ private extension SplashViewController {
     let output = viewModel.transform(input: input)
     
     output.requiredForceUpdate
-      .emit(with: self) { owner, _ in
+      .sinkOnMain(with: self) { owner, _ in
         owner.presentRequiredForceUpdateAlert()
-      }
-      .disposed(by: disposeBag)
+      }.store(in: &cancellables)
     
     forceUpdateAlert.didTapConfirmButton
       .sinkOnMain(with: self) { owner, _ in

--- a/Projects/App/Sources/Splash/SplashViewModel.swift
+++ b/Projects/App/Sources/Splash/SplashViewModel.swift
@@ -53,7 +53,7 @@ private extension SplashViewModel {
 
       isRequired ? requiredForceUpdateRelay.accept(()) : await MainActor.run { listener?.didFinishSplash() }
     } catch {
-      exit(0)
+      await MainActor.run { listener?.didFinishSplash() }
     }
   }
 }

--- a/Projects/App/Sources/Splash/SplashViewModel.swift
+++ b/Projects/App/Sources/Splash/SplashViewModel.swift
@@ -7,9 +7,8 @@
 //
 
 import Foundation
+import Combine
 import UseCase
-import RxCocoa
-import RxSwift
 
 protocol SplashListener: AnyObject {
   func didFinishSplash()
@@ -24,15 +23,14 @@ final class SplashViewModel: SplashViewModelType {
   private let useCase: AppUseCase
   weak var listener: SplashListener?
   
-  private let disposeBag = DisposeBag()
-  private let requiredForceUpdateRelay = PublishRelay<Void>()
+  private let requiredForceUpdateSubject = PassthroughSubject<Void, Never>()
   
   // MARK: - Input
   struct Input { }
   
   // MARK: - Output
   struct Output {
-    let requiredForceUpdate: Signal<Void>
+    let requiredForceUpdate: AnyPublisher<Void, Never>
   }
   
   public init(useCase: AppUseCase) {
@@ -41,7 +39,7 @@ final class SplashViewModel: SplashViewModelType {
   
   func transform(input: Input) -> Output {
     Task { await checkForceUpdate() }
-    return Output(requiredForceUpdate: requiredForceUpdateRelay.asSignal())
+    return Output(requiredForceUpdate: requiredForceUpdateSubject.eraseToAnyPublisher())
   }
 }
 
@@ -51,7 +49,9 @@ private extension SplashViewModel {
     do {
       let isRequired = try await useCase.isAppForceUpdateRequired()
 
-      isRequired ? requiredForceUpdateRelay.accept(()) : await MainActor.run { listener?.didFinishSplash() }
+      await MainActor.run {
+        isRequired ? requiredForceUpdateSubject.send(()) : listener?.didFinishSplash()
+      }
     } catch {
       await MainActor.run { listener?.didFinishSplash() }
     }

--- a/Projects/Cores/Core/Utils/ServiceConfiguration.swift
+++ b/Projects/Cores/Core/Utils/ServiceConfiguration.swift
@@ -27,6 +27,24 @@ public final class ServiceConfiguration {
     }
     return appKey
   }
+
+  public var googleClientId: String {
+    guard let clientId = Bundle.main.object(forInfoDictionaryKey: "GoogleClientID") as? String else {
+      fatalError("Google Client ID could not find in plist. Please check plist or user-defined!")
+    }
+    return clientId
+  }
+
+  public var googleServerClientId: String? {
+    guard
+      let clientId = Bundle.main.object(forInfoDictionaryKey: "GoogleServerClientID") as? String,
+      !clientId.isEmpty,
+      !clientId.hasPrefix("$(")
+    else {
+      return nil
+    }
+    return clientId
+  }
   
   /// 사용자의 `userName`을 리턴합니다.
   public var userName: String {

--- a/Projects/Data/PhotiNetwork/HTTP/HTTPHeader.swift
+++ b/Projects/Data/PhotiNetwork/HTTP/HTTPHeader.swift
@@ -37,7 +37,8 @@ public extension HTTPHeader {
   
   /// `acessToken`을 통해 `Bearer` `Authorization` 헤더를 리턴합니다.
   static func authorization(acessToken: String) -> HTTPHeader {
-    authorization("Bearer \(acessToken)")
+    let value = acessToken.hasPrefix("Bearer ") ? acessToken : "Bearer \(acessToken)"
+    return authorization(value)
   }
   
   /// `Refresh-Token`헤더를 리턴합니다.

--- a/Projects/Data/PhotiNetwork/Interceptor/AuthenticationInterceptor/AuthenticationInterceptor.swift
+++ b/Projects/Data/PhotiNetwork/Interceptor/AuthenticationInterceptor/AuthenticationInterceptor.swift
@@ -51,6 +51,10 @@ private extension AuthenticationInterceptor {
   func requestRefreshToken(_ token: String) async throws {
     let response = try await Provider(stubBehavior: .never)
       .request(RefreshTokenAPI.refresh(token))
+
+    guard (200..<300).contains(response.statusCode) else {
+      throw NetworkError.networkFailed(reason: .interceptorMapping)
+    }
     
     if let accessToken = response.headers["Authorization"] {
       UserDefaults.standard.setValue(accessToken, forKey: "Authorization")

--- a/Projects/Data/PhotiNetwork/SupportFiles/BaseResponse.swift
+++ b/Projects/Data/PhotiNetwork/SupportFiles/BaseResponse.swift
@@ -53,9 +53,9 @@ extension BaseResponse {
 public struct BaseResponseDTO<ResponseType: Decodable>: Decodable {
   public let code: String
   public let message: String
-  public let data: ResponseType
+  public let data: ResponseType?
   
-  public init(code: String, message: String, data: ResponseType) {
+  public init(code: String, message: String, data: ResponseType?) {
     self.code = code
     self.message = message
     self.data = data

--- a/Projects/Data/Project.swift
+++ b/Projects/Data/Project.swift
@@ -38,8 +38,19 @@ let project = Project.make(
         .Project.Data.DataMapper,
         .Project.Data.PhotiNetwork,
         .Project.Domain.Repository,
-        .SPM.KakaoSDKUser
-      ]
+        .SPM.KakaoSDKUser,
+        .SPM.GoogleSignIn,
+        .SPM.GTMSessionFetcherCore
+      ],
+      settings: .settings(
+        base: [
+          "HEADER_SEARCH_PATHS": [
+            "$(inherited)",
+            "$(SRCROOT)/../../Tuist/Dependencies/SwiftPackageManager/.build/checkouts/" +
+            "gtm-session-fetcher/Sources/Core/Public"
+          ]
+        ]
+      )
     ),
     .make(
       name: "PhotiNetwork",

--- a/Projects/Data/Repository/Implementations/AppRepositoryImpl/AppRepositoryImpl.swift
+++ b/Projects/Data/Repository/Implementations/AppRepositoryImpl/AppRepositoryImpl.swift
@@ -15,7 +15,10 @@ public class AppRepositoryImpl: AppRepository {
   public init() { }
   
   public func fetchForceUpdateRequired(version: String) async throws -> Bool {
-    let provider = Provider<AppAPI>(stubBehavior: .never)
+    let provider = Provider<AppAPI>(
+      stubBehavior: .never,
+      session: .init(interceptor: nil)
+    )
     let dto = AppVersionRequestDTO(os: "ios", appVersion: version)
     do {
       let result = try await provider.request(.appVersion(dto: dto), type: AppVersionResponseDTO.self)

--- a/Projects/Data/Repository/Implementations/OAuthRepositoryImpl/OAuthAPI.swift
+++ b/Projects/Data/Repository/Implementations/OAuthRepositoryImpl/OAuthAPI.swift
@@ -16,8 +16,8 @@ public enum OAuthAPI {
   case setUsername(dto: OAuthUsernameRequestDTO)
   /// 카카오/구글 탈퇴 - 클라이언트에서 unlink 후 호출
   case withdrawKakaoGoogle(dto: OAuthWithdrawRequestDTO)
-  /// 애플 탈퇴 - 서버에서 revoke 처리
-  case withdrawApple(accessToken: String)
+  /// 애플 탈퇴 - 재인증에서 받은 authorization code를 access_token 파라미터로 전달
+  case withdrawApple(authorizationCode: String)
 }
 
 extension OAuthAPI: TargetType {
@@ -61,8 +61,8 @@ extension OAuthAPI: TargetType {
     case let .withdrawKakaoGoogle(dto):
       return .requestJSONEncodable(dto)
 
-    case let .withdrawApple(accessToken):
-      let parameters = ["access_token": accessToken]
+    case let .withdrawApple(authorizationCode):
+      let parameters = ["access_token": authorizationCode]
       return .requestParameters(parameters: parameters, encoding: URLEncoding.queryString)
     }
   }

--- a/Projects/Data/Repository/Implementations/OAuthRepositoryImpl/OAuthRepositoryImpl.swift
+++ b/Projects/Data/Repository/Implementations/OAuthRepositoryImpl/OAuthRepositoryImpl.swift
@@ -11,6 +11,7 @@ import DTO
 import Entity
 import Repository
 import PhotiNetwork
+import GoogleSignIn
 import KakaoSDKUser
 
 public struct OAuthRepositoryImpl: OAuthRepository {
@@ -41,17 +42,68 @@ public extension OAuthRepositoryImpl {
   }
 
   func withdrawGoogle() async throws {
-    // TODO: 구글 SDK 연동 후 구현
-    // 1. GIDSignIn.sharedInstance.currentUser?.userID로 sub 획득
-    // 2. GIDSignIn.sharedInstance.disconnect()로 연결 해제
-    // 3. requestWithdraw(provider: "GOOGLE", sub: sub) 호출
-    throw APIError.serverError
+    try configureGoogleSignInIfNeeded()
+    let user = try await restoreGoogleUserIfNeeded()
+    guard let sub = user.userID, !sub.isEmpty else {
+      throw APIError.authenticationFailed
+    }
+
+    try await disconnectGoogle()
+    try await requestWithdraw(provider: "GOOGLE", sub: sub)
   }
 
-  func withdrawApple() async throws {
-    // TODO: 애플 재인증 후 authorization code 획득하여 서버 전달
-    // ASAuthorizationAppleIDProvider를 사용하여 재인증
-    throw APIError.serverError
+  func withdrawApple(authorizationCode: String) async throws {
+    try await requestAuthorizableAPI(
+      api: OAuthAPI.withdrawApple(authorizationCode: authorizationCode),
+      responseType: SuccessResponseDTO.self
+    )
+  }
+}
+
+// MARK: - Google SDK Methods
+private extension OAuthRepositoryImpl {
+  func configureGoogleSignInIfNeeded() throws {
+    guard GIDSignIn.sharedInstance.configuration == nil else { return }
+
+    let clientId = ServiceConfiguration.shared.googleClientId
+    guard !clientId.isEmpty, !clientId.hasPrefix("$(") else {
+      throw APIError.authenticationFailed
+    }
+
+    GIDSignIn.sharedInstance.configuration = GIDConfiguration(
+      clientID: clientId,
+      serverClientID: ServiceConfiguration.shared.googleServerClientId
+    )
+  }
+
+  func restoreGoogleUserIfNeeded() async throws -> GIDGoogleUser {
+    if let currentUser = GIDSignIn.sharedInstance.currentUser {
+      return currentUser
+    }
+
+    return try await withCheckedThrowingContinuation { continuation in
+      GIDSignIn.sharedInstance.restorePreviousSignIn { user, error in
+        if let error {
+          continuation.resume(throwing: error)
+        } else if let user {
+          continuation.resume(returning: user)
+        } else {
+          continuation.resume(throwing: APIError.authenticationFailed)
+        }
+      }
+    }
+  }
+
+  func disconnectGoogle() async throws {
+    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+      GIDSignIn.sharedInstance.disconnect { error in
+        if let error {
+          continuation.resume(throwing: error)
+        } else {
+          continuation.resume()
+        }
+      }
+    }
   }
 }
 
@@ -117,6 +169,8 @@ private extension OAuthRepositoryImpl {
         return
       } else if result.statusCode == 401 || result.statusCode == 403 {
         throw APIError.authenticationFailed
+      } else if result.statusCode == 404 {
+        throw APIError.userNotFound
       } else if result.statusCode == 409 {
         throw APIError.oauthFailed(reason: .usernameAlreadyExists)
       } else {
@@ -150,6 +204,8 @@ private extension OAuthRepositoryImpl {
         throw APIError.authenticationFailed
       } else if result.statusCode == 403 {
         throw APIError.authenticationFailed
+      } else if result.statusCode == 404 {
+        throw APIError.userNotFound
       } else if result.statusCode == 409 {
         throw APIError.oauthFailed(reason: .usernameAlreadyExists)
       } else {

--- a/Projects/Data/Repository/Implementations/OAuthRepositoryImpl/OAuthRepositoryImpl.swift
+++ b/Projects/Data/Repository/Implementations/OAuthRepositoryImpl/OAuthRepositoryImpl.swift
@@ -29,9 +29,8 @@ public extension OAuthRepositoryImpl {
   func setUsername(_ username: String) async throws {
     let requestDTO = OAuthUsernameRequestDTO(username: username)
 
-    try await requestAuthorizableAPI(
-      api: OAuthAPI.setUsername(dto: requestDTO),
-      responseType: SuccessResponseDTO.self
+    try await requestAuthorizableAPIWithoutResponse(
+      api: OAuthAPI.setUsername(dto: requestDTO)
     )
   }
 
@@ -103,6 +102,35 @@ private extension OAuthRepositoryImpl {
 
 // MARK: - Private Methods
 private extension OAuthRepositoryImpl {
+  func requestAuthorizableAPIWithoutResponse(
+    api: OAuthAPI,
+    behavior: StubBehavior = .never
+  ) async throws {
+    do {
+      let provider = Provider<OAuthAPI>(
+        stubBehavior: behavior,
+        session: .init(interceptor: AuthenticationInterceptor())
+      )
+
+      let result = try await provider.request(api, type: VoidResponseDTO.self)
+      if (200..<300).contains(result.statusCode) {
+        return
+      } else if result.statusCode == 401 || result.statusCode == 403 {
+        throw APIError.authenticationFailed
+      } else if result.statusCode == 409 {
+        throw APIError.oauthFailed(reason: .usernameAlreadyExists)
+      } else {
+        throw APIError.serverError
+      }
+    } catch {
+      if case NetworkError.networkFailed(reason: .interceptorMapping) = error {
+        throw APIError.authenticationFailed
+      } else {
+        throw error
+      }
+    }
+  }
+
   @discardableResult
   func requestAuthorizableAPI<T: Decodable>(
     api: OAuthAPI,

--- a/Projects/Domain/Entity/UserProfile.swift
+++ b/Projects/Domain/Entity/UserProfile.swift
@@ -17,7 +17,9 @@ public enum AuthProvider: String {
 
 public enum WithdrawCredential {
   case password(String)
-  case oauth(provider: AuthProvider)
+  case kakao
+  case google
+  case apple(authorizationCode: String)
 }
 
 public struct UserProfile {

--- a/Projects/Domain/Repository/Interfaces/OAuthRepository.swift
+++ b/Projects/Domain/Repository/Interfaces/OAuthRepository.swift
@@ -19,6 +19,6 @@ public protocol OAuthRepository {
   /// 구글 회원 탈퇴 - SDK disconnect + 서버 API 호출
   func withdrawGoogle() async throws
 
-  /// 애플 회원 탈퇴 - 서버에서 revoke 처리
-  func withdrawApple() async throws
+  /// 애플 회원 탈퇴 - 서버에서 authorization code를 토큰으로 교환한 뒤 revoke 처리
+  func withdrawApple(authorizationCode: String) async throws
 }

--- a/Projects/Domain/UseCase/Implementations/ProfileEidtUseCaseImpl.swift
+++ b/Projects/Domain/UseCase/Implementations/ProfileEidtUseCaseImpl.swift
@@ -52,17 +52,12 @@ public extension ProfileEditUseCaseImpl {
     switch credential {
     case let .password(password):
       try await myPageRepository.deleteUserAccount(password: password)
-    case let .oauth(provider):
-      switch provider {
-      case .kakao:
-        try await oauthRepository.withdrawKakao()
-      case .google:
-        try await oauthRepository.withdrawGoogle()
-      case .apple:
-        try await oauthRepository.withdrawApple()
-      case .normal:
-        break
-      }
+    case .kakao:
+      try await oauthRepository.withdrawKakao()
+    case .google:
+      try await oauthRepository.withdrawGoogle()
+    case let .apple(authorizationCode):
+      try await oauthRepository.withdrawApple(authorizationCode: authorizationCode)
     }
     authRepository.removeToken()
   }

--- a/Projects/Presentation/Challenge/Implementations/ChallengeOrganize/ChallengeGoal/ChallengeGoalViewController.swift
+++ b/Projects/Presentation/Challenge/Implementations/ChallengeOrganize/ChallengeGoal/ChallengeGoalViewController.swift
@@ -256,12 +256,10 @@ private extension ChallengeGoalViewController {
   }
 
   func viewBind() {
-    let tapGesture = UITapGestureRecognizer()
-    downImageView.addGestureRecognizer(tapGesture)
-    downImageView.isUserInteractionEnabled = true
-    tapGesture.addAction(UIAction { [weak self] _ in
-      self?.showTimePickerBottomSheet()
-    }, for: .ended)
+    downImageView.tapGesturePublisher
+      .sinkOnMain(with: self) { owner, _ in
+        owner.showTimePickerBottomSheet()
+      }.store(in: &cancellables)
 
     dateTextField.didTapButtonPublisher
       .sinkOnMain(with: self) { owner, _ in

--- a/Projects/Presentation/Challenge/Implementations/ChallengeOrganize/ChallengePreview/ChallengePreviewViewController.swift
+++ b/Projects/Presentation/Challenge/Implementations/ChallengeOrganize/ChallengePreview/ChallengePreviewViewController.swift
@@ -221,7 +221,9 @@ private extension ChallengePreviewViewController {
       }.store(in: &cancellables)
 
     output.isLoading
-      .sinkOnMain { $0 ? LoadingAnimation.logo.start() : LoadingAnimation.logo.stop() }
+      .sinkOnMain(with: self) { _, isLoading in
+        isLoading ? LoadingAnimation.logo.start() : LoadingAnimation.logo.stop()
+      }
       .store(in: &cancellables)
   }
 }

--- a/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedComment/Views/CommentTextField/FeedCommentTextField.swift
+++ b/Projects/Presentation/Challenge/Implementations/Member/Feed/FeedComment/Views/CommentTextField/FeedCommentTextField.swift
@@ -25,15 +25,13 @@ final class FeedCommentTextField: UIView {
   }
 
   var didBeginInitialEditing: AnyPublisher<Void, Never> {
-    textField.publisher(for: .editingDidBegin)
+    textField.eventPublisher(for: .editingDidBegin)
       .first()
-      .map { _ in () }
       .eraseToAnyPublisher()
   }
 
   var didTapReturn: AnyPublisher<Void, Never> {
-    textField.publisher(for: .editingDidEndOnExit)
-      .map { _ in () }
+    textField.eventPublisher(for: .editingDidEndOnExit)
       .eraseToAnyPublisher()
   }
 

--- a/Projects/Presentation/Home/Implementations/HomeCoordinator.swift
+++ b/Projects/Presentation/Home/Implementations/HomeCoordinator.swift
@@ -167,8 +167,15 @@ private extension HomeCoordinator {
       
       count == 0 ? await attachNoneChallengeHome(animated: animated) : await attachChallengeHome(animated: animated)
     } catch {
-      if let error = error as? APIError, case .authenticationFailed = error {
-        await attachNoneMemberHome(animated: animated)
+      if let error = error as? APIError {
+        switch error {
+          case .authenticationFailed:
+            await attachNoneMemberHome(animated: animated)
+          case .challengeFailed(reason: .userNotFound):
+            await presentNetworkUnstableAlert(shouldRetry: false)
+          default:
+            await presentNetworkUnstableAlert()
+        }
       } else {
         await presentNetworkUnstableAlert()
       }
@@ -181,9 +188,11 @@ private extension HomeCoordinator {
     await detachNoneChallengeHome()
   }
   
-  @MainActor func presentNetworkUnstableAlert() {
+  @MainActor func presentNetworkUnstableAlert(shouldRetry: Bool = true) {
     let alert = navigationControllerable.navigationController.presentNetworkUnstableAlert()
-    
+
+    guard shouldRetry else { return }
+
     alert.didTapConfirmButton
       .sinkOnMain(with: self) { owner, _ in
         Task { await owner.attachInitialScreenIfNeeded() }

--- a/Projects/Presentation/LogIn/Implementations/LogInContainer.swift
+++ b/Projects/Presentation/LogIn/Implementations/LogInContainer.swift
@@ -31,7 +31,10 @@ public final class LogInContainer:
   var oauthUseCase: OAuthUseCase { dependency.oauthUseCase }
 
   public func coordinator(listener: LogInListener) -> ViewableCoordinating {
-    let viewModel = LogInViewModel(loginUseCase: dependency.logInUseCase)
+    let viewModel = LogInViewModel(
+      loginUseCase: dependency.logInUseCase,
+      oauthUseCase: dependency.oauthUseCase
+    )
     let viewControllerable = LogInViewController(viewModel: viewModel)
 
     let signUp = SignUpContainer(dependency: self)

--- a/Projects/Presentation/LogIn/Implementations/LogInCoordinator.swift
+++ b/Projects/Presentation/LogIn/Implementations/LogInCoordinator.swift
@@ -70,7 +70,7 @@ final class LogInCoordinator: ViewableCoordinator<LogInPresentable> {
 
 // MARK: - OAuthSignUp
 @MainActor extension LogInCoordinator {
-  func attachOAuthSignUp(provider: String, idToken: String) {
+  func attachOAuthSignUp() {
     guard
       oAuthSignUpCoordinator == nil,
       let navigationController = viewControllerable.uiviewController.navigationController
@@ -79,12 +79,9 @@ final class LogInCoordinator: ViewableCoordinator<LogInPresentable> {
     let navigation = NavigationControllerable(navigationController: navigationController)
     let coordinater = oAuthSignUpContainable.coordinator(
       navigationControllerable: navigation,
-      listener: self,
-      provider: provider,
-      idToken: idToken
+      listener: self
     )
     addChild(coordinater)
-    coordinater.start()
     self.oAuthSignUpCoordinator = coordinater
   }
 

--- a/Projects/Presentation/LogIn/Implementations/LogInViewController.swift
+++ b/Projects/Presentation/LogIn/Implementations/LogInViewController.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2024 com.alloon. All rights reserved.
 //
 
+import AuthenticationServices
 import UIKit
 import Combine
 import Coordinator
@@ -16,6 +17,8 @@ import DesignSystem
 final class LogInViewController: UIViewController, ViewControllerable {
   private var cancellables = Set<AnyCancellable>()
   private let viewModel: LogInViewModel
+  private let appleIdTokenSubject = PassthroughSubject<String, Never>()
+  private var appleAuthController: ASAuthorizationController?
   
   // MARK: - UI Components
   private let navigationBar = PhotiNavigationBar(
@@ -148,7 +151,7 @@ private extension LogInViewController {
       didTapFindIdButton: findView.findIdTapPublisher,
       didTapFindPasswordButton: findView.findPasswordTapPublisher,
       didTapSignUpButton: signUpButton.tapPublisher,
-      didTapAppleLoginButton: snsLoginView.didTapAppleLoginButton,
+      appleIdToken: appleIdTokenSubject.eraseToAnyPublisher(),
       didTapKakaoLoginButton: snsLoginView.didTapKakaoLoginButton,
       didTapGoogleLoginButton: snsLoginView.didTapGoogleLoginButton
     )
@@ -174,6 +177,11 @@ private extension LogInViewController {
     loginButton.tapPublisher
       .sinkOnMain(with: self) { owner, _ in
         owner.view.endEditing(true)
+      }.store(in: &cancellables)
+
+    snsLoginView.didTapAppleLoginButton
+      .sinkOnMain(with: self) { owner, _ in
+        owner.requestAppleLogin()
       }.store(in: &cancellables)
   }
   
@@ -218,8 +226,52 @@ private extension LogInViewController {
 // MARK: - LogInPresentable
 extension LogInViewController: LogInPresentable { }
 
+// MARK: - Apple Sign In
+extension LogInViewController: ASAuthorizationControllerPresentationContextProviding {
+  func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+    view.window ?? UIWindow()
+  }
+}
+
+extension LogInViewController: ASAuthorizationControllerDelegate {
+  func authorizationController(
+    controller: ASAuthorizationController,
+    didCompleteWithAuthorization authorization: ASAuthorization
+  ) {
+    appleAuthController = nil
+    guard
+      let credential = authorization.credential as? ASAuthorizationAppleIDCredential,
+      let identityTokenData = credential.identityToken,
+      let idToken = String(data: identityTokenData, encoding: .utf8)
+    else {
+      return
+    }
+    appleIdTokenSubject.send(idToken)
+  }
+
+  func authorizationController(
+    controller: ASAuthorizationController,
+    didCompleteWithError error: Error
+  ) {
+    appleAuthController = nil
+    if let authError = error as? ASAuthorizationError, authError.code == .canceled { return }
+  }
+}
+
 // MARK: - Private Methods
 private extension LogInViewController {
+  func requestAppleLogin() {
+    let provider = ASAuthorizationAppleIDProvider()
+    let request = provider.createRequest()
+    request.requestedScopes = [.fullName, .email]
+
+    let controller = ASAuthorizationController(authorizationRequests: [request])
+    controller.delegate = self
+    controller.presentationContextProvider = self
+    appleAuthController = controller
+    controller.performRequests()
+  }
+
   func displayWarningToastView() {
     warningToastView.present(to: self)
   }

--- a/Projects/Presentation/LogIn/Implementations/LogInViewController.swift
+++ b/Projects/Presentation/LogIn/Implementations/LogInViewController.swift
@@ -10,14 +10,17 @@ import AuthenticationServices
 import UIKit
 import Combine
 import Coordinator
+import Core
 import SnapKit
 import CoreUI
 import DesignSystem
+import GoogleSignIn
 
 final class LogInViewController: UIViewController, ViewControllerable {
   private var cancellables = Set<AnyCancellable>()
   private let viewModel: LogInViewModel
   private let appleIdTokenSubject = PassthroughSubject<String, Never>()
+  private let googleIdTokenSubject = PassthroughSubject<String, Never>()
   private var appleAuthController: ASAuthorizationController?
   
   // MARK: - UI Components
@@ -153,7 +156,7 @@ private extension LogInViewController {
       didTapSignUpButton: signUpButton.tapPublisher,
       appleIdToken: appleIdTokenSubject.eraseToAnyPublisher(),
       didTapKakaoLoginButton: snsLoginView.didTapKakaoLoginButton,
-      didTapGoogleLoginButton: snsLoginView.didTapGoogleLoginButton
+      googleIdToken: googleIdTokenSubject.eraseToAnyPublisher()
     )
    
     let output = viewModel.transform(input: input)
@@ -182,6 +185,11 @@ private extension LogInViewController {
     snsLoginView.didTapAppleLoginButton
       .sinkOnMain(with: self) { owner, _ in
         owner.requestAppleLogin()
+      }.store(in: &cancellables)
+
+    snsLoginView.didTapGoogleLoginButton
+      .sinkOnMain(with: self) { owner, _ in
+        owner.requestGoogleLogin()
       }.store(in: &cancellables)
   }
   
@@ -270,6 +278,26 @@ private extension LogInViewController {
     controller.presentationContextProvider = self
     appleAuthController = controller
     controller.performRequests()
+  }
+
+  func requestGoogleLogin() {
+    let clientId = ServiceConfiguration.shared.googleClientId
+    let serverClientId = ServiceConfiguration.shared.googleServerClientId
+
+    guard !clientId.isEmpty else { return }
+
+    GIDSignIn.sharedInstance.configuration = GIDConfiguration(
+      clientID: clientId,
+      serverClientID: serverClientId
+    )
+
+    GIDSignIn.sharedInstance.signIn(withPresenting: self) { [weak self] result, error in
+      if error != nil { return }
+
+      guard let idToken = result?.user.idToken?.tokenString else { return }
+
+      self?.googleIdTokenSubject.send(idToken)
+    }
   }
 
   func displayWarningToastView() {

--- a/Projects/Presentation/LogIn/Implementations/LogInViewModel.swift
+++ b/Projects/Presentation/LogIn/Implementations/LogInViewModel.swift
@@ -55,7 +55,7 @@ final class LogInViewModel: LogInViewModelType {
     let didTapSignUpButton: AnyPublisher<Void, Never>
     let appleIdToken: AnyPublisher<String, Never>
     let didTapKakaoLoginButton: AnyPublisher<Void, Never>
-    let didTapGoogleLoginButton: AnyPublisher<Void, Never>
+    let googleIdToken: AnyPublisher<String, Never>
   }
   
   // MARK: - Output
@@ -104,9 +104,9 @@ final class LogInViewModel: LogInViewModelType {
         owner.requestKakaoLogin()
       }.store(in: &cancellables)
 
-    input.didTapGoogleLoginButton
-      .sinkOnMain(with: self) { _, _ in
-        // TODO: Google 로그인 구현
+    input.googleIdToken
+      .sink(with: self) { owner, idToken in
+        Task { await owner.requestOAuthLogin(provider: "GOOGLE", idToken: idToken) }
       }.store(in: &cancellables)
     
     let didTapLoginButtonWithInfo = input.didTapLoginButton

--- a/Projects/Presentation/LogIn/Implementations/LogInViewModel.swift
+++ b/Projects/Presentation/LogIn/Implementations/LogInViewModel.swift
@@ -15,7 +15,7 @@ import KakaoSDKUser
 
 protocol LogInCoordinatable: AnyObject {
   func attachSignUp()
-  func attachOAuthSignUp(provider: String, idToken: String)
+  func attachOAuthSignUp()
   func attachFindId()
   func attachFindPassword()
   func didFinishLogIn(userName: String)
@@ -28,7 +28,7 @@ protocol LogInViewModelType {
 
   var coordinator: LogInCoordinatable? { get set }
 
-  init(loginUseCase: LogInUseCase)
+  init(loginUseCase: LogInUseCase, oauthUseCase: OAuthUseCase)
 
   func transform(input: Input) -> Output
 }
@@ -38,6 +38,7 @@ final class LogInViewModel: LogInViewModelType {
   weak var coordinator: LogInCoordinatable?
 
   private let loginUseCase: LogInUseCase
+  private let oauthUseCase: OAuthUseCase
   private let loadingAnimationSubject = PassthroughSubject<Bool, Never>()
   private let invalidIdOrPasswordSubject = PassthroughSubject<Void, Never>()
   private let deletedUserSubject = PassthroughSubject<Void, Never>()
@@ -52,7 +53,7 @@ final class LogInViewModel: LogInViewModelType {
     let didTapFindIdButton: AnyPublisher<Void, Never>
     let didTapFindPasswordButton: AnyPublisher<Void, Never>
     let didTapSignUpButton: AnyPublisher<Void, Never>
-    let didTapAppleLoginButton: AnyPublisher<Void, Never>
+    let appleIdToken: AnyPublisher<String, Never>
     let didTapKakaoLoginButton: AnyPublisher<Void, Never>
     let didTapGoogleLoginButton: AnyPublisher<Void, Never>
   }
@@ -67,8 +68,9 @@ final class LogInViewModel: LogInViewModelType {
   }
   
   // MARK: - Initializers
-  init(loginUseCase: LogInUseCase) {
+  init(loginUseCase: LogInUseCase, oauthUseCase: OAuthUseCase) {
     self.loginUseCase = loginUseCase
+    self.oauthUseCase = oauthUseCase
   }
   
   func transform(input: Input) -> Output {
@@ -92,9 +94,9 @@ final class LogInViewModel: LogInViewModelType {
         owner.coordinator?.didTapBackButton()
       }.store(in: &cancellables)
     
-    input.didTapAppleLoginButton
-      .sinkOnMain(with: self) { owner, _ in
-        // TODO: Apple 로그인 구현
+    input.appleIdToken
+      .sink(with: self) { owner, idToken in
+        Task { await owner.requestOAuthLogin(provider: "APPLE", idToken: idToken) }
       }.store(in: &cancellables)
 
     input.didTapKakaoLoginButton
@@ -103,7 +105,7 @@ final class LogInViewModel: LogInViewModelType {
       }.store(in: &cancellables)
 
     input.didTapGoogleLoginButton
-      .sinkOnMain(with: self) { owner, _ in
+      .sinkOnMain(with: self) { _, _ in
         // TODO: Google 로그인 구현
       }.store(in: &cancellables)
     
@@ -144,6 +146,31 @@ private extension LogInViewModel {
     }
   }
 
+  func requestOAuthLogin(provider: String, idToken: String) async {
+    await MainActor.run {
+      loadingAnimationSubject.send(true)
+    }
+
+    do {
+      let result = try await oauthUseCase.login(provider: provider, idToken: idToken)
+
+      await MainActor.run {
+        switch result {
+          case let .existingUser(username):
+            coordinator?.didFinishLogIn(userName: username)
+          case .newUser:
+            loadingAnimationSubject.send(false)
+            coordinator?.attachOAuthSignUp()
+        }
+      }
+    } catch {
+      await MainActor.run {
+        loadingAnimationSubject.send(false)
+        networkUnstableSubject.send(())
+      }
+    }
+  }
+
   func requestKakaoLogin() {
     let nonce = UUID().uuidString
 
@@ -160,9 +187,7 @@ private extension LogInViewModel {
         return
       }
 
-      Task { @MainActor in
-        self.coordinator?.attachOAuthSignUp(provider: "KAKAO", idToken: idToken)
-      }
+      Task { await self.requestOAuthLogin(provider: "KAKAO", idToken: idToken) }
     }
 
     if UserApi.isKakaoTalkLoginAvailable() {

--- a/Projects/Presentation/LogIn/Implementations/OAuthSignUp/OAuthSignUpContainer.swift
+++ b/Projects/Presentation/LogIn/Implementations/OAuthSignUp/OAuthSignUpContainer.swift
@@ -16,9 +16,7 @@ protocol OAuthSignUpDependency {
 protocol OAuthSignUpContainable: Containable {
   func coordinator(
     navigationControllerable: NavigationControllerable,
-    listener: OAuthSignUpListener,
-    provider: String,
-    idToken: String
+    listener: OAuthSignUpListener
   ) -> Coordinating
 }
 
@@ -32,9 +30,7 @@ final class OAuthSignUpContainer:
 
   func coordinator(
     navigationControllerable: NavigationControllerable,
-    listener: OAuthSignUpListener,
-    provider: String,
-    idToken: String
+    listener: OAuthSignUpListener
   ) -> Coordinating {
     let enterIdContainable = EnterIdContainer(dependency: self)
     let agreementContainable = AgreementContainer(dependency: self)
@@ -42,10 +38,7 @@ final class OAuthSignUpContainer:
     let coordinator = OAuthSignUpCoordinator(
       navigationControllerable: navigationControllerable,
       enterIdContainable: enterIdContainable,
-      agreementContainable: agreementContainable,
-      oauthUseCase: dependency.oauthUseCase,
-      provider: provider,
-      idToken: idToken
+      agreementContainable: agreementContainable
     )
     coordinator.listener = listener
     return coordinator

--- a/Projects/Presentation/LogIn/Implementations/OAuthSignUp/OAuthSignUpCoordinator.swift
+++ b/Projects/Presentation/LogIn/Implementations/OAuthSignUp/OAuthSignUpCoordinator.swift
@@ -6,7 +6,6 @@
 //
 
 import Coordinator
-import UseCase
 
 protocol OAuthSignUpListener: AnyObject {
   func didFinishOAuthSignUp(userName: String)
@@ -24,49 +23,20 @@ final class OAuthSignUpCoordinator: Coordinator {
   private let agreementContainable: AgreementContainable
   private var agreementCoordinator: Coordinating?
 
-  private let oauthUseCase: OAuthUseCase
-  private let provider: String
-  private let idToken: String
-
   init(
     navigationControllerable: NavigationControllerable,
     enterIdContainable: EnterIdContainable,
-    agreementContainable: AgreementContainable,
-    oauthUseCase: OAuthUseCase,
-    provider: String,
-    idToken: String
+    agreementContainable: AgreementContainable
   ) {
     self.navigationControllerable = navigationControllerable
     self.enterIdContainable = enterIdContainable
     self.agreementContainable = agreementContainable
-    self.oauthUseCase = oauthUseCase
-    self.provider = provider
-    self.idToken = idToken
     super.init()
   }
 
   override func start() {
     navigationControllerable.navigationController.navigationBar.isHidden = true
-    Task { await requestOAuthLogin() }
-  }
-
-  private func requestOAuthLogin() async {
-    do {
-      let result = try await oauthUseCase.login(provider: provider, idToken: idToken)
-
-      await MainActor.run {
-        switch result {
-          case let .existingUser(username):
-            listener?.didFinishOAuthSignUp(userName: username)
-          case .newUser:
-            Task { await attachEnterId() }
-        }
-      }
-    } catch {
-      await MainActor.run {
-        listener?.didTapBackButtonAtOAuthSignUp()
-      }
-    }
+    Task { await attachEnterId() }
   }
 
   override func stop() {

--- a/Projects/Presentation/MyPage/Implementations/Setting/ProfileEdit/Withdraw/WithdrawViewController.swift
+++ b/Projects/Presentation/MyPage/Implementations/Setting/ProfileEdit/Withdraw/WithdrawViewController.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2024 com.photi. All rights reserved.
 //
 
+import AuthenticationServices
 import UIKit
 import Combine
 import Coordinator
@@ -18,6 +19,9 @@ final class WithdrawViewController: UIViewController, ViewControllerable {
 
   private var cancellables = Set<AnyCancellable>()
   private let didConfirmOAuthWithdrawSubject = PassthroughSubject<Void, Never>()
+  private let appleAuthorizationCodeSubject = PassthroughSubject<String, Never>()
+  private let appleAuthorizationFailedSubject = PassthroughSubject<Void, Never>()
+  private var appleAuthorizationController: ASAuthorizationController?
 
   // MARK: - UIComponents
   private let navigationBar = PhotiNavigationBar(leftView: .backButton, displayMode: .dark)
@@ -112,7 +116,9 @@ private extension WithdrawViewController {
       didTapBackButton: navigationBar.didTapBackButton,
       didTapWithdrawButton: withdrawButton.tapPublisher,
       didTapCancelButton: cancelButton.tapPublisher,
-      didConfirmOAuthWithdraw: didConfirmOAuthWithdrawSubject.eraseToAnyPublisher()
+      didConfirmOAuthWithdraw: didConfirmOAuthWithdrawSubject.eraseToAnyPublisher(),
+      appleAuthorizationCode: appleAuthorizationCodeSubject.eraseToAnyPublisher(),
+      appleAuthorizationFailed: appleAuthorizationFailedSubject.eraseToAnyPublisher()
     )
 
     let output = viewModel.transform(input: input)
@@ -143,6 +149,13 @@ private extension WithdrawViewController {
       }
       .store(in: &cancellables)
 
+    output.requestAppleAuthorization
+      .receive(on: DispatchQueue.main)
+      .sink { [weak self] in
+        self?.requestAppleAuthorization()
+      }
+      .store(in: &cancellables)
+
     output.networkUnstable
       .receive(on: DispatchQueue.main)
       .sink { [weak self] in
@@ -168,6 +181,59 @@ private extension WithdrawViewController {
       .store(in: &cancellables)
 
     alert.present(to: self, animted: true)
+  }
+}
+
+// MARK: - Apple Authorization
+extension WithdrawViewController: ASAuthorizationControllerPresentationContextProviding {
+  func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+    view.window ?? UIWindow()
+  }
+}
+
+extension WithdrawViewController: ASAuthorizationControllerDelegate {
+  func authorizationController(
+    controller: ASAuthorizationController,
+    didCompleteWithAuthorization authorization: ASAuthorization
+  ) {
+    appleAuthorizationController = nil
+
+    guard
+      let credential = authorization.credential as? ASAuthorizationAppleIDCredential,
+      let authorizationCodeData = credential.authorizationCode,
+      let authorizationCode = String(data: authorizationCodeData, encoding: .utf8)
+    else {
+      appleAuthorizationFailedSubject.send(())
+      return
+    }
+
+    appleAuthorizationCodeSubject.send(authorizationCode)
+  }
+
+  func authorizationController(
+    controller: ASAuthorizationController,
+    didCompleteWithError error: Error
+  ) {
+    appleAuthorizationController = nil
+
+    if let authorizationError = error as? ASAuthorizationError,
+       authorizationError.code == .canceled {
+      return
+    }
+
+    appleAuthorizationFailedSubject.send(())
+  }
+}
+
+// MARK: - Apple Authorization Methods
+private extension WithdrawViewController {
+  func requestAppleAuthorization() {
+    let request = ASAuthorizationAppleIDProvider().createRequest()
+    let controller = ASAuthorizationController(authorizationRequests: [request])
+    controller.delegate = self
+    controller.presentationContextProvider = self
+    appleAuthorizationController = controller
+    controller.performRequests()
   }
 }
 

--- a/Projects/Presentation/MyPage/Implementations/Setting/ProfileEdit/Withdraw/WithdrawViewModel.swift
+++ b/Projects/Presentation/MyPage/Implementations/Setting/ProfileEdit/Withdraw/WithdrawViewModel.swift
@@ -34,6 +34,7 @@ final class WithdrawViewModel: WithdrawViewModelType {
 
   private let useCase: ProfileEditUseCase
   private let showOAuthAlertSubject = PassthroughSubject<String, Never>()
+  private let requestAppleAuthorizationSubject = PassthroughSubject<Void, Never>()
   private let isLoadingSubject = CurrentValueSubject<Bool, Never>(false)
   private let networkUnstableSubject = PassthroughSubject<Void, Never>()
 
@@ -43,11 +44,14 @@ final class WithdrawViewModel: WithdrawViewModelType {
     let didTapWithdrawButton: AnyPublisher<Void, Never>
     let didTapCancelButton: AnyPublisher<Void, Never>
     let didConfirmOAuthWithdraw: AnyPublisher<Void, Never>
+    let appleAuthorizationCode: AnyPublisher<String, Never>
+    let appleAuthorizationFailed: AnyPublisher<Void, Never>
   }
 
   // MARK: - Output
   struct Output {
     let showOAuthAlert: AnyPublisher<String, Never>
+    let requestAppleAuthorization: AnyPublisher<Void, Never>
     let isLoading: AnyPublisher<Bool, Never>
     let networkUnstable: AnyPublisher<Void, Never>
   }
@@ -90,15 +94,39 @@ final class WithdrawViewModel: WithdrawViewModelType {
         guard let self else { return }
         let providerString = ServiceConfiguration.shared.authProvider
         let provider = AuthProvider(rawValue: providerString) ?? .normal
-        Task { await self.withdrawOAuth(provider: provider) }
+        if provider == .apple {
+          self.requestAppleAuthorizationSubject.send(())
+        } else {
+          Task { await self.withdrawOAuth(provider: provider) }
+        }
       }
       .store(in: &cancellables)
 
+    bindAppleAuthorization(input: input)
+
     return Output(
       showOAuthAlert: showOAuthAlertSubject.eraseToAnyPublisher(),
+      requestAppleAuthorization: requestAppleAuthorizationSubject.eraseToAnyPublisher(),
       isLoading: isLoadingSubject.eraseToAnyPublisher(),
       networkUnstable: networkUnstableSubject.eraseToAnyPublisher()
     )
+  }
+}
+
+// MARK: - Bind Methods
+private extension WithdrawViewModel {
+  func bindAppleAuthorization(input: Input) {
+    input.appleAuthorizationCode
+      .sink { [weak self] authorizationCode in
+        Task { await self?.withdrawApple(authorizationCode: authorizationCode) }
+      }
+      .store(in: &cancellables)
+
+    input.appleAuthorizationFailed
+      .sink { [weak self] in
+        self?.networkUnstableSubject.send(())
+      }
+      .store(in: &cancellables)
   }
 }
 
@@ -120,10 +148,31 @@ private extension WithdrawViewModel {
     isLoadingSubject.send(true)
 
     do {
-      try await useCase.withdraw(with: .oauth(provider: provider))
+      switch provider {
+      case .kakao:
+        try await useCase.withdraw(with: .kakao)
+      case .google:
+        try await useCase.withdraw(with: .google)
+      case .apple, .normal:
+        throw APIError.serverError
+      }
       coordinator?.withdrawalSucceed()
     } catch {
       isLoadingSubject.send(false)
+      handleError(error)
+    }
+  }
+
+  @MainActor
+  func withdrawApple(authorizationCode: String) async {
+    defer { isLoadingSubject.send(false) }
+
+    isLoadingSubject.send(true)
+
+    do {
+      try await useCase.withdraw(with: .apple(authorizationCode: authorizationCode))
+      coordinator?.withdrawalSucceed()
+    } catch {
       handleError(error)
     }
   }

--- a/Projects/Presentation/Project.swift
+++ b/Projects/Presentation/Project.swift
@@ -105,8 +105,18 @@ let project = Project.make(
 				.Project.DesignSystem,
 				.SPM.SnapKit,
 				.SPM.KakaoSDKAuth,
-				.SPM.KakaoSDKUser
-			]
+				.SPM.KakaoSDKUser,
+				.SPM.GoogleSignIn,
+				.SPM.GTMSessionFetcherCore
+			],
+			settings: .settings(
+				base: [
+					"HEADER_SEARCH_PATHS": [
+						"$(inherited)",
+						"$(SRCROOT)/../../Tuist/Dependencies/SwiftPackageManager/.build/checkouts/gtm-session-fetcher/Sources/Core/Public"
+					]
+				]
+			)
 		),
 		.make(
 			name: "LogIn",

--- a/Tuist/Dependencies.swift
+++ b/Tuist/Dependencies.swift
@@ -8,7 +8,8 @@
 import ProjectDescription
 
 let dependencies = Dependencies(
-		swiftPackageManager: [
+		swiftPackageManager: .init(
+      [
 				.remote(
 						url: "https://github.com/ReactiveX/RxSwift.git",
 						requirement: .exact("6.6.0")
@@ -40,7 +41,16 @@ let dependencies = Dependencies(
         .remote(
           url: "https://github.com/kakao/kakao-ios-sdk.git",
           requirement: .exact("2.23.0")
+        ),
+        .remote(
+          url: "https://github.com/google/GoogleSignIn-iOS.git",
+          requirement: .exact("7.1.0")
         )
-		],
+		  ],
+      productTypes: [
+        "AppAuthCore": .staticLibrary,
+        "GTMSessionFetcherCore": .staticLibrary
+      ]
+    ),
 		platforms: [.iOS]
 )

--- a/Tuist/ProjectDescriptionHelpers/Target+Extensions.swift
+++ b/Tuist/ProjectDescriptionHelpers/Target+Extensions.swift
@@ -15,6 +15,7 @@ public extension Target {
 		bundleId: String,
 		deploymentTarget: DeploymentTarget = .iOS(targetVersion: "15.0", devices: [.iphone]),
 		infoPlist: InfoPlist = .default,
+        entitlements: Path? = nil,
 		sources: SourceFilesList,
 		resources: ResourceFileElements? = nil,
 		scripts: [TargetScript] = [],
@@ -30,6 +31,7 @@ public extension Target {
 			infoPlist: infoPlist,
 			sources: sources,
 			resources: resources,
+            entitlements: entitlements,
 			scripts: scripts,
 			dependencies: dependencies,
 			settings: settings

--- a/Tuist/ProjectDescriptionHelpers/TargetDependency+SPM.swift
+++ b/Tuist/ProjectDescriptionHelpers/TargetDependency+SPM.swift
@@ -23,4 +23,6 @@ public extension TargetDependency.SPM {
   static let KakaoSDKAuth = TargetDependency.external(name: "KakaoSDKAuth")
   static let KakaoSDKUser = TargetDependency.external(name: "KakaoSDKUser")
   static let KakaoSDKCommon = TargetDependency.external(name: "KakaoSDKCommon")
+  static let GoogleSignIn = TargetDependency.external(name: "GoogleSignIn")
+  static let GTMSessionFetcherCore = TargetDependency.external(name: "GTMSessionFetcherCore")
 }

--- a/scripts/patch_workspace.py
+++ b/scripts/patch_workspace.py
@@ -1,32 +1,89 @@
 #!/usr/bin/env python3
-# Tuist generates the workspace without kakao-ios-sdk because its xcodeproj
-# is named KakaoOpenSDK.xcodeproj instead of kakao-ios-sdk.xcodeproj.
-# This script adds it to the workspace after every `tuist generate`.
+# Apply small patches needed after every `tuist generate`.
+#
+# - Tuist generates the workspace without kakao-ios-sdk because its xcodeproj
+#   is named KakaoOpenSDK.xcodeproj instead of kakao-ios-sdk.xcodeproj.
+# - Xcode explicit Swift modules can make GTMAppAuth resolve AppAuthCore and
+#   GTMSessionFetcherCore as empty generated Swift modules instead of their
+#   ObjC Clang modules.
 
 workspace = 'Photi.xcworkspace/contents.xcworkspacedata'
+gtm_app_auth_project = (
+    'Tuist/Dependencies/SwiftPackageManager/.build/checkouts/'
+    'GTMAppAuth/GTMAppAuth.xcodeproj/project.pbxproj'
+)
+core_project_patches = {
+    'Tuist/Dependencies/SwiftPackageManager/.build/checkouts/'
+    'AppAuth-iOS/AppAuth.xcodeproj/project.pbxproj': (
+        '\t\t\t\t60179C533F72B45F6B444262 /* TuistBundle+AppAuthCore.swift in Sources */,\n'
+    ),
+    'Tuist/Dependencies/SwiftPackageManager/.build/checkouts/'
+    'gtm-session-fetcher/GTMSessionFetcher.xcodeproj/project.pbxproj': (
+        '\t\t\t\t0E34FFCAA9D761E74384D197 /* TuistBundle+GTMSessionFetcherCore.swift in Sources */,\n'
+    ),
+}
 
 with open(workspace) as f:
     content = f.read()
 
 if 'KakaoOpenSDK' in content:
     print('KakaoSDK already in workspace, skipping.')
+else:
+    entry = (
+        '\n               <FileRef\n'
+        '                  location = "group:kakao-ios-sdk/KakaoOpenSDK.xcodeproj">\n'
+        '               </FileRef>'
+    )
+
+    idx = content.rfind('</FileRef>')
+    if idx == -1:
+        print('ERROR: Could not find insertion point in workspace.')
+        exit(1)
+
+    idx += len('</FileRef>')
+    content = content[:idx] + entry + content[idx:]
+
+    with open(workspace, 'w') as f:
+        f.write(content)
+
+    print('KakaoSDK added to workspace.')
+
+try:
+    with open(gtm_app_auth_project) as f:
+        content = f.read()
+except FileNotFoundError:
+    print('GTMAppAuth project not found, skipping.')
     exit(0)
 
-entry = (
-    '\n               <FileRef\n'
-    '                  location = "group:kakao-ios-sdk/KakaoOpenSDK.xcodeproj">\n'
-    '               </FileRef>'
-)
+if 'SWIFT_ENABLE_EXPLICIT_MODULES = NO;' in content:
+    print('GTMAppAuth explicit Swift modules already disabled, skipping.')
+else:
+    patched = content.replace(
+        'SWIFT_VERSION = 5.0;',
+        'SWIFT_ENABLE_EXPLICIT_MODULES = NO;\n\t\t\t\tSWIFT_VERSION = 5.0;'
+    )
+    if patched == content:
+        print('ERROR: Could not patch GTMAppAuth build settings.')
+        exit(1)
 
-idx = content.rfind('</FileRef>')
-if idx == -1:
-    print('ERROR: Could not find insertion point in workspace.')
-    exit(1)
+    with open(gtm_app_auth_project, 'w') as f:
+        f.write(patched)
 
-idx += len('</FileRef>')
-content = content[:idx] + entry + content[idx:]
+    print('GTMAppAuth explicit Swift modules disabled.')
 
-with open(workspace, 'w') as f:
-    f.write(content)
+for project, dummy_source in core_project_patches.items():
+    try:
+        with open(project) as f:
+            content = f.read()
+    except FileNotFoundError:
+        print(f'{project} not found, skipping.')
+        continue
 
-print('KakaoSDK added to workspace.')
+    if dummy_source not in content:
+        print(f'{project} dummy Swift source already removed, skipping.')
+        continue
+
+    with open(project, 'w') as f:
+        f.write(content.replace(dummy_source, ''))
+
+    print(f'{project} dummy Swift source removed.')


### PR DESCRIPTION
## 관련 이슈

- #393 
- #394 

## 작업 설명

- Apple Sign In을 연동하고 ID Token 기반 OAuth 로그인을 구현했습니다.
- Google Sign-In SDK를 추가하고 ID Token 기반 OAuth 로그인을 구현했습니다.
- OAuth 로그인 결과에 따라 기존 사용자는 홈으로, 신규 사용자는 추가 회원가입 화면으로 이동하도록 처리했습니다.
- OAuth 사용자명 설정 API의 빈 응답 처리를 보완했습니다.
- 인증이 필요하지 않은 앱 버전 조회 요청에서 인증 인터셉터를 제외했습니다.
- 앱 버전 조회 실패 시 앱이 종료되지 않고 정상 진입하도록 수정했습니다.
- 메인 브랜치의 Rx 제거 이후 남아 있던 App/Splash 코드를 Combine으로 전환했습니다.
- Challenge 모듈의 Combine publisher API 불일치로 발생한 빌드 오류를 수정했습니다.

## 스크린샷

- Apple 로그인 동작 영상
- Google 로그인 동작 영상

## PR 특이 사항

- xcconfig에 `GOOGLE_CLIENT_ID`, `GOOGLE_SERVER_CLIENT_ID`, `GOOGLE_REVERSED_CLIENT_ID` 설정이 필요합니다. (개인적으로 전달 드리겠습니다.)
- Apple 로그인을 위한 Sign In with Apple entitlement를 추가했습니다.
- Tuist 프로젝트 생성 후 `scripts/patch_workspace.py`를 통해 Google Sign-In 하위 의존성의 Xcode 호환 패치를 적용합니다. (tuist generate 후 Google SDK 하위 프로젝트가 Xcode 26에서 빌드되도록 보정하는 스크립트입니다.)